### PR TITLE
feat: Phase 1 — agentflow monorepo + @agentflow/core

### DIFF
--- a/.github/workflows/agentflow-ci.yml
+++ b/.github/workflows/agentflow-ci.yml
@@ -1,0 +1,25 @@
+name: AgentFlow CI
+on:
+  push:
+    paths:
+      - 'agentflow/**'
+  pull_request:
+    paths:
+      - 'agentflow/**'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agentflow
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun run test
+      - run: bun run build

--- a/agentflow/.gitignore
+++ b/agentflow/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.turbo/
+*.log
+.env
+.DS_Store
+bun.lockb

--- a/agentflow/CLAUDE.md
+++ b/agentflow/CLAUDE.md
@@ -1,0 +1,21 @@
+# AgentFlow — Code Workspace
+
+Bun monorepo. Main entry: `packages/core/`.
+
+## Commands
+- `bun install` — install deps
+- `bun run build` — build all packages
+- `bun run test` — run all tests
+- `bun run typecheck` — type-check all packages
+- `bun run lint` — lint with Biome
+
+## Package dependency order (critical path)
+core ← executor ← cli
+core ← runners/claude
+core ← runners/codex
+core ← testing
+executor ← testing
+runners/* ← executor (via RunnerRegistry)
+
+## Phase 1 complete: @agentflow/core
+## Phases 2-6: executor, runners, testing, CLI, examples

--- a/agentflow/biome.json
+++ b/agentflow/biome.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": { "noExplicitAny": "warn" }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "files": {
+    "ignore": ["dist/**", "node_modules/**", ".turbo/**"]
+  }
+}

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -1,0 +1,253 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentflow-workspace",
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.0",
+        "turbo": "^2.3.0",
+        "typescript": "^5.6.0",
+        "zod": "^3.23.0",
+      },
+    },
+    "packages/core": {
+      "name": "@agentflow/core",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.23.0",
+      },
+      "peerDependencies": {
+        "zod": ">=3.23.0 <4.0.0",
+      },
+    },
+  },
+  "overrides": {
+    "zod": "^3.23.0",
+  },
+  "packages": {
+    "@agentflow/core": ["@agentflow/core@workspace:packages/core"],
+
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/agentflow/package.json
+++ b/agentflow/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agentflow-workspace",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "workspaces": ["packages/*"],
+  "packageManager": "bun@1.2.0",
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "typecheck": "turbo run typecheck",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.0",
+    "turbo": "^2.3.0",
+    "typescript": "^5.6.0",
+    "zod": "^3.23.0"
+  },
+  "overrides": {
+    "zod": "^3.23.0"
+  }
+}

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@agentflow/core",
+  "version": "0.1.0",
+  "type": "module",
+  "private": false,
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "peerDependencies": {
+    "zod": ">=3.23.0 <4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/agentflow/packages/core/src/__tests__/builders.test.ts
+++ b/agentflow/packages/core/src/__tests__/builders.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import {
+  defineAgent,
+  defineWorkflow,
+  loop,
+  resolveAgentDef,
+  sessionToken,
+  shareSessionWith,
+} from "../builders.js";
+
+describe("defineAgent", () => {
+  it("returns correct structure with runner brand", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ text }) => `Process: ${text}`,
+    });
+
+    expect(agent.runner).toBe("claude");
+    expect(agent.input).toBeDefined();
+    expect(agent.output).toBeDefined();
+    expect(agent.prompt).toBeTypeOf("function");
+  });
+
+  it("sanitizeInput is not set in raw def (defaults handled in resolveAgentDef)", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ text }) => `Process: ${text}`,
+    });
+
+    // Raw def doesn't set sanitizeInput — resolver handles the default
+    expect(agent.sanitizeInput).toBeUndefined();
+  });
+
+  it("preserves explicit sanitizeInput: false", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ text }) => `Process: ${text}`,
+      sanitizeInput: false,
+    });
+
+    expect(agent.sanitizeInput).toBe(false);
+  });
+
+  it("throws on invalid runner name with special chars", () => {
+    expect(() =>
+      defineAgent({
+        runner: "my runner!" as string,
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+      }),
+    ).toThrow(/invalid characters/);
+  });
+
+  it("throws on runner name with spaces", () => {
+    expect(() =>
+      defineAgent({
+        runner: "my runner" as string,
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+      }),
+    ).toThrow(/invalid characters/);
+  });
+
+  it("warns when output is z.any()", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.any(),
+      prompt: () => "test",
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ZodAny"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("warns when output is z.unknown()", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.unknown(),
+      prompt: () => "test",
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ZodUnknown"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("throws on invalid mcp.server name", () => {
+    expect(() =>
+      defineAgent({
+        runner: "claude",
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+        mcps: [{ server: "my server!" }],
+      }),
+    ).toThrow(/invalid characters/);
+  });
+
+  it("accepts valid mcp.server name", () => {
+    expect(() =>
+      defineAgent({
+        runner: "claude",
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+        mcps: [{ server: "my-mcp-server.v2" }],
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("resolveAgentDef", () => {
+  it("fills all defaults", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ text }) => `Process: ${text}`,
+    });
+
+    const resolved = resolveAgentDef(agent);
+
+    expect(resolved.sanitizeInput).toBe(true);
+    expect(resolved.timeoutMs).toBe(300_000);
+    expect(resolved.maxOutputBytes).toBe(1_048_576);
+    expect(resolved.retry.max).toBe(3);
+    expect(resolved.retry.backoff).toBe("exponential");
+    expect(resolved.retry.on).toContain("subprocess_error");
+    expect(resolved.retry.on).toContain("output_validation_error");
+    expect(resolved.retry.timeoutMs).toBe(300_000);
+  });
+
+  it("preserves explicit sanitizeInput: false", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: () => "test",
+      sanitizeInput: false,
+    });
+
+    const resolved = resolveAgentDef(agent);
+    expect(resolved.sanitizeInput).toBe(false);
+  });
+
+  it("preserves explicit sanitizeInput: true", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: () => "test",
+      sanitizeInput: true,
+    });
+
+    const resolved = resolveAgentDef(agent);
+    expect(resolved.sanitizeInput).toBe(true);
+  });
+
+  it("merges partial retry config with defaults", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: () => "test",
+      retry: { max: 5 },
+    });
+
+    const resolved = resolveAgentDef(agent);
+    expect(resolved.retry.max).toBe(5);
+    expect(resolved.retry.backoff).toBe("exponential");
+    expect(resolved.retry.timeoutMs).toBe(300_000);
+  });
+
+  it("uses explicit timeoutMs", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: () => "test",
+      timeoutMs: 60_000,
+    });
+
+    const resolved = resolveAgentDef(agent);
+    expect(resolved.timeoutMs).toBe(60_000);
+  });
+
+  it("uses explicit maxOutputBytes", () => {
+    const agent = defineAgent({
+      runner: "claude",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: () => "test",
+      maxOutputBytes: 512_000,
+    });
+
+    const resolved = resolveAgentDef(agent);
+    expect(resolved.maxOutputBytes).toBe(512_000);
+  });
+});
+
+describe("sessionToken", () => {
+  it("creates token with kind='token'", () => {
+    const token = sessionToken("my-session", "claude");
+    expect(token.kind).toBe("token");
+    expect(token.name).toBe("my-session");
+  });
+
+  it("throws on invalid runner name", () => {
+    expect(() => sessionToken("my-session", "invalid runner!" as string)).toThrow(
+      /invalid characters/,
+    );
+  });
+});
+
+describe("shareSessionWith", () => {
+  it("creates ref with kind='share' and correct taskName", () => {
+    const ref = shareSessionWith<Record<string, never>, never>("analyze" as never);
+    expect(ref.kind).toBe("share");
+    expect(ref.taskName).toBe("analyze");
+  });
+
+  it("creates correct taskName for different task names", () => {
+    const ref = shareSessionWith<Record<string, never>, never>("summarize" as never);
+    expect(ref.taskName).toBe("summarize");
+  });
+});
+
+describe("defineWorkflow", () => {
+  it("returns config unchanged (identity)", () => {
+    const analyzeAgent = defineAgent({
+      runner: "claude",
+      input: z.object({ repoPath: z.string() }),
+      output: z.object({ issues: z.array(z.string()) }),
+      prompt: ({ repoPath }) => `Analyze ${repoPath}`,
+    });
+
+    const config = {
+      name: "test-workflow",
+      tasks: {
+        analyze: {
+          agent: analyzeAgent,
+          input: { repoPath: "./src" },
+        },
+      },
+    } as const;
+
+    const workflow = defineWorkflow(config);
+    expect(workflow).toBe(config);
+    expect(workflow.name).toBe("test-workflow");
+    expect(workflow.tasks.analyze).toBeDefined();
+  });
+});
+
+describe("loop", () => {
+  it("adds kind='loop' to config", () => {
+    const evalAgent = defineAgent({
+      runner: "claude",
+      input: z.object({ count: z.number() }),
+      output: z.object({ satisfied: z.boolean() }),
+      prompt: ({ count }) => `Eval count: ${count}`,
+    });
+
+    const loopDef = loop({
+      dependsOn: [],
+      max: 5,
+      until: () => false,
+      context: "persistent",
+      tasks: {
+        eval: { agent: evalAgent, input: { count: 0 } },
+      },
+    });
+
+    expect(loopDef.kind).toBe("loop");
+    expect(loopDef.max).toBe(5);
+    expect(loopDef.context).toBe("persistent");
+  });
+});

--- a/agentflow/packages/core/src/__tests__/errors.test.ts
+++ b/agentflow/packages/core/src/__tests__/errors.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import {
+  AgentFlowError,
+  AgentHitlConflictError,
+  BudgetExceededError,
+  GenericAgentFlowError,
+  LoopMaxIterationsError,
+  NodeMaxRetriesError,
+  PathTraversalError,
+  PreFlightError,
+  SessionMismatchError,
+  TimeoutError,
+  ToolNotUsedError,
+  ValidationError,
+} from "../errors.js";
+
+describe("AgentFlowError base class", () => {
+  it("GenericAgentFlowError is instanceof Error and AgentFlowError", () => {
+    const err = new GenericAgentFlowError("test", "test_code");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("fromJSON returns an AgentFlowError", () => {
+    const err = AgentFlowError.fromJSON({ message: "test", code: "test_code" });
+    expect(err).toBeInstanceOf(AgentFlowError);
+    expect(err.message).toBe("test");
+    expect(err.code).toBe("test_code");
+  });
+});
+
+describe("NodeMaxRetriesError", () => {
+  const attempts = [
+    { attempt: 1, error: "subprocess failed", errorCode: "subprocess_error" as const },
+    { attempt: 2, error: "validation failed", errorCode: "output_validation_error" as const },
+  ];
+
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new NodeMaxRetriesError("myTask", attempts);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new NodeMaxRetriesError("myTask", attempts);
+    expect(err.code).toBe("node_max_retries");
+  });
+
+  it("has readable message with taskName and attempt count", () => {
+    const err = new NodeMaxRetriesError("myTask", attempts);
+    expect(err.message).toContain("myTask");
+    expect(err.message).toContain("2");
+    expect(err.message).toContain("validation failed");
+  });
+
+  it("toJSON includes taskName and attempts", () => {
+    const err = new NodeMaxRetriesError("myTask", attempts);
+    const json = err.toJSON();
+    expect(json["name"]).toBe("NodeMaxRetriesError");
+    expect(json["code"]).toBe("node_max_retries");
+    expect(json["message"]).toContain("myTask");
+    expect(json["taskName"]).toBe("myTask");
+    expect(json["attempts"]).toEqual(attempts);
+  });
+});
+
+describe("LoopMaxIterationsError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new LoopMaxIterationsError("fixLoop", 5);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new LoopMaxIterationsError("fixLoop", 5);
+    expect(err.code).toBe("loop_max_iterations");
+  });
+
+  it("has readable message", () => {
+    const err = new LoopMaxIterationsError("fixLoop", 5);
+    expect(err.message).toContain("fixLoop");
+    expect(err.message).toContain("5");
+  });
+
+  it("toJSON returns serializable object", () => {
+    const err = new LoopMaxIterationsError("fixLoop", 5);
+    const json = err.toJSON();
+    expect(json["name"]).toBe("LoopMaxIterationsError");
+    expect(json["code"]).toBe("loop_max_iterations");
+    expect(json["message"]).toBeTruthy();
+  });
+});
+
+describe("ToolNotUsedError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new ToolNotUsedError("task1", ["bash", "edit"]);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new ToolNotUsedError("task1", ["bash"]);
+    expect(err.code).toBe("tool_not_used");
+  });
+
+  it("includes required tools in message", () => {
+    const err = new ToolNotUsedError("task1", ["bash", "edit"]);
+    expect(err.message).toContain("bash");
+    expect(err.message).toContain("edit");
+  });
+});
+
+describe("BudgetExceededError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new BudgetExceededError(10.0, 12.5);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new BudgetExceededError(10.0, 12.5);
+    expect(err.code).toBe("budget_exceeded");
+  });
+
+  it("has readable message with costs", () => {
+    const err = new BudgetExceededError(10.0, 12.5);
+    expect(err.message).toContain("12.5000");
+    expect(err.message).toContain("10.0000");
+  });
+});
+
+describe("ValidationError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new ValidationError("task1", "Expected string, got number");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new ValidationError("task1", "Expected string");
+    expect(err.code).toBe("validation_error");
+  });
+
+  it("toJSON returns serializable object", () => {
+    const err = new ValidationError("task1", "zod error details");
+    const json = err.toJSON();
+    expect(json["name"]).toBe("ValidationError");
+    expect(json["code"]).toBe("validation_error");
+    expect(typeof json["message"]).toBe("string");
+  });
+});
+
+describe("AgentHitlConflictError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new AgentHitlConflictError("task1");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new AgentHitlConflictError("task1");
+    expect(err.code).toBe("agent_hitl_conflict");
+  });
+});
+
+describe("PreFlightError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new PreFlightError(["runner not found"], ["model deprecated"]);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new PreFlightError(["error1"], []);
+    expect(err.code).toBe("pre_flight_error");
+  });
+
+  it("includes errors in message", () => {
+    const err = new PreFlightError(["runner not found", "budget invalid"], ["model deprecated"]);
+    expect(err.message).toContain("runner not found");
+    expect(err.message).toContain("budget invalid");
+  });
+});
+
+describe("PathTraversalError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new PathTraversalError("../secret", "traversal detected");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new PathTraversalError("../secret", "reason");
+    expect(err.code).toBe("path_traversal");
+  });
+
+  it("carries .path and .reason", () => {
+    const err = new PathTraversalError("../secret", "traversal detected");
+    expect(err.path).toBe("../secret");
+    expect(err.reason).toBe("traversal detected");
+  });
+
+  it("toJSON returns serializable object with name, code, message", () => {
+    const err = new PathTraversalError("../secret", "traversal detected");
+    const json = err.toJSON();
+    expect(json["name"]).toBe("PathTraversalError");
+    expect(json["code"]).toBe("path_traversal");
+    expect(typeof json["message"]).toBe("string");
+  });
+});
+
+describe("SessionMismatchError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new SessionMismatchError("task1", "claude", "codex");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new SessionMismatchError("task1", "claude", "codex");
+    expect(err.code).toBe("session_mismatch");
+  });
+
+  it("includes runner info in message", () => {
+    const err = new SessionMismatchError("task1", "claude", "codex");
+    expect(err.message).toContain("claude");
+    expect(err.message).toContain("codex");
+    expect(err.message).toContain("task1");
+  });
+});
+
+describe("TimeoutError", () => {
+  it("is instanceof Error and AgentFlowError", () => {
+    const err = new TimeoutError("task1", 30_000);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AgentFlowError);
+  });
+
+  it("has correct code", () => {
+    const err = new TimeoutError("task1", 30_000);
+    expect(err.code).toBe("timeout");
+  });
+
+  it("includes task name and timeout in message", () => {
+    const err = new TimeoutError("task1", 30_000);
+    expect(err.message).toContain("task1");
+    expect(err.message).toContain("30000");
+  });
+});
+
+describe("error instanceof chain", () => {
+  it.each([
+    ["NodeMaxRetriesError", new NodeMaxRetriesError("t", [])],
+    ["LoopMaxIterationsError", new LoopMaxIterationsError("t", 1)],
+    ["ToolNotUsedError", new ToolNotUsedError("t", [])],
+    ["BudgetExceededError", new BudgetExceededError(1, 2)],
+    ["ValidationError", new ValidationError("t", "err")],
+    ["AgentHitlConflictError", new AgentHitlConflictError("t")],
+    ["PreFlightError", new PreFlightError(["e"], [])],
+    ["PathTraversalError", new PathTraversalError("p", "r")],
+    ["SessionMismatchError", new SessionMismatchError("t", "a", "b")],
+    ["TimeoutError", new TimeoutError("t", 1000)],
+  ])("%s is instanceof AgentFlowError and Error", (_name, err) => {
+    expect(err).toBeInstanceOf(AgentFlowError);
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/agentflow/packages/core/src/__tests__/schemas.test.ts
+++ b/agentflow/packages/core/src/__tests__/schemas.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { safePath, validateStaticIdentifier } from "../schemas.js";
+
+describe("safePath()", () => {
+  const schema = safePath();
+
+  describe("accepts valid paths", () => {
+    it.each([
+      ["src/index.ts"],
+      ["./src/index.ts"],
+      ["deep/nested/file.ts"],
+      ["foo..bar.ts"],
+      [".hidden"],
+      [".config/settings.json"],
+      ["src/"],
+    ])("accepts %s", (p) => {
+      expect(schema.safeParse(p).success).toBe(true);
+    });
+  });
+
+  describe("rejects invalid paths", () => {
+    it("rejects ../etc/passwd (path traversal)", () => {
+      const result = schema.safeParse("../etc/passwd");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects foo/../../etc (path traversal)", () => {
+      const result = schema.safeParse("foo/../../etc");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects ./foo/../../../bar (path traversal)", () => {
+      const result = schema.safeParse("./foo/../../../bar");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects ~/secret (home expansion)", () => {
+      const result = schema.safeParse("~/secret");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects ~root/.ssh (home expansion variant)", () => {
+      const result = schema.safeParse("~root/.ssh");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects /etc/passwd (absolute path)", () => {
+      const result = schema.safeParse("/etc/passwd");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects C:\\Windows\\System32 (Windows drive path)", () => {
+      const result = schema.safeParse("C:\\Windows\\System32");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects \\\\server\\share\\x (UNC path)", () => {
+      const result = schema.safeParse("\\\\server\\share\\x");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects file:///etc/passwd (URL)", () => {
+      const result = schema.safeParse("file:///etc/passwd");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects http://evil.com/ (URL)", () => {
+      const result = schema.safeParse("http://evil.com/");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects path with null byte", () => {
+      const result = schema.safeParse("src/\x00etc/passwd");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      const result = schema.safeParse("");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects string with leading space", () => {
+      const result = schema.safeParse(" src/index.ts");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects 5000-char string (overlong)", () => {
+      const result = schema.safeParse("a".repeat(5000));
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects environment variable $VAR", () => {
+      const result = schema.safeParse("$HOME/secret");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects environment variable ${VAR}", () => {
+      const result = schema.safeParse("${HOME}/secret");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects %VAR% style env vars", () => {
+      const result = schema.safeParse("%HOME%/secret");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects control character 0x01", () => {
+      const result = schema.safeParse("src/\x01index.ts");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects control character 0x1F", () => {
+      const result = schema.safeParse("src/\x1Findex.ts");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects DEL character 0x7F", () => {
+      const result = schema.safeParse("src/\x7Findex.ts");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects javascript: URL", () => {
+      const result = schema.safeParse("javascript:alert(1)");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects backslash traversal foo\\..\\.\\bar", () => {
+      const result = schema.safeParse("foo\\..\\bar");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects single-backslash Windows absolute path \\Windows\\foo", () => {
+      const result = schema.safeParse("\\Windows\\foo");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("allowAbsolute option", () => {
+    it("accepts absolute path when allowAbsolute: true", () => {
+      const schema = safePath({ allowAbsolute: true });
+      const result = schema.safeParse("/etc/passwd");
+      expect(result.success).toBe(true);
+    });
+
+    it("still rejects traversal even with allowAbsolute: true", () => {
+      const schema = safePath({ allowAbsolute: true });
+      const result = schema.safeParse("/etc/../etc/passwd");
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("validateStaticIdentifier()", () => {
+  describe("accepts valid identifiers", () => {
+    it.each([
+      ["claude"],
+      ["claude-opus-4-6"],
+      ["my.mcp-server"],
+      ["runner123"],
+      ["a"],
+      ["A-B_C.D"],
+    ])("accepts '%s'", (id) => {
+      expect(() => validateStaticIdentifier(id)).not.toThrow();
+    });
+  });
+
+  describe("rejects invalid identifiers", () => {
+    it("rejects empty string", () => {
+      expect(() => validateStaticIdentifier("")).toThrow(/invalid characters/);
+    });
+
+    it("rejects 'my runner' (space)", () => {
+      expect(() => validateStaticIdentifier("my runner")).toThrow(/invalid characters/);
+    });
+
+    it("rejects 'server;rm' (semicolon)", () => {
+      expect(() => validateStaticIdentifier("server;rm")).toThrow(/invalid characters/);
+    });
+
+    it("rejects '../path' (traversal)", () => {
+      expect(() => validateStaticIdentifier("../path")).toThrow(/invalid characters/);
+    });
+
+    it("rejects 'name/path' (slash)", () => {
+      expect(() => validateStaticIdentifier("name/path")).toThrow(/invalid characters/);
+    });
+
+    it("rejects 'runner!' (bang)", () => {
+      expect(() => validateStaticIdentifier("runner!")).toThrow(/invalid characters/);
+    });
+  });
+});

--- a/agentflow/packages/core/src/__tests__/types.test-d.ts
+++ b/agentflow/packages/core/src/__tests__/types.test-d.ts
@@ -1,0 +1,99 @@
+import { describe, it, assertType, expectTypeOf } from "vitest";
+import { z } from "zod";
+import { defineAgent, resolveAgentDef } from "../builders.js";
+import type { AgentDef, RunnerOf, OutputOf, SessionToken, TaskDef } from "../types.js";
+
+// ─── Test agents ──────────────────────────────────────────────────────────────
+
+const analyzeAgent = defineAgent({
+  runner: "claude",
+  model: "claude-opus-4-6",
+  input: z.object({ repoPath: z.string() }),
+  output: z.object({ issues: z.array(z.string()), count: z.number() }),
+  prompt: ({ repoPath }) => `Analyze ${repoPath} for issues`,
+});
+
+const codexAgent = defineAgent({
+  runner: "codex",
+  input: z.object({ code: z.string() }),
+  output: z.object({ result: z.string() }),
+  prompt: ({ code }) => `Review: ${code}`,
+});
+
+// ─── Type tests ───────────────────────────────────────────────────────────────
+
+describe("defineAgent type inference", () => {
+  it("runner is literal 'claude', not string", () => {
+    // Should be AgentDef<..., ..., "claude"> not AgentDef<..., ..., string>
+    expectTypeOf(analyzeAgent.runner).toEqualTypeOf<"claude">();
+  });
+
+  it("AgentDef is typed correctly", () => {
+    assertType<AgentDef<
+      z.ZodObject<{ repoPath: z.ZodString }, "strip">,
+      z.ZodObject<{ issues: z.ZodArray<z.ZodString>; count: z.ZodNumber }, "strip">,
+      "claude"
+    >>(analyzeAgent);
+  });
+});
+
+describe("RunnerOf type utility", () => {
+  it("RunnerOf<analyzeAgent> = 'claude'", () => {
+    expectTypeOf<RunnerOf<typeof analyzeAgent>>().toEqualTypeOf<"claude">();
+  });
+
+  it("RunnerOf<codexAgent> = 'codex'", () => {
+    expectTypeOf<RunnerOf<typeof codexAgent>>().toEqualTypeOf<"codex">();
+  });
+});
+
+describe("OutputOf type utility", () => {
+  it("OutputOf matches zod schema inferred type", () => {
+    expectTypeOf<OutputOf<typeof analyzeAgent>>().toEqualTypeOf<{
+      issues: string[];
+      count: number;
+    }>();
+  });
+});
+
+describe("resolveAgentDef types", () => {
+  it("sanitizeInput is typed boolean (not boolean | undefined)", () => {
+    const resolved = resolveAgentDef(analyzeAgent);
+    expectTypeOf(resolved.sanitizeInput).toEqualTypeOf<boolean>();
+  });
+
+  it("timeoutMs is typed number (not number | undefined)", () => {
+    const resolved = resolveAgentDef(analyzeAgent);
+    expectTypeOf(resolved.timeoutMs).toEqualTypeOf<number>();
+  });
+
+  it("maxOutputBytes is typed number (not number | undefined)", () => {
+    const resolved = resolveAgentDef(analyzeAgent);
+    expectTypeOf(resolved.maxOutputBytes).toEqualTypeOf<number>();
+  });
+});
+
+describe("SessionToken phantom brand type safety", () => {
+  it("SessionToken<'claude'> is assignable to session field of claude agent task", () => {
+    const claudeToken: SessionToken<"claude"> = { kind: "token", name: "my-session" };
+
+    // This should type-check fine
+    assertType<TaskDef<typeof analyzeAgent>>({
+      agent: analyzeAgent,
+      session: claudeToken,
+    });
+  });
+
+  it("SessionToken<'claude'> is NOT assignable to session field of codex agent task", () => {
+    const claudeToken: SessionToken<"claude"> = { kind: "token", name: "my-session" };
+
+    // Build the task object — session field should be a type error (cross-provider)
+    const badTask: TaskDef<typeof codexAgent> = {
+      agent: codexAgent,
+      // @ts-expect-error - cross-provider session assignment should be a type error
+      session: claudeToken,
+    };
+    // Suppress unused variable warning
+    void badTask;
+  });
+});

--- a/agentflow/packages/core/src/builders.ts
+++ b/agentflow/packages/core/src/builders.ts
@@ -1,0 +1,174 @@
+import type { ZodType } from "zod";
+import type {
+  AgentDef,
+  LoopDef,
+  ResolvedAgentDef,
+  RetryConfig,
+  Runner,
+  RunnerOfTask,
+  SessionToken,
+  ShareSessionRef,
+  TasksMap,
+  WorkflowDef,
+} from "./types.js";
+import { validateStaticIdentifier } from "./schemas.js";
+
+/** In-memory runner registry. Used by executor to find runner implementations. */
+const _runnerRegistry = new Map<string, Runner>();
+
+/**
+ * Define an AI agent with typed I/O and execution configuration.
+ *
+ * @example
+ * const analyzeAgent = defineAgent({
+ *   runner: "claude",
+ *   model: "claude-opus-4-6",
+ *   input: z.object({ repoPath: safePath() }),
+ *   output: z.object({ issues: z.array(z.string()) }),
+ *   prompt: ({ repoPath }) => `Analyze ${repoPath} for issues`,
+ * });
+ */
+export function defineAgent<
+  I extends ZodType,
+  O extends ZodType,
+  const R extends string,
+>(config: AgentDef<I, O, R>): AgentDef<I, O, R> {
+  // Validate static identifiers at definition time
+  validateStaticIdentifier(config.runner, "runner");
+  if (config.model !== undefined) {
+    validateStaticIdentifier(config.model, "model");
+  }
+  for (const mcp of config.mcps ?? []) {
+    validateStaticIdentifier(mcp.server, "mcp.server");
+  }
+
+  // Warn if output schema is z.any() / z.unknown() — security boundary would be bypassed
+  // biome-ignore lint/suspicious/noExplicitAny: internal type inspection
+  const typeName = (config.output as any)._def?.typeName;
+  if (typeName === "ZodAny" || typeName === "ZodUnknown") {
+    console.warn(
+      `[agentflow] defineAgent runner="${config.runner}": output schema is ${typeName} — ` +
+        "prompt injection from agent stdout will pass through to downstream agents unsanitized. " +
+        "Use a specific Zod object schema.",
+    );
+  }
+
+  return config;
+}
+
+const DEFAULT_RETRY: RetryConfig = {
+  max: 3,
+  on: ["subprocess_error", "output_validation_error"],
+  backoff: "exponential",
+  timeoutMs: 300_000,
+};
+
+/**
+ * Resolve an AgentDef to its fully-defaulted form for executor consumption.
+ * Executors MUST consume ResolvedAgentDef — never raw AgentDef.
+ */
+export function resolveAgentDef<
+  I extends ZodType,
+  O extends ZodType,
+  R extends string,
+>(def: AgentDef<I, O, R>): ResolvedAgentDef<I, O, R> {
+  const resolvedRetry: RetryConfig = {
+    max: def.retry?.max ?? DEFAULT_RETRY.max,
+    on: def.retry?.on ?? DEFAULT_RETRY.on,
+    backoff: def.retry?.backoff ?? DEFAULT_RETRY.backoff,
+  };
+  const retryTimeoutMs = def.retry?.timeoutMs ?? DEFAULT_RETRY.timeoutMs;
+  if (retryTimeoutMs !== undefined) {
+    (resolvedRetry as { timeoutMs?: number }).timeoutMs = retryTimeoutMs;
+  }
+  return {
+    ...def,
+    sanitizeInput: def.sanitizeInput ?? true,
+    retry: resolvedRetry,
+    timeoutMs: def.timeoutMs ?? 300_000,
+    maxOutputBytes: def.maxOutputBytes ?? 1_048_576,
+  };
+}
+
+/**
+ * Define a workflow from a map of tasks.
+ *
+ * @example
+ * export default defineWorkflow({
+ *   name: "bug-fix-pipeline",
+ *   tasks: { analyze: { agent: analyzeAgent, input: { repoPath: "./src" } } },
+ * });
+ */
+export function defineWorkflow<const T extends TasksMap>(
+  config: WorkflowDef<T>,
+): WorkflowDef<T> {
+  return config;
+}
+
+/**
+ * Define a loop task. Runs inner DAG iteratively until `until` returns true.
+ *
+ * @example
+ * const fixLoop = loop({
+ *   dependsOn: ["analyze"],
+ *   max: 5,
+ *   until: (ctx) => ctx.eval.output.satisfied === true,
+ *   context: "persistent",
+ *   input: (ctx) => ({ issues: ctx.analyze.output.issues }),
+ *   tasks: { fix: fixTask, eval: evalTask },
+ * });
+ */
+export function loop<const T extends TasksMap>(
+  config: Omit<LoopDef<T>, "kind">,
+): LoopDef<T> {
+  return { ...config, kind: "loop" };
+}
+
+/**
+ * Create a named session group for sharing conversation context between agents.
+ * Session sharing works within a single provider only. Cross-provider sharing
+ * is a TypeScript compile error.
+ *
+ * @example
+ * const sharedCtx = sessionToken("analysis-context", "claude");
+ * // Use in tasks:
+ * analyze: { agent: analyzeAgent, session: sharedCtx }
+ * summarize: { agent: summarizeAgent, session: sharedCtx }
+ */
+export function sessionToken<const R extends string>(
+  name: string,
+  runner: R,
+): SessionToken<R> {
+  validateStaticIdentifier(runner, "sessionToken runner");
+  return { kind: "token", name } as SessionToken<R>;
+}
+
+/**
+ * Create a transitive session reference to share context with another task's session.
+ * The runner brand is inferred from the target task — passing this to an agent
+ * with a different runner is a compile-time error.
+ *
+ * @example
+ * summarize: { agent: summarizeAgent, session: shareSessionWith<typeof tasks, "analyze">("analyze") }
+ */
+export function shareSessionWith<
+  T extends TasksMap,
+  K extends keyof T & string,
+>(_taskName: K): ShareSessionRef<RunnerOfTask<T, K>> {
+  return { kind: "share", taskName: _taskName } as ShareSessionRef<RunnerOfTask<T, K>>;
+}
+
+/**
+ * Get a runner from the registry by name.
+ * Used by the executor — not intended for user code.
+ */
+export function getRunner(name: string): Runner | undefined {
+  return _runnerRegistry.get(name);
+}
+
+/**
+ * Get all registered runners.
+ */
+export function getRunners(): ReadonlyMap<string, Runner> {
+  return _runnerRegistry;
+}

--- a/agentflow/packages/core/src/errors.ts
+++ b/agentflow/packages/core/src/errors.ts
@@ -1,0 +1,196 @@
+import type { RetryErrorKind } from "./types.js";
+
+/** Base error for all AgentFlow errors. */
+export abstract class AgentFlowError extends Error {
+  abstract readonly code: string;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = this.constructor.name;
+    // Fix prototype chain for transpiled ES5/CommonJS targets
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      cause:
+        this.cause instanceof Error
+          ? (this.cause as AgentFlowError).toJSON?.() ?? this.cause.message
+          : this.cause,
+    };
+  }
+
+  static fromJSON(json: Record<string, unknown>): AgentFlowError {
+    // Registry-based revival — extend in each subclass if needed
+    const msg =
+      typeof json["message"] === "string" ? json["message"] : "Unknown error";
+    const err = new GenericAgentFlowError(
+      msg,
+      typeof json["code"] === "string" ? json["code"] : "unknown",
+    );
+    return err;
+  }
+}
+
+/** Fallback for deserialized errors without a specific class. */
+export class GenericAgentFlowError extends AgentFlowError {
+  readonly code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export interface AttemptRecord {
+  readonly attempt: number;
+  readonly error: string;
+  readonly errorCode: RetryErrorKind;
+}
+
+export class NodeMaxRetriesError extends AgentFlowError {
+  readonly code = "node_max_retries" as const;
+  constructor(
+    readonly taskName: string,
+    readonly attempts: readonly AttemptRecord[],
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Task "${taskName}" failed after ${attempts.length} attempt(s). Last error: ${attempts.at(-1)?.error ?? "unknown"}`,
+      options,
+    );
+  }
+  override toJSON(): Record<string, unknown> {
+    return { ...super.toJSON(), taskName: this.taskName, attempts: this.attempts };
+  }
+}
+
+export class LoopMaxIterationsError extends AgentFlowError {
+  readonly code = "loop_max_iterations" as const;
+  constructor(
+    readonly taskName: string,
+    readonly maxIterations: number,
+    options?: ErrorOptions,
+  ) {
+    super(`Loop "${taskName}" exceeded max iterations (${maxIterations})`, options);
+  }
+}
+
+export class ToolNotUsedError extends AgentFlowError {
+  readonly code = "tool_not_used" as const;
+  constructor(
+    readonly taskName: string,
+    readonly requiredTools: readonly string[],
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Task "${taskName}" did not use required tools: ${requiredTools.join(", ")}`,
+      options,
+    );
+  }
+}
+
+export class BudgetExceededError extends AgentFlowError {
+  readonly code = "budget_exceeded" as const;
+  constructor(
+    readonly maxCost: number,
+    readonly actualCost: number,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Budget exceeded: spent $${actualCost.toFixed(4)} (limit $${maxCost.toFixed(4)})`,
+      options,
+    );
+  }
+}
+
+export class ValidationError extends AgentFlowError {
+  readonly code = "validation_error" as const;
+  constructor(
+    readonly taskName: string,
+    readonly zodError: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Output validation failed for task "${taskName}": ${zodError}`, options);
+  }
+}
+
+export class AgentHitlConflictError extends AgentFlowError {
+  readonly code = "agent_hitl_conflict" as const;
+  constructor(
+    readonly taskName: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Task "${taskName}" agent raised internal HITL prompt — use allowedTools or dangerously-skip-permissions`,
+      options,
+    );
+  }
+}
+
+export class PreFlightError extends AgentFlowError {
+  readonly code = "pre_flight_error" as const;
+  constructor(
+    readonly errors: readonly string[],
+    readonly warnings: readonly string[],
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Pre-flight validation failed:\n${errors.map((e) => `  ✗ ${e}`).join("\n")}`,
+      options,
+    );
+  }
+}
+
+export class InvalidIdentifierError extends AgentFlowError {
+  readonly code = "invalid_identifier" as const;
+  constructor(
+    readonly field: string,
+    readonly value: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `${field} "${value}" contains invalid characters. Must match /^[a-zA-Z0-9._-]+$/`,
+      options,
+    );
+  }
+}
+
+export class PathTraversalError extends AgentFlowError {
+  readonly code = "path_traversal" as const;
+  constructor(
+    readonly path: string,
+    readonly reason: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Path traversal rejected: "${path}" — ${reason}`, options);
+  }
+}
+
+export class SessionMismatchError extends AgentFlowError {
+  readonly code = "session_mismatch" as const;
+  constructor(
+    readonly taskName: string,
+    readonly expectedRunner: string,
+    readonly actualRunner: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Session mismatch on task "${taskName}": expected runner "${expectedRunner}", got "${actualRunner}". Cross-provider session sharing is not supported.`,
+      options,
+    );
+  }
+}
+
+export class TimeoutError extends AgentFlowError {
+  readonly code = "timeout" as const;
+  constructor(
+    readonly taskName: string,
+    readonly timeoutMs: number,
+    options?: ErrorOptions,
+  ) {
+    super(`Task "${taskName}" timed out after ${timeoutMs}ms`, options);
+  }
+}

--- a/agentflow/packages/core/src/index.ts
+++ b/agentflow/packages/core/src/index.ts
@@ -1,0 +1,68 @@
+// v1 API surface — stable
+// All exports below are part of the public API
+
+// Types
+export type {
+  AgentDef,
+  ResolvedAgentDef,
+  BudgetConfig,
+  CtxFor,
+  DependsOnOf,
+  HITLConfig,
+  HITLMode,
+  InputOf,
+  Logger,
+  LoopContext,
+  LoopDef,
+  MCPConfig,
+  OutputOf,
+  OutputZodOf,
+  RetryConfig,
+  RetryErrorKind,
+  Runner,
+  RunnerOf,
+  RunnerOfTask,
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  SessionRef,
+  SessionToken,
+  ShareSessionRef,
+  TaskDef,
+  TaskMetrics,
+  TasksMap,
+  WorkflowDef,
+  WorkflowHooks,
+  WorkflowMetrics,
+} from "./types.js";
+
+// Builders
+export {
+  defineAgent,
+  defineWorkflow,
+  getRunner,
+  getRunners,
+  loop,
+  resolveAgentDef,
+  sessionToken,
+  shareSessionWith,
+} from "./builders.js";
+
+// Schemas
+export { safePath, validateStaticIdentifier } from "./schemas.js";
+
+// Errors
+export {
+  AgentFlowError,
+  AgentHitlConflictError,
+  BudgetExceededError,
+  GenericAgentFlowError,
+  InvalidIdentifierError,
+  LoopMaxIterationsError,
+  NodeMaxRetriesError,
+  PathTraversalError,
+  PreFlightError,
+  SessionMismatchError,
+  TimeoutError,
+  ToolNotUsedError,
+  ValidationError,
+} from "./errors.js";

--- a/agentflow/packages/core/src/schemas.ts
+++ b/agentflow/packages/core/src/schemas.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+import * as path from "node:path";
+import { InvalidIdentifierError } from "./errors.js";
+
+const STATIC_IDENTIFIER_RE = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Validates that a string is a safe static identifier for runner/model/mcp.server names.
+ * Throws InvalidIdentifierError for unsafe values.
+ */
+export function validateStaticIdentifier(name: string, field = "identifier"): void {
+  if (!name || !STATIC_IDENTIFIER_RE.test(name)) {
+    throw new InvalidIdentifierError(field, name);
+  }
+}
+
+/**
+ * Zod refinement for safe file paths.
+ *
+ * Blocks:
+ * - Path traversal (.. segments)
+ * - Home expansion (~ prefix or ~ segments)
+ * - Absolute paths (unless allowAbsolute: true)
+ * - Null bytes and control characters
+ * - Environment variable expansion ($VAR, ${VAR}, %VAR%)
+ * - URL-like strings (file://, http://, etc.)
+ * - Windows UNC paths (\\server\share)
+ * - Windows drive paths (C:\)
+ * - Overlong paths (> 4096 chars)
+ * - Trailing/leading whitespace
+ * - Empty strings
+ *
+ * NOTE: This is a syntactic check only. It does NOT guarantee the path exists
+ * or that symlinks stay within baseDir. The executor performs runtime realpath
+ * checks before tool invocation.
+ */
+export function safePath(opts?: {
+  allowAbsolute?: boolean;
+}): z.ZodEffects<z.ZodString, string, string> {
+  const allowAbsolute = opts?.allowAbsolute ?? false;
+
+  return z.string().superRefine((val, ctx) => {
+    // Empty
+    if (val.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Path must not be empty" });
+      return;
+    }
+
+    // Overlong
+    if (val.length > 4096) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Path exceeds maximum length of 4096 characters",
+      });
+      return;
+    }
+
+    // Leading/trailing whitespace
+    if (val !== val.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Path must not have leading or trailing whitespace",
+      });
+      return;
+    }
+
+    // Null byte
+    if (val.includes("\x00")) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Path must not contain null bytes" });
+      return;
+    }
+
+    // Control characters (0x01-0x1F, 0x7F)
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional security check
+    if (/[\x01-\x1F\x7F]/.test(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Path must not contain control characters",
+      });
+      return;
+    }
+
+    // URL-like
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(val) || /^javascript:/i.test(val)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Path must not be a URL" });
+      return;
+    }
+
+    // UNC paths (Windows \\server\share)
+    if (val.startsWith("\\\\")) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "UNC paths are not allowed" });
+      return;
+    }
+
+    // Single-leading backslash (Windows absolute path \Windows\foo).
+    // path.isAbsolute() returns false for these on POSIX — check explicitly.
+    if (val.startsWith("\\")) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Absolute paths are not allowed" });
+      return;
+    }
+
+    // Windows drive paths (C:\ or C:/)
+    if (/^[a-zA-Z]:[/\\]/.test(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Windows drive paths are not allowed",
+      });
+      return;
+    }
+
+    // Home expansion
+    if (val.startsWith("~") || val.includes("/~") || val.includes("\\~")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Home directory expansion is not allowed",
+      });
+      return;
+    }
+
+    // Environment variable expansion
+    if (
+      /\$[{(]?[A-Za-z_][A-Za-z0-9_]*[)}]?/.test(val) ||
+      /%[A-Za-z_][A-Za-z0-9_]*%/.test(val)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Environment variable expansion is not allowed",
+      });
+      return;
+    }
+
+    // Absolute path check
+    if (path.isAbsolute(val)) {
+      if (!allowAbsolute) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Absolute paths are not allowed" });
+        return;
+      }
+    }
+
+    // Path traversal — check each normalized segment
+    // Normalize using posix to handle mixed separators
+    const normalized = val.replace(/\\/g, "/");
+    const segments = normalized.split("/").filter((s) => s.length > 0);
+    for (const segment of segments) {
+      if (segment === "..") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Path must not contain ".." traversal segments',
+        });
+        return;
+      }
+    }
+
+    // Double-check with path.normalize
+    const normalizedFull = path.normalize(val);
+    if (normalizedFull.startsWith("..") || normalizedFull.includes(`${path.sep}..`)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Path must not traverse above working directory",
+      });
+    }
+  });
+}

--- a/agentflow/packages/core/src/types.ts
+++ b/agentflow/packages/core/src/types.ts
@@ -1,0 +1,378 @@
+import type { ZodType } from "zod";
+
+// ─── Error kinds ──────────────────────────────────────────────────────────────
+
+export type RetryErrorKind =
+  | "subprocess_error"
+  | "output_validation_error"
+  | "tool_not_used"
+  | "timeout"
+  | "rate_limit"
+  | "provider_unavailable"
+  | "budget_exceeded"
+  | "agent_hitl_conflict";
+
+// ─── Config types ─────────────────────────────────────────────────────────────
+
+export type HITLMode = "off" | "permissions" | "checkpoint";
+
+/**
+ * HITL (Human-In-The-Loop) configuration.
+ * - "off": fully autonomous
+ * - "permissions": static tool allowlist at spawn time. Tools not listed are DENIED by default.
+ * - "checkpoint": executor pauses before task, waits for explicit user approval
+ */
+export type HITLConfig =
+  | { readonly mode: "off" }
+  | {
+      readonly mode: "permissions";
+      /**
+       * Allowlist of tools. Any tool not listed here is DENIED.
+       * Deny-by-default when mode is "permissions".
+       */
+      readonly permissions: Readonly<Record<string, boolean>>;
+    }
+  | {
+      readonly mode: "checkpoint";
+      readonly message?: string;
+    };
+
+export interface RetryConfig {
+  readonly max: number;
+  readonly on: readonly RetryErrorKind[];
+  readonly backoff: "exponential" | "linear" | "fixed";
+  /** Timeout per attempt in ms. Default: 300_000 (5 min). */
+  readonly timeoutMs?: number;
+}
+
+export interface BudgetConfig {
+  /** Maximum cost in USD. */
+  readonly maxCost: number;
+  readonly onExceed: "halt" | "warn";
+}
+
+export interface MCPConfig {
+  /** Static identifier: must match /^[a-zA-Z0-9._-]+$/. */
+  readonly server: string;
+  readonly args?: readonly string[];
+  readonly autoStart?: boolean;
+}
+
+/** Minimal logger interface for executor/hook injection. */
+export interface Logger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+// ─── Runner interface ─────────────────────────────────────────────────────────
+
+export interface RunnerSpawnArgs {
+  prompt: string;
+  model?: string;
+  tools?: readonly string[];
+  skills?: readonly string[];
+  mcps?: readonly MCPConfig[];
+  sessionHandle?: string;
+  permissions?: Readonly<Record<string, boolean>>;
+  /**
+   * System prompt injected by the executor (JSON schema contract + sanitize directives).
+   * Runners MUST prepend this BEFORE the user prompt.
+   */
+  systemPrompt?: string;
+}
+
+export interface RunnerSpawnResult {
+  /**
+   * Raw UNTRUSTED stdout. The executor MUST zod.parse() against AgentDef.output
+   * before any downstream use. Never pass raw stdout to other agents.
+   */
+  readonly stdout: string;
+  readonly sessionHandle: string;
+  readonly tokensIn: number;
+  readonly tokensOut: number;
+}
+
+/**
+ * Runner adapter interface. Each runner knows the flags of its CLI and output format.
+ * Runners are schema-agnostic — they return raw stdout; executor handles parsing.
+ */
+export interface Runner {
+  validate(): Promise<{ ok: boolean; version?: string; error?: string }>;
+  spawn(args: RunnerSpawnArgs): Promise<RunnerSpawnResult>;
+}
+
+// ─── Session types (phantom-branded) ─────────────────────────────────────────
+
+declare const __runnerBrand: unique symbol;
+
+/**
+ * Named session group. Phantom-branded by runner type R.
+ * Passing this to an agent with a different runner brand is a compile-time error.
+ */
+export interface SessionToken<R extends string = string> {
+  readonly kind: "token";
+  readonly name: string;
+  /** @internal phantom brand — never set at runtime */
+  readonly [__runnerBrand]?: R;
+}
+
+/**
+ * Transitive session ref — inherits the runner brand of the referenced task.
+ * Cross-provider session sharing is a compile-time error.
+ */
+export interface ShareSessionRef<R extends string = string> {
+  readonly kind: "share";
+  readonly taskName: string;
+  /** @internal phantom brand — never set at runtime */
+  readonly [__runnerBrand]?: R;
+}
+
+export type SessionRef<R extends string = string> =
+  | SessionToken<R>
+  | ShareSessionRef<R>;
+
+// ─── Agent definition ─────────────────────────────────────────────────────────
+
+/**
+ * Defines an AI agent with typed I/O and execution configuration.
+ *
+ * SECURITY: `output` is the Zod security boundary. Everything outside the schema
+ * is discarded. Prefer precise object schemas over z.any()/z.string().
+ *
+ * SECURITY: `sanitizeInput` (default true) controls whether the executor sanitizes
+ * ctx.*.output data before interpolating into prompts. Do not disable unless
+ * upstream schema guarantees data is safe.
+ */
+export interface AgentDef<
+  I extends ZodType = ZodType,
+  O extends ZodType = ZodType,
+  R extends string = string,
+> {
+  /** Runner identifier. Must match /^[a-zA-Z0-9._-]+$/. Static value only — no functions. */
+  readonly runner: R;
+  /** Model identifier. Static value only — no functions. */
+  readonly model?: string;
+  readonly input: I;
+  /**
+   * Output schema. REQUIRED. This is the security boundary — executor parses
+   * raw stdout through this schema; unparsed content is discarded.
+   */
+  readonly output: O;
+  readonly prompt: (input: import("zod").infer<I>) => string;
+  /** Tool identifiers. Static values only — no functions. */
+  readonly tools?: readonly string[];
+  /** Skill identifiers. Static values only — no functions. */
+  readonly skills?: readonly string[];
+  /** MCP server configs. Static values only — no functions. */
+  readonly mcps?: readonly MCPConfig[];
+  readonly hitl?: HITLConfig;
+  readonly retry?: Partial<RetryConfig>;
+  /**
+   * Sanitize ctx.*.output data before prompt interpolation.
+   * Default: true. Setting false disables prompt-injection sanitization.
+   * @defaultValue true
+   */
+  readonly sanitizeInput?: boolean;
+  readonly mustUse?: readonly string[];
+  /** Per-agent timeout in ms (single run, not per retry). Default: 300_000 (5 min). */
+  readonly timeoutMs?: number;
+  /**
+   * Environment variable passthrough. Default: inherit all (v1).
+   * Narrowing is supported but not enforced in v1.
+   */
+  readonly env?: {
+    readonly pass?: readonly string[];
+    readonly scrub?: readonly (string | RegExp)[];
+  };
+  /** Max stdout bytes before output_validation_error. Default: 1_048_576 (1 MB). */
+  readonly maxOutputBytes?: number;
+  /**
+   * Fallback chain. v2 feature — typed here to prevent breaking API changes.
+   * @v2
+   */
+  readonly fallback?: never;
+}
+
+/**
+ * AgentDef with all defaults resolved. Consumed by the executor — never raw AgentDef.
+ * Executors MUST use resolveAgentDef() to get this type.
+ */
+export interface ResolvedAgentDef<
+  I extends ZodType = ZodType,
+  O extends ZodType = ZodType,
+  R extends string = string,
+> extends Omit<AgentDef<I, O, R>, "sanitizeInput" | "retry" | "timeoutMs" | "maxOutputBytes"> {
+  /** Always explicitly set to true or false after resolveAgentDef(). */
+  readonly sanitizeInput: boolean;
+  readonly retry: RetryConfig;
+  readonly timeoutMs: number;
+  readonly maxOutputBytes: number;
+}
+
+// ─── Task map types ───────────────────────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
+export type TasksMap = Record<string, TaskDef<AgentDef<any, any, any>, readonly string[]> | LoopDef<TasksMap>>;
+
+/**
+ * Extract the runner brand from an AgentDef.
+ * RunnerOf<AgentDef<any, any, "claude">> = "claude"
+ *
+ * Uses property-based extraction to avoid TypeScript interface variance issues
+ * with conditional `extends AgentDef<...>` matching.
+ */
+export type RunnerOf<A> = A extends { runner: infer R extends string } ? R : never;
+
+/**
+ * Extract the output Zod type from an AgentDef.
+ */
+export type OutputZodOf<A> = A extends AgentDef<ZodType, infer O, string> ? O : never;
+
+/**
+ * Extract the typed output from an AgentDef.
+ */
+export type OutputOf<A> = A extends { output: infer O extends ZodType }
+  ? import("zod").infer<O>
+  : never;
+
+/**
+ * Extract the typed input from an AgentDef.
+ */
+export type InputOf<A> = A extends { input: infer I extends ZodType }
+  ? import("zod").infer<I>
+  : never;
+
+/**
+ * Extract the runner brand from a task in a TasksMap.
+ * RunnerOfTask<T, K> = RunnerOf<T[K]["agent"]>
+ */
+export type RunnerOfTask<T extends TasksMap, K extends keyof T> =
+  // biome-ignore lint/suspicious/noExplicitAny: structural infer
+  T[K] extends TaskDef<infer A, readonly string[]> ? RunnerOf<A> : never;
+
+/**
+ * Extract the direct dependsOn keys of task K in workflow T.
+ */
+export type DependsOnOf<T extends TasksMap, K extends keyof T> =
+  // biome-ignore lint/suspicious/noExplicitAny: structural infer
+  T[K] extends TaskDef<AgentDef<any, any, any>, infer D extends readonly string[]>
+    ? D[number] & keyof T
+    : never;
+
+/**
+ * Context available inside a task's `input` function.
+ * Only tasks listed in `dependsOn` are accessible.
+ * Loop outputs are typed as unknown (v1 known limitation).
+ */
+export type CtxFor<T extends TasksMap, K extends keyof T> = {
+  // biome-ignore lint/suspicious/noExplicitAny: structural infer
+  readonly [P in DependsOnOf<T, K>]: T[P] extends TaskDef<infer A, readonly string[]>
+    ? {
+        readonly output: OutputOf<A>;
+        /** Source discriminant for executor sanitization decisions. */
+        readonly _source: "agent";
+      }
+    : T[P] extends LoopDef<TasksMap>
+      ? {
+          /**
+           * Loop output type is unknown in v1 (known limitation).
+           * Cast: (ctx.myLoop.output as { taskName: { field: Type } }).taskName.field
+           */
+          readonly output: unknown;
+          readonly _source: "loop";
+        }
+      : never;
+};
+
+// ─── Task definition ──────────────────────────────────────────────────────────
+
+/**
+ * A single task in a workflow.
+ * D = tuple of dependsOn task keys (enables typed ctx in input function).
+ */
+export interface TaskDef<
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
+  A extends AgentDef<any, any, any> = AgentDef<any, any, any>,
+  D extends readonly string[] = readonly string[],
+> {
+  readonly agent: A;
+  readonly dependsOn?: D;
+  readonly input?:
+    | import("zod").infer<A extends { input: infer I extends ZodType } ? I : never>
+    | ((ctx: CtxFor<TasksMap, string>) => import("zod").infer<A extends { input: infer I extends ZodType } ? I : never>);
+  readonly session?: SessionRef<RunnerOf<A>>;
+  readonly hitl?: HITLConfig;
+  readonly mustUse?: readonly string[];
+}
+
+// ─── Loop definition ──────────────────────────────────────────────────────────
+
+export type LoopContext = "persistent" | "fresh";
+
+export interface LoopDef<T extends TasksMap = TasksMap> {
+  readonly kind: "loop";
+  readonly dependsOn?: readonly string[];
+  readonly max: number;
+  readonly until: (ctx: unknown) => boolean;
+  readonly context?: LoopContext;
+  readonly input?: ((ctx: unknown) => unknown) | unknown;
+  readonly tasks: T;
+  /**
+   * Context window limit. Advisory in v1 — executor may not enforce.
+   * @v1advisory
+   */
+  readonly contextLimit?: number;
+}
+
+// ─── Workflow types ───────────────────────────────────────────────────────────
+
+export interface TaskMetrics {
+  readonly tokensIn: number;
+  readonly tokensOut: number;
+  readonly latencyMs: number;
+  readonly retries: number;
+  /** Estimated USD cost based on model and token counts. */
+  readonly estimatedCost: number;
+}
+
+export interface WorkflowMetrics {
+  readonly totalLatencyMs: number;
+  readonly totalTokensIn: number;
+  readonly totalTokensOut: number;
+  readonly totalEstimatedCost: number;
+  readonly taskCount: number;
+}
+
+export interface WorkflowHooks<T extends TasksMap = TasksMap> {
+  readonly onTaskStart?: (taskName: keyof T & string) => void;
+  readonly onTaskComplete?: (
+    taskName: keyof T & string,
+    output: unknown,
+    metrics: TaskMetrics,
+  ) => void;
+  readonly onTaskError?: (
+    taskName: keyof T & string,
+    error: Error,
+    attempt: number,
+  ) => void;
+  /**
+   * Called when a checkpoint HITL gate is reached.
+   * Use this to send Telegram/Slack notifications before proceeding.
+   */
+  readonly onCheckpoint?: (taskName: keyof T & string, message: string) => void;
+  readonly onWorkflowComplete?: (result: unknown, summary: WorkflowMetrics) => void;
+}
+
+export interface WorkflowDef<T extends TasksMap = TasksMap> {
+  readonly name: string;
+  readonly tasks: T;
+  readonly hooks?: WorkflowHooks<T>;
+  readonly budget?: BudgetConfig;
+  /**
+   * Environment profiles. v2 feature — type reserved to prevent breaking API changes.
+   * @v2
+   */
+  readonly profiles?: never;
+}

--- a/agentflow/packages/core/tsconfig.json
+++ b/agentflow/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "node_modules", "dist"]
+}

--- a/agentflow/packages/core/tsconfig.test.json
+++ b/agentflow/packages/core/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/agentflow/tsconfig.base.json
+++ b/agentflow/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM"],
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/agentflow/turbo.json
+++ b/agentflow/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "tui",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "tsconfig.json"]
+    },
+    "lint": {
+      "inputs": ["src/**/*.ts", "biome.json"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Bootstraps Bun/Turborepo monorepo with `@agentflow/core` package
- Full type-safe DSL: `defineAgent`, `defineWorkflow`, `loop`, `sessionToken`, `shareSessionWith`
- Provider-branded sessions via phantom `unique symbol` — cross-provider sharing is a compile-time error
- Zod security boundary: raw stdout never passed downstream
- `safePath()` refinement blocks path traversal, UNC, Windows absolute, backslash absolute, control chars, env vars, URLs
- `validateStaticIdentifier()` with typed `InvalidIdentifierError` for runner/model/MCP names
- Full error hierarchy: `AgentFlowError` + 9 typed subclasses with `toJSON()`
- 109 tests (unit + type-level), TypeScript strict mode, Biome lint, GitHub Actions CI

## Test plan

- [x] `bun run typecheck` — clean (strict + exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- [x] `bun run test` — 109/109 passing
- [x] `bun run build` — clean
- [x] VERIFY gate: Reality Checker APPROVED (41/41), Security Engineer APPROVED, Code Reviewer APPROVED