### PR TITLE
feat: Phase 2 — @agentflow/executor + @agentflow/runner-claude

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -23,12 +23,40 @@
         "zod": ">=3.23.0 <4.0.0",
       },
     },
+    "packages/executor": {
+      "name": "@agentflow/executor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agentflow/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.23.0",
+      },
+    },
+    "packages/runners/claude": {
+      "name": "@agentflow/runner-claude",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agentflow/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
   },
   "overrides": {
     "zod": "^3.23.0",
   },
   "packages": {
     "@agentflow/core": ["@agentflow/core@workspace:packages/core"],
+
+    "@agentflow/executor": ["@agentflow/executor@workspace:packages/executor"],
+
+    "@agentflow/runner-claude": ["@agentflow/runner-claude@workspace:packages/runners/claude"],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
@@ -158,6 +186,8 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
@@ -177,6 +207,8 @@
     "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 

--- a/agentflow/package.json
+++ b/agentflow/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": ["packages/*", "packages/runners/*"],
   "packageManager": "bun@1.2.0",
   "scripts": {
     "build": "turbo run build",

--- a/agentflow/packages/core/src/__tests__/types.test-d.ts
+++ b/agentflow/packages/core/src/__tests__/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, it, assertType, expectTypeOf } from "vitest";
 import { z } from "zod";
 import { defineAgent, resolveAgentDef } from "../builders.js";
-import type { AgentDef, RunnerOf, OutputOf, SessionToken, TaskDef } from "../types.js";
+import type { AgentDef, BoundCtx, RunnerOf, OutputOf, SessionToken, TaskDef } from "../types.js";
 
 // ─── Test agents ──────────────────────────────────────────────────────────────
 
@@ -95,5 +95,43 @@ describe("SessionToken phantom brand type safety", () => {
     };
     // Suppress unused variable warning
     void badTask;
+  });
+});
+
+describe("BoundCtx — dependsOn key enforcement", () => {
+  it("BoundCtx restricts ctx to declared keys only", () => {
+    // With literal deps D = ["analyze"], only "analyze" is valid
+    type Ctx = BoundCtx<readonly ["analyze"]>;
+    assertType<{ readonly analyze: { readonly output: unknown; readonly _source: string } }>({} as Ctx);
+  });
+
+  it("accessing an undeclared dep key is a type error", () => {
+    type Ctx = BoundCtx<readonly ["analyze"]>;
+    const ctx = {} as Ctx;
+
+    // @ts-expect-error — "fix" is not in dependsOn, should be a type error
+    void ctx.fix;
+  });
+
+  it("declared dep key compiles fine", () => {
+    type Ctx = BoundCtx<readonly ["analyze", "fix"]>;
+    const ctx = {} as Ctx;
+    void ctx.analyze.output;
+    void ctx.fix.output;
+  });
+
+  it("TaskDef input callback ctx is restricted to dependsOn keys", () => {
+    // Constructing a TaskDef with as-const dependsOn — ctx should be typed
+    const taskWithTypedCtx: TaskDef<typeof analyzeAgent, readonly ["prior"]> = {
+      agent: analyzeAgent,
+      dependsOn: ["prior"] as const,
+      input: (ctx) => {
+        void ctx.prior.output; // ✓ "prior" is in dependsOn
+        // @ts-expect-error — "other" is not in dependsOn
+        void ctx.other;
+        return { repoPath: "./src" };
+      },
+    };
+    void taskWithTypedCtx;
   });
 });

--- a/agentflow/packages/core/src/builders.ts
+++ b/agentflow/packages/core/src/builders.ts
@@ -159,6 +159,19 @@ export function shareSessionWith<
 }
 
 /**
+ * Register a runner implementation in the global registry.
+ * Must be called before running any workflow that uses this runner.
+ *
+ * @example
+ * import { ClaudeRunner } from "@agentflow/runner-claude";
+ * registerRunner("claude", new ClaudeRunner());
+ */
+export function registerRunner(name: string, runner: Runner): void {
+  validateStaticIdentifier(name, "runner name");
+  _runnerRegistry.set(name, runner);
+}
+
+/**
  * Get a runner from the registry by name.
  * Used by the executor — not intended for user code.
  */

--- a/agentflow/packages/core/src/index.ts
+++ b/agentflow/packages/core/src/index.ts
@@ -4,6 +4,7 @@
 // Types
 export type {
   AgentDef,
+  BoundCtx,
   ResolvedAgentDef,
   BudgetConfig,
   CtxFor,
@@ -42,6 +43,7 @@ export {
   getRunner,
   getRunners,
   loop,
+  registerRunner,
   resolveAgentDef,
   sessionToken,
   shareSessionWith,
@@ -66,3 +68,4 @@ export {
   ToolNotUsedError,
   ValidationError,
 } from "./errors.js";
+export type { AttemptRecord } from "./errors.js";

--- a/agentflow/packages/core/src/types.ts
+++ b/agentflow/packages/core/src/types.ts
@@ -289,8 +289,27 @@ export type CtxFor<T extends TasksMap, K extends keyof T> = {
 // ─── Task definition ──────────────────────────────────────────────────────────
 
 /**
+ * Typed ctx available inside a task's `input` function.
+ * Restricts access to only declared `dependsOn` keys.
+ * Output is `unknown` — cast to the expected type or use `CtxFor<T, K>` for full typing.
+ *
+ * Requires `dependsOn: [...] as const` to get key-level enforcement.
+ * Without `as const`, D[number] = string and all keys are accepted (no enforcement).
+ */
+export type BoundCtx<D extends readonly string[]> = {
+  readonly [P in D[number]]: { readonly output: unknown; readonly _source: string };
+};
+
+/**
  * A single task in a workflow.
- * D = tuple of dependsOn task keys (enables typed ctx in input function).
+ *
+ * @typeParam A - Agent definition
+ * @typeParam D - Tuple of dependsOn task keys (`as const` required for type enforcement)
+ *
+ * Type safety levels for the `input` callback:
+ * - With `dependsOn: ["a", "b"] as const` → ctx restricted to keys "a" | "b", output is unknown
+ * - Without `as const` → no key restriction (falls back to string index)
+ * - For fully-typed output use `CtxFor<typeof workflow.tasks, "taskName">` directly
  */
 export interface TaskDef<
   // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
@@ -301,7 +320,7 @@ export interface TaskDef<
   readonly dependsOn?: D;
   readonly input?:
     | import("zod").infer<A extends { input: infer I extends ZodType } ? I : never>
-    | ((ctx: CtxFor<TasksMap, string>) => import("zod").infer<A extends { input: infer I extends ZodType } ? I : never>);
+    | ((ctx: BoundCtx<D>) => import("zod").infer<A extends { input: infer I extends ZodType } ? I : never>);
   readonly session?: SessionRef<RunnerOf<A>>;
   readonly hitl?: HITLConfig;
   readonly mustUse?: readonly string[];

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@agentflow/executor",
+  "version": "0.1.0",
+  "type": "module",
+  "private": false,
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": { "@agentflow/core": "workspace:*" },
+  "devDependencies": { "@types/node": "^22.0.0", "vitest": "^2.1.0", "zod": "^3.23.0" }
+}

--- a/agentflow/packages/executor/src/__tests__/dag-resolver.test.ts
+++ b/agentflow/packages/executor/src/__tests__/dag-resolver.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { defineAgent, defineWorkflow } from "@agentflow/core";
+import { topologicalSort, getReadyTasks } from "../dag-resolver.js";
+import { CyclicDependencyError } from "../errors.js";
+import type { TasksMap } from "@agentflow/core";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const dummyAgent = defineAgent({
+  runner: "mock",
+  input: z.object({}),
+  output: z.object({ done: z.boolean() }),
+  prompt: () => "test",
+});
+
+function makeTask(dependsOn?: string[]) {
+  return {
+    agent: dummyAgent,
+    dependsOn,
+  };
+}
+
+// ─── topologicalSort tests ────────────────────────────────────────────────────
+
+describe("topologicalSort", () => {
+  it("sorts a linear chain A→B→C correctly", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask(["A"]),
+      C: makeTask(["B"]),
+    };
+
+    const batches = topologicalSort(tasks);
+    expect(batches).toHaveLength(3);
+    expect(batches[0]).toEqual(["A"]);
+    expect(batches[1]).toEqual(["B"]);
+    expect(batches[2]).toEqual(["C"]);
+  });
+
+  it("puts B and C in the same batch for diamond A→{B,C}→D", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask(["A"]),
+      C: makeTask(["A"]),
+      D: makeTask(["B", "C"]),
+    };
+
+    const batches = topologicalSort(tasks);
+    expect(batches).toHaveLength(3);
+    expect(batches[0]).toEqual(["A"]);
+    // B and C can be in either order in the second batch
+    expect(batches[1]).toHaveLength(2);
+    expect(batches[1]).toContain("B");
+    expect(batches[1]).toContain("C");
+    expect(batches[2]).toEqual(["D"]);
+  });
+
+  it("puts all disconnected tasks (no deps) in first batch", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask([]),
+      C: makeTask([]),
+    };
+
+    const batches = topologicalSort(tasks);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(3);
+    expect(batches[0]).toContain("A");
+    expect(batches[0]).toContain("B");
+    expect(batches[0]).toContain("C");
+  });
+
+  it("returns single batch with single task and no deps", () => {
+    const tasks: TasksMap = {
+      A: makeTask(),
+    };
+
+    const batches = topologicalSort(tasks);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(["A"]);
+  });
+
+  it("returns empty array for empty tasks map", () => {
+    const batches = topologicalSort({});
+    expect(batches).toEqual([]);
+  });
+
+  it("throws CyclicDependencyError for A→B→A cycle", () => {
+    const tasks: TasksMap = {
+      A: makeTask(["B"]),
+      B: makeTask(["A"]),
+    };
+
+    expect(() => topologicalSort(tasks)).toThrow(CyclicDependencyError);
+  });
+
+  it("throws CyclicDependencyError for self-loop A→A", () => {
+    const tasks: TasksMap = {
+      A: makeTask(["A"]),
+    };
+
+    expect(() => topologicalSort(tasks)).toThrow(CyclicDependencyError);
+  });
+
+  it("throws CyclicDependencyError for three-node cycle A→B→C→A", () => {
+    const tasks: TasksMap = {
+      A: makeTask(["C"]),
+      B: makeTask(["A"]),
+      C: makeTask(["B"]),
+    };
+
+    expect(() => topologicalSort(tasks)).toThrow(CyclicDependencyError);
+  });
+
+  it("includes cycle path in CyclicDependencyError", () => {
+    const tasks: TasksMap = {
+      A: makeTask(["B"]),
+      B: makeTask(["A"]),
+    };
+
+    let caught: CyclicDependencyError | undefined;
+    try {
+      topologicalSort(tasks);
+    } catch (e) {
+      if (e instanceof CyclicDependencyError) {
+        caught = e;
+      }
+    }
+
+    expect(caught).toBeInstanceOf(CyclicDependencyError);
+    expect(caught?.cycle).toBeDefined();
+    expect(caught?.cycle.length).toBeGreaterThan(0);
+  });
+
+  it("handles tasks with no dependsOn property (undefined)", () => {
+    const tasks: TasksMap = {
+      A: { agent: dummyAgent },
+      B: { agent: dummyAgent, dependsOn: ["A"] },
+    };
+
+    const batches = topologicalSort(tasks);
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toEqual(["A"]);
+    expect(batches[1]).toEqual(["B"]);
+  });
+
+  it("uses defineWorkflow tasks correctly", () => {
+    const workflow = defineWorkflow({
+      name: "test",
+      tasks: {
+        fetch: makeTask([]),
+        process: makeTask(["fetch"]),
+        report: makeTask(["process"]),
+      },
+    });
+
+    const batches = topologicalSort(workflow.tasks);
+    expect(batches).toHaveLength(3);
+  });
+});
+
+// ─── getReadyTasks tests ──────────────────────────────────────────────────────
+
+describe("getReadyTasks", () => {
+  it("returns all tasks with no deps when nothing completed", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask([]),
+    };
+
+    const ready = getReadyTasks(new Set(), tasks);
+    expect(ready).toHaveLength(2);
+    expect(ready).toContain("A");
+    expect(ready).toContain("B");
+  });
+
+  it("returns dependent task once its dep is completed", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask(["A"]),
+    };
+
+    const ready = getReadyTasks(new Set(["A"]), tasks);
+    expect(ready).toEqual(["B"]);
+  });
+
+  it("returns empty array when all tasks are completed", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask(["A"]),
+    };
+
+    const ready = getReadyTasks(new Set(["A", "B"]), tasks);
+    expect(ready).toEqual([]);
+  });
+
+  it("only returns task B when both deps A and C are complete (not just one)", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      C: makeTask([]),
+      B: makeTask(["A", "C"]),
+    };
+
+    // Only A is done — B should NOT be ready
+    const readyPartial = getReadyTasks(new Set(["A"]), tasks);
+    expect(readyPartial).not.toContain("B");
+    expect(readyPartial).toContain("C");
+
+    // Both A and C done — B should be ready
+    const readyFull = getReadyTasks(new Set(["A", "C"]), tasks);
+    expect(readyFull).toContain("B");
+  });
+
+  it("excludes already-completed tasks from the result", () => {
+    const tasks: TasksMap = {
+      A: makeTask([]),
+      B: makeTask(["A"]),
+    };
+
+    const ready = getReadyTasks(new Set(["A"]), tasks);
+    expect(ready).not.toContain("A");
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/node-runner.test.ts
+++ b/agentflow/packages/executor/src/__tests__/node-runner.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import {
+  AgentHitlConflictError,
+  NodeMaxRetriesError,
+  defineAgent,
+} from "@agentflow/core";
+import type { Runner, RunnerSpawnResult } from "@agentflow/core";
+import { runNode } from "../node-runner.js";
+import { OutputValidationError } from "../errors.js";
+
+// ─── Mock runner factory ──────────────────────────────────────────────────────
+
+function makeSuccessResult(data: unknown): RunnerSpawnResult {
+  return {
+    stdout: JSON.stringify(data),
+    sessionHandle: "sess-test",
+    tokensIn: 10,
+    tokensOut: 20,
+  };
+}
+
+function makeMockRunner(spawnImpl: () => Promise<RunnerSpawnResult>): Runner {
+  return {
+    validate: vi.fn().mockResolvedValue({ ok: true, version: "1.0.0" }),
+    spawn: vi.fn(spawnImpl),
+  };
+}
+
+// ─── Test agents ──────────────────────────────────────────────────────────────
+
+const simpleAgent = defineAgent({
+  runner: "mock",
+  input: z.object({ text: z.string() }),
+  output: z.object({ result: z.string() }),
+  prompt: ({ text }) => `Process: ${text}`,
+  retry: { max: 3, on: ["subprocess_error", "output_validation_error"], backoff: "fixed" },
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("runNode", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns typed output on successful run", async () => {
+    const runner = makeMockRunner(() =>
+      Promise.resolve(makeSuccessResult({ result: "success" })),
+    );
+    const task = { agent: simpleAgent, input: { text: "hello" } };
+
+    const [result] = await Promise.all([
+      runNode(task, { text: "hello" }, runner, "test-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(result.output).toEqual({ result: "success" });
+    expect(result.tokensIn).toBe(10);
+    expect(result.tokensOut).toBe(20);
+    expect(result.retries).toBe(0);
+  });
+
+  it("retries on subprocess_error and succeeds on second attempt", async () => {
+    const subprocessErr = new Error("subprocess error occurred");
+    (subprocessErr as Error & { code: string }).code = "subprocess_error";
+
+    let callCount = 0;
+    const runner = makeMockRunner(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(subprocessErr);
+      }
+      return Promise.resolve(makeSuccessResult({ result: "retried" }));
+    });
+
+    const task = { agent: simpleAgent };
+    const [result] = await Promise.all([
+      runNode(task, { text: "hello" }, runner, "test-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(result.output).toEqual({ result: "retried" });
+    expect(result.retries).toBe(1);
+    expect(callCount).toBe(2);
+  });
+
+  it("retries on output_validation_error and succeeds on second attempt", async () => {
+    let callCount = 0;
+    const runner = makeMockRunner(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Return invalid JSON that will fail Zod schema
+        return Promise.resolve({
+          stdout: JSON.stringify({ wrong_field: "bad" }),
+          sessionHandle: "",
+          tokensIn: 5,
+          tokensOut: 5,
+        });
+      }
+      return Promise.resolve(makeSuccessResult({ result: "valid" }));
+    });
+
+    const task = { agent: simpleAgent };
+    const [result] = await Promise.all([
+      runNode(task, { text: "hello" }, runner, "test-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(result.output).toEqual({ result: "valid" });
+    expect(callCount).toBe(2);
+  });
+
+  it("throws NodeMaxRetriesError after max attempts", async () => {
+    const subprocessErr = new Error("subprocess error occurred");
+    (subprocessErr as Error & { code: string }).code = "subprocess_error";
+
+    const runner = makeMockRunner(() => Promise.reject(subprocessErr));
+    const task = {
+      agent: defineAgent({
+        runner: "mock",
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: ({ text }) => `Process: ${text}`,
+        retry: { max: 2, on: ["subprocess_error"], backoff: "fixed" },
+      }),
+    };
+
+    await expect(
+      Promise.all([
+        runNode(task, { text: "hello" }, runner, "failing-task"),
+        vi.runAllTimersAsync(),
+      ]),
+    ).rejects.toThrow(NodeMaxRetriesError);
+  });
+
+  it("NodeMaxRetriesError contains task name and attempts", async () => {
+    const subprocessErr = new Error("subprocess error occurred");
+    (subprocessErr as Error & { code: string }).code = "subprocess_error";
+
+    const runner = makeMockRunner(() => Promise.reject(subprocessErr));
+    const task = {
+      agent: defineAgent({
+        runner: "mock",
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+        retry: { max: 2, on: ["subprocess_error"], backoff: "fixed" },
+      }),
+    };
+
+    let caught: NodeMaxRetriesError | undefined;
+    try {
+      await Promise.all([
+        runNode(task, { text: "hello" }, runner, "my-task"),
+        vi.runAllTimersAsync(),
+      ]);
+    } catch (e) {
+      if (e instanceof NodeMaxRetriesError) {
+        caught = e;
+      }
+    }
+
+    expect(caught?.taskName).toBe("my-task");
+    expect(caught?.attempts.length).toBe(2);
+  });
+
+  it("does NOT retry AgentHitlConflictError — throws immediately", async () => {
+    let callCount = 0;
+    const runner = makeMockRunner(() => {
+      callCount++;
+      return Promise.reject(new AgentHitlConflictError("test-task"));
+    });
+
+    const task = { agent: simpleAgent };
+
+    await expect(
+      Promise.all([
+        runNode(task, { text: "hello" }, runner, "test-task"),
+        vi.runAllTimersAsync(),
+      ]),
+    ).rejects.toThrow(AgentHitlConflictError);
+    expect(callCount).toBe(1);
+  });
+
+  it("throws immediately for error not in retry list", async () => {
+    const unknownErr = new Error("unknown error type");
+
+    let callCount = 0;
+    const runner = makeMockRunner(() => {
+      callCount++;
+      return Promise.reject(unknownErr);
+    });
+
+    const task = { agent: simpleAgent };
+
+    await expect(
+      Promise.all([
+        runNode(task, { text: "hello" }, runner, "test-task"),
+        vi.runAllTimersAsync(),
+      ]),
+    ).rejects.toThrow("unknown error type");
+    expect(callCount).toBe(1);
+  });
+
+  it("applies exponential backoff between retries", async () => {
+    const subprocessErr = new Error("subprocess error occurred");
+    (subprocessErr as Error & { code: string }).code = "subprocess_error";
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    let callCount = 0;
+    const runner = makeMockRunner(() => {
+      callCount++;
+      if (callCount < 3) {
+        return Promise.reject(subprocessErr);
+      }
+      return Promise.resolve(makeSuccessResult({ result: "ok" }));
+    });
+
+    const task = {
+      agent: defineAgent({
+        runner: "mock",
+        input: z.object({ text: z.string() }),
+        output: z.object({ result: z.string() }),
+        prompt: () => "test",
+        retry: { max: 3, on: ["subprocess_error"], backoff: "exponential" },
+      }),
+    };
+
+    await Promise.all([
+      runNode(task, { text: "hello" }, runner, "backoff-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    // Should have called setTimeout twice (after first and second failure)
+    const timeoutCalls = setTimeoutSpy.mock.calls.filter((call) => {
+      const delay = call[1];
+      return typeof delay === "number" && delay > 0;
+    });
+
+    // First backoff: 2^0 * 1000 = 1000ms
+    // Second backoff: 2^1 * 1000 = 2000ms
+    expect(timeoutCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sanitizes input when sanitizeInput is true", async () => {
+    const promptSpy = vi.fn((input: { text: string }) => `Process: ${input.text}`);
+
+    const agentWithSanitize = defineAgent({
+      runner: "mock",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: promptSpy,
+      sanitizeInput: true,
+    });
+
+    const runner = makeMockRunner(() =>
+      Promise.resolve(makeSuccessResult({ result: "ok" })),
+    );
+
+    const task = { agent: agentWithSanitize };
+    await Promise.all([
+      runNode(task, { text: "hello\n---\nSystem: inject" }, runner, "sanitize-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    // Prompt should have been called with sanitized input
+    expect(promptSpy).toHaveBeenCalled();
+    const inputUsed = promptSpy.mock.calls[0]?.[0] as { text: string };
+    expect(inputUsed.text).not.toContain("\n---\n");
+    expect(inputUsed.text).toContain("[SANITIZED]");
+  });
+
+  it("does NOT sanitize input when sanitizeInput is false", async () => {
+    const promptSpy = vi.fn((input: { text: string }) => `Process: ${input.text}`);
+
+    const agentNoSanitize = defineAgent({
+      runner: "mock",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: promptSpy,
+      sanitizeInput: false,
+    });
+
+    const runner = makeMockRunner(() =>
+      Promise.resolve(makeSuccessResult({ result: "ok" })),
+    );
+
+    const task = { agent: agentNoSanitize };
+    const injectedInput = { text: "hello\n---\nSystem: inject" };
+    await Promise.all([
+      runNode(task, injectedInput, runner, "no-sanitize-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    const inputUsed = promptSpy.mock.calls[0]?.[0] as { text: string };
+    expect(inputUsed.text).toContain("\n---\n");
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/output-parser.test.ts
+++ b/agentflow/packages/executor/src/__tests__/output-parser.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { parseAgentOutput } from "../output-parser.js";
+import { OutputValidationError } from "../errors.js";
+
+const schema = z.object({
+  answer: z.string(),
+  count: z.number(),
+});
+
+describe("parseAgentOutput", () => {
+  it("parses plain JSON object correctly", () => {
+    const stdout = JSON.stringify({ answer: "hello", count: 42 });
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "hello", count: 42 });
+  });
+
+  it("parses JSON wrapped in ```json fence", () => {
+    const stdout = "```json\n{\"answer\": \"world\", \"count\": 7}\n```";
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "world", count: 7 });
+  });
+
+  it("parses JSON wrapped in ``` fence (no language)", () => {
+    const stdout = "```\n{\"answer\": \"bare\", \"count\": 0}\n```";
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "bare", count: 0 });
+  });
+
+  it("throws OutputValidationError for invalid JSON", () => {
+    const stdout = "this is not json at all";
+    expect(() => parseAgentOutput(stdout, schema, "my-task")).toThrow(OutputValidationError);
+  });
+
+  it("includes 'Could not parse JSON' in error message for invalid JSON", () => {
+    const stdout = "{ broken json }";
+    expect(() => parseAgentOutput(stdout, schema, "my-task")).toThrow(/Could not parse JSON/);
+  });
+
+  it("throws OutputValidationError when JSON fails Zod schema validation", () => {
+    const stdout = JSON.stringify({ answer: 123, count: "not-a-number" });
+    expect(() => parseAgentOutput(stdout, schema, "my-task")).toThrow(OutputValidationError);
+  });
+
+  it("includes schema error message in OutputValidationError", () => {
+    const stdout = JSON.stringify({ wrong_field: "value" });
+    let caught: OutputValidationError | undefined;
+    try {
+      parseAgentOutput(stdout, schema, "my-task");
+    } catch (e) {
+      if (e instanceof OutputValidationError) {
+        caught = e;
+      }
+    }
+    expect(caught).toBeInstanceOf(OutputValidationError);
+    expect(caught?.taskName).toBe("my-task");
+  });
+
+  it("strips extra fields by Zod (strip mode)", () => {
+    const stdout = JSON.stringify({ answer: "hello", count: 1, extra: "unwanted" });
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "hello", count: 1 });
+    expect("extra" in result).toBe(false);
+  });
+
+  it("handles whitespace around JSON", () => {
+    const stdout = "  \n" + JSON.stringify({ answer: "padded", count: 5 }) + "\n  ";
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "padded", count: 5 });
+  });
+
+  it("throws OutputValidationError for invalid JSON in fence", () => {
+    const stdout = "```json\n{broken}\n```";
+    expect(() => parseAgentOutput(stdout, schema, "my-task")).toThrow(OutputValidationError);
+  });
+
+  it("sets correct taskName in OutputValidationError", () => {
+    const stdout = "not-json";
+    let caught: OutputValidationError | undefined;
+    try {
+      parseAgentOutput(stdout, schema, "specific-task-name");
+    } catch (e) {
+      if (e instanceof OutputValidationError) {
+        caught = e;
+      }
+    }
+    expect(caught?.taskName).toBe("specific-task-name");
+  });
+
+  it("works with z.string() schema", () => {
+    const stdout = '"hello world"';
+    const result = parseAgentOutput(stdout, z.string(), "test-task");
+    expect(result).toBe("hello world");
+  });
+
+  it("works with z.array schema", () => {
+    const stdout = JSON.stringify([1, 2, 3]);
+    const result = parseAgentOutput(stdout, z.array(z.number()), "test-task");
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("extracts JSON from fence block preceded by prose (regression B2)", () => {
+    // Regression test: agent output with explanation text before the code fence.
+    // Common Claude pattern: "Here's the result:\n\n```json\n{...}\n```"
+    const stdout = "Here's the structured result:\n\n```json\n{\"answer\": \"prose\", \"count\": 3}\n```";
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "prose", count: 3 });
+  });
+
+  it("extracts JSON from fence block followed by prose", () => {
+    const stdout = "```json\n{\"answer\": \"before\", \"count\": 1}\n```\n\nNote: this is the answer.";
+    const result = parseAgentOutput(stdout, schema, "test-task");
+    expect(result).toEqual({ answer: "before", count: 1 });
+  });
+});

--- a/agentflow/packages/executor/src/dag-resolver.ts
+++ b/agentflow/packages/executor/src/dag-resolver.ts
@@ -1,0 +1,149 @@
+import type { TasksMap } from "@agentflow/core";
+import { CyclicDependencyError } from "./errors.js";
+
+/**
+ * Topological sort using Kahn's algorithm.
+ * Returns tasks grouped by level — all tasks in the same sub-array have their
+ * dependencies satisfied by previous levels and CAN run in parallel.
+ * Throws CyclicDependencyError if a cycle is detected.
+ *
+ * LoopDef tasks are treated as leaf nodes (no traversal into inner tasks).
+ */
+export function topologicalSort(tasks: TasksMap): string[][] {
+  const taskNames = Object.keys(tasks);
+
+  if (taskNames.length === 0) {
+    return [];
+  }
+
+  // Build in-degree map and adjacency list
+  const inDegree = new Map<string, number>();
+  // dependents[A] = list of tasks that depend on A
+  const dependents = new Map<string, string[]>();
+
+  for (const name of taskNames) {
+    inDegree.set(name, 0);
+    dependents.set(name, []);
+  }
+
+  for (const name of taskNames) {
+    const task = tasks[name];
+    const deps = task?.dependsOn ?? [];
+    for (const dep of deps) {
+      // Only count dependencies that are within this tasks map
+      if (!inDegree.has(dep)) {
+        // External dependency — skip (not in this DAG)
+        continue;
+      }
+      inDegree.set(name, (inDegree.get(name) ?? 0) + 1);
+      dependents.get(dep)?.push(name);
+    }
+  }
+
+  const batches: string[][] = [];
+  // Start with all tasks that have no dependencies
+  let currentQueue = taskNames.filter((n) => (inDegree.get(n) ?? 0) === 0);
+
+  while (currentQueue.length > 0) {
+    batches.push([...currentQueue]);
+    const nextQueue: string[] = [];
+
+    for (const name of currentQueue) {
+      for (const dependent of dependents.get(name) ?? []) {
+        const newDegree = (inDegree.get(dependent) ?? 0) - 1;
+        inDegree.set(dependent, newDegree);
+        if (newDegree === 0) {
+          nextQueue.push(dependent);
+        }
+      }
+    }
+
+    currentQueue = nextQueue;
+  }
+
+  // If any task still has in-degree > 0, there's a cycle
+  const remaining = taskNames.filter((n) => (inDegree.get(n) ?? 0) > 0);
+  if (remaining.length > 0) {
+    // Try to construct cycle path for error message
+    const cycle = findCycle(remaining, tasks);
+    throw new CyclicDependencyError(cycle);
+  }
+
+  return batches;
+}
+
+/**
+ * Returns tasks whose all dependsOn are in the completedSet.
+ * Used by the executor to find the next batch to run.
+ */
+export function getReadyTasks(completed: ReadonlySet<string>, tasks: TasksMap): string[] {
+  const ready: string[] = [];
+
+  for (const [name, task] of Object.entries(tasks)) {
+    if (completed.has(name)) {
+      continue;
+    }
+    const deps = task?.dependsOn ?? [];
+    const allDepsComplete = deps.every((dep) => completed.has(dep));
+    if (allDepsComplete) {
+      ready.push(name);
+    }
+  }
+
+  return ready;
+}
+
+/**
+ * Attempt to find a cycle path among the remaining nodes with in-degree > 0.
+ * Uses DFS to find a cycle in the subgraph of remaining nodes.
+ */
+function findCycle(remaining: string[], tasks: TasksMap): string[] {
+  const remainingSet = new Set(remaining);
+
+  // DFS-based cycle detection
+  const visited = new Set<string>();
+  const path: string[] = [];
+  const pathSet = new Set<string>();
+
+  function dfs(node: string): string[] | null {
+    if (pathSet.has(node)) {
+      // Found cycle — extract it
+      const cycleStart = path.indexOf(node);
+      return [...path.slice(cycleStart), node];
+    }
+    if (visited.has(node)) {
+      return null;
+    }
+
+    visited.add(node);
+    path.push(node);
+    pathSet.add(node);
+
+    const task = tasks[node];
+    const deps = task?.dependsOn ?? [];
+    for (const dep of deps) {
+      if (remainingSet.has(dep)) {
+        const cycle = dfs(dep);
+        if (cycle !== null) {
+          return cycle;
+        }
+      }
+    }
+
+    path.pop();
+    pathSet.delete(node);
+    return null;
+  }
+
+  for (const node of remaining) {
+    if (!visited.has(node)) {
+      const cycle = dfs(node);
+      if (cycle !== null) {
+        return cycle;
+      }
+    }
+  }
+
+  // Fallback: just return the remaining nodes
+  return remaining;
+}

--- a/agentflow/packages/executor/src/errors.ts
+++ b/agentflow/packages/executor/src/errors.ts
@@ -1,0 +1,35 @@
+import { AgentFlowError } from "@agentflow/core";
+
+export class OutputValidationError extends AgentFlowError {
+  readonly code = "output_validation_error" as const;
+  constructor(
+    readonly taskName: string,
+    readonly reason: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Output validation failed for task "${taskName}": ${reason}`, options);
+  }
+}
+
+export class CyclicDependencyError extends AgentFlowError {
+  readonly code = "cyclic_dependency" as const;
+  constructor(
+    readonly cycle: string[],
+    options?: ErrorOptions,
+  ) {
+    super(`Cyclic dependency detected: ${cycle.join(" → ")}`, options);
+  }
+}
+
+export class RunnerNotRegisteredError extends AgentFlowError {
+  readonly code = "runner_not_registered" as const;
+  constructor(
+    readonly runnerName: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Runner "${runnerName}" is not registered. Call registerRunner() before running the workflow.`,
+      options,
+    );
+  }
+}

--- a/agentflow/packages/executor/src/index.ts
+++ b/agentflow/packages/executor/src/index.ts
@@ -1,0 +1,7 @@
+export { WorkflowExecutor } from "./workflow-executor.js";
+export type { WorkflowResult } from "./workflow-executor.js";
+export { OutputValidationError, CyclicDependencyError, RunnerNotRegisteredError } from "./errors.js";
+export { topologicalSort, getReadyTasks } from "./dag-resolver.js";
+export { parseAgentOutput } from "./output-parser.js";
+export { runNode } from "./node-runner.js";
+export type { NodeRunResult } from "./node-runner.js";

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -1,0 +1,190 @@
+import {
+  AgentHitlConflictError,
+  NodeMaxRetriesError,
+  TimeoutError,
+  resolveAgentDef,
+} from "@agentflow/core";
+import type { AgentDef, AttemptRecord, Runner, TaskDef } from "@agentflow/core";
+import type { ZodType } from "zod";
+import { OutputValidationError } from "./errors.js";
+import { parseAgentOutput } from "./output-parser.js";
+
+export interface NodeRunResult<O> {
+  output: O;
+  tokensIn: number;
+  tokensOut: number;
+  latencyMs: number;
+  retries: number;
+}
+
+// ─── Input sanitization ───────────────────────────────────────────────────────
+
+const INJECTION_PATTERNS = [
+  /\n---\n/g,
+  /\nSystem:/g,
+  /\nHuman:/g,
+  /\nAssistant:/g,
+];
+
+/**
+ * Recursively sanitize string values in an object against prompt injection patterns.
+ * Only string leaf values are sanitized — objects and arrays are traversed.
+ */
+function sanitizeCtxData(data: unknown): unknown {
+  if (typeof data === "string") {
+    let sanitized = data;
+    for (const pattern of INJECTION_PATTERNS) {
+      sanitized = sanitized.replace(pattern, " [SANITIZED] ");
+    }
+    return sanitized;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(sanitizeCtxData);
+  }
+
+  if (data !== null && typeof data === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      result[key] = sanitizeCtxData(value);
+    }
+    return result;
+  }
+
+  return data;
+}
+
+// ─── Backoff calculation ──────────────────────────────────────────────────────
+
+function calculateBackoffMs(backoff: "exponential" | "linear" | "fixed", attempt: number): number {
+  switch (backoff) {
+    case "exponential": {
+      const ms = 2 ** attempt * 1000;
+      return Math.min(ms, 30_000);
+    }
+    case "linear":
+      return attempt * 1000;
+    case "fixed":
+      return 1000;
+  }
+}
+
+// ─── runNode ──────────────────────────────────────────────────────────────────
+
+/**
+ * Run a single task with retry logic.
+ * Retries on: subprocess_error, output_validation_error, timeout.
+ * Throws NodeMaxRetriesError after max attempts.
+ * AgentHitlConflictError is never retried.
+ */
+export async function runNode<
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+  A extends AgentDef<any, any, any>,
+>(
+  task: TaskDef<A>,
+  resolvedInput: import("zod").infer<A extends { input: infer I extends ZodType } ? I : ZodType>,
+  runner: Runner,
+  taskName: string,
+): Promise<NodeRunResult<import("zod").infer<A extends { output: infer O extends ZodType } ? O : ZodType>>> {
+  const resolvedDef = resolveAgentDef(task.agent);
+  const maxAttempts = resolvedDef.retry.max;
+  const attempts: AttemptRecord[] = [];
+  const startTime = Date.now();
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      // Apply prompt injection sanitization if enabled
+      const safeInput = resolvedDef.sanitizeInput
+        ? (sanitizeCtxData(resolvedInput) as typeof resolvedInput)
+        : resolvedInput;
+
+      const prompt = resolvedDef.prompt(safeInput);
+
+      // Build spawn args — only include optional properties when defined
+      // (exactOptionalPropertyTypes requires we not pass explicit undefined)
+      const spawnArgs: import("@agentflow/core").RunnerSpawnArgs = { prompt };
+      if (resolvedDef.model !== undefined) {
+        spawnArgs.model = resolvedDef.model;
+      }
+      if (resolvedDef.tools !== undefined && resolvedDef.tools.length > 0) {
+        spawnArgs.tools = resolvedDef.tools;
+      }
+      if (resolvedDef.mcps !== undefined && resolvedDef.mcps.length > 0) {
+        spawnArgs.mcps = resolvedDef.mcps;
+      }
+
+      const spawnResult = await runner.spawn(spawnArgs);
+
+      // Parse and validate output through Zod security boundary
+      const output = parseAgentOutput(
+        spawnResult.stdout,
+        resolvedDef.output,
+        taskName,
+      ) as import("zod").infer<A extends { output: infer O extends ZodType } ? O : ZodType>;
+
+      const latencyMs = Date.now() - startTime;
+
+      return {
+        output,
+        tokensIn: spawnResult.tokensIn,
+        tokensOut: spawnResult.tokensOut,
+        latencyMs,
+        retries: attempt,
+      };
+    } catch (err) {
+      // HITL conflict — never retry, throw immediately
+      if (err instanceof AgentHitlConflictError) {
+        throw err;
+      }
+
+      // Determine if this error kind is retryable
+      let errorCode: "subprocess_error" | "output_validation_error" | "timeout" | null = null;
+      let errorMessage: string;
+
+      if (err instanceof OutputValidationError) {
+        errorCode = "output_validation_error";
+        errorMessage = err.message;
+      } else if (err instanceof TimeoutError) {
+        errorCode = "timeout";
+        errorMessage = err.message;
+      } else if (err instanceof Error && err.message.includes("subprocess")) {
+        errorCode = "subprocess_error";
+        errorMessage = err.message;
+      } else if (err instanceof Error) {
+        // Check if the error has a code that matches a subprocess error
+        const errWithCode = err as Error & { code?: string };
+        if (errWithCode.code === "subprocess_error") {
+          errorCode = "subprocess_error";
+          errorMessage = err.message;
+        } else {
+          // Unknown error — throw immediately without retry
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+
+      // Check if this error kind is in the retry list
+      if (errorCode !== null && resolvedDef.retry.on.includes(errorCode)) {
+        attempts.push({
+          attempt,
+          error: errorMessage,
+          errorCode,
+        });
+
+        // Apply backoff before next attempt (not after last attempt)
+        if (attempt < maxAttempts - 1) {
+          const backoffMs = calculateBackoffMs(resolvedDef.retry.backoff, attempt);
+          if (backoffMs > 0) {
+            await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
+          }
+        }
+      } else {
+        // Error not in retry list — throw immediately
+        throw err;
+      }
+    }
+  }
+
+  throw new NodeMaxRetriesError(taskName, attempts);
+}

--- a/agentflow/packages/executor/src/output-parser.ts
+++ b/agentflow/packages/executor/src/output-parser.ts
@@ -1,0 +1,68 @@
+import type { ZodType } from "zod";
+import { OutputValidationError } from "./errors.js";
+
+// Match the first fenced code block anywhere in the string (not anchored to start/end).
+// This handles the common case where an agent wraps output in prose:
+//   "Here's the result:\n\n```json\n{...}\n```"
+const MARKDOWN_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n```/;
+
+/**
+ * Parse agent raw stdout into typed output.
+ *
+ * Steps:
+ * 1. Try JSON.parse(stdout)
+ * 2. If fails: strip markdown code fences (```json...```) and retry
+ * 3. schema.safeParse(parsed) → typed result or throw OutputValidationError
+ *
+ * Zod is the security boundary — raw stdout never passes through untransformed.
+ */
+export function parseAgentOutput<O extends ZodType>(
+  stdout: string,
+  schema: O,
+  taskName: string,
+): import("zod").infer<O> {
+  const trimmed = stdout.trim();
+
+  // Step 1: try direct JSON parse
+  let parsed: unknown;
+  let parseError: string | undefined;
+
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (e) {
+    parseError = e instanceof Error ? e.message : String(e);
+
+    // Step 2: strip markdown fences and retry
+    const fenceMatch = MARKDOWN_FENCE_RE.exec(trimmed);
+    if (fenceMatch !== null) {
+      const innerContent = fenceMatch[1];
+      if (innerContent !== undefined) {
+        try {
+          parsed = JSON.parse(innerContent);
+          parseError = undefined;
+        } catch (e2) {
+          parseError = e2 instanceof Error ? e2.message : String(e2);
+        }
+      }
+    }
+  }
+
+  if (parseError !== undefined) {
+    throw new OutputValidationError(
+      taskName,
+      `Could not parse JSON from agent output: ${parseError}`,
+    );
+  }
+
+  // Step 3: Zod validation — security boundary
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new OutputValidationError(
+      taskName,
+      result.error.message,
+    );
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: inferred from generic O
+  return result.data as import("zod").infer<O>;
+}

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -1,0 +1,116 @@
+import { getRunner } from "@agentflow/core";
+import type { AgentDef, TaskDef, TaskMetrics, TasksMap, WorkflowDef, WorkflowMetrics } from "@agentflow/core";
+import { RunnerNotRegisteredError } from "./errors.js";
+import { topologicalSort } from "./dag-resolver.js";
+import { runNode } from "./node-runner.js";
+
+export interface WorkflowResult<T extends TasksMap> {
+  outputs: { [K in keyof T]?: unknown };
+  metrics: WorkflowMetrics;
+}
+
+// Context entry stored for each completed task
+interface CtxEntry {
+  output: unknown;
+  _source: "agent";
+}
+
+export class WorkflowExecutor<T extends TasksMap> {
+  constructor(private readonly workflow: WorkflowDef<T>) {}
+
+  async run(_input?: unknown): Promise<WorkflowResult<T>> {
+    const { tasks, hooks } = this.workflow;
+    const workflowStart = Date.now();
+
+    // Topological sort to get execution batches
+    const batches = topologicalSort(tasks);
+
+    // Execution context: maps task name → output
+    const ctx: Record<string, CtxEntry> = {};
+    const outputs: { [K in keyof T]?: unknown } = {};
+
+    // Accumulated metrics
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    let taskCount = 0;
+
+    // Phase 2: run sequentially even if a batch has multiple tasks
+    for (const batch of batches) {
+      for (const taskName of batch) {
+        const taskDef = tasks[taskName];
+
+        // Skip LoopDef tasks in Phase 2 (not implemented)
+        if (taskDef === undefined || "kind" in taskDef) {
+          continue;
+        }
+
+        // We know this is a TaskDef<AgentDef<...>, ...> here
+        // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+        const task = taskDef as TaskDef<AgentDef<any, any, any>>;
+        const runnerName: string = task.agent.runner;
+
+        // Get runner from registry
+        const runner = getRunner(runnerName);
+        if (runner === undefined) {
+          throw new RunnerNotRegisteredError(runnerName);
+        }
+
+        // Resolve input
+        let resolvedInput: unknown;
+        if (typeof task.input === "function") {
+          resolvedInput = (task.input as (ctx: Record<string, CtxEntry>) => unknown)(ctx);
+        } else {
+          resolvedInput = task.input;
+        }
+
+        // Fire onTaskStart hook
+        hooks?.onTaskStart?.(taskName as keyof T & string);
+
+        try {
+          const result = await runNode(task, resolvedInput, runner, taskName);
+
+          // Store output in context
+          const ctxEntry: CtxEntry = { output: result.output, _source: "agent" };
+          ctx[taskName] = ctxEntry;
+          outputs[taskName as keyof T] = result.output;
+
+          taskCount++;
+          totalTokensIn += result.tokensIn;
+          totalTokensOut += result.tokensOut;
+
+          const taskMetrics: TaskMetrics = {
+            tokensIn: result.tokensIn,
+            tokensOut: result.tokensOut,
+            latencyMs: result.latencyMs,
+            retries: result.retries,
+            estimatedCost: 0, // Phase 2: no cost calculation
+          };
+
+          // Fire onTaskComplete hook
+          hooks?.onTaskComplete?.(taskName as keyof T & string, result.output, taskMetrics);
+        } catch (err) {
+          // Fire onTaskError hook
+          if (err instanceof Error) {
+            hooks?.onTaskError?.(taskName as keyof T & string, err, 0);
+          }
+          throw err;
+        }
+      }
+    }
+
+    const totalLatencyMs = Date.now() - workflowStart;
+
+    const metrics: WorkflowMetrics = {
+      totalLatencyMs,
+      totalTokensIn,
+      totalTokensOut,
+      totalEstimatedCost: 0,
+      taskCount,
+    };
+
+    // Fire onWorkflowComplete hook
+    hooks?.onWorkflowComplete?.(outputs, metrics);
+
+    return { outputs, metrics };
+  }
+}

--- a/agentflow/packages/executor/tsconfig.json
+++ b/agentflow/packages/executor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "types": ["node"],
+    "paths": { "@agentflow/core": ["../core/src/index.ts"] }
+  },
+  "references": [{ "path": "../core" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@agentflow/runner-claude",
+  "version": "0.1.0",
+  "type": "module",
+  "private": false,
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": { "@agentflow/core": "workspace:*" },
+  "devDependencies": { "@types/bun": "^1.1.0", "@types/node": "^22.0.0", "vitest": "^2.1.0" }
+}

--- a/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
+++ b/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi } from "vitest";
+import { AgentHitlConflictError } from "@agentflow/core";
+import { ClaudeRunner, ClaudeSubprocessError } from "../claude-runner.js";
+import type { SpawnFn, SpawnResult, SpawnSyncFn, SpawnSyncResult } from "../claude-runner.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function encodeStr(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function makeSpawnSyncResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+  return {
+    exitCode,
+    stdout: encodeStr(stdout),
+    stderr: encodeStr(stderr),
+  };
+}
+
+function makeSpawnResult(stdout: string, exitCode = 0, stderr = ""): SpawnResult {
+  const encoder = new TextEncoder();
+
+  const makeStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(encoder.encode(stdout)),
+    stderr: makeStream(encoder.encode(stderr)),
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+function makeJsonlOutput(
+  resultContent: string,
+  sessionId = "sess-123",
+  tokensIn = 10,
+  tokensOut = 20,
+): string {
+  const resultLine = JSON.stringify({
+    type: "result",
+    result: resultContent,
+    session_id: sessionId,
+    usage: {
+      input_tokens: tokensIn,
+      output_tokens: tokensOut,
+    },
+  });
+  return `{"type":"assistant","message":"thinking..."}\n${resultLine}\n`;
+}
+
+// ─── validate() tests ─────────────────────────────────────────────────────────
+
+describe("ClaudeRunner.validate()", () => {
+  it("returns ok: true with version when claude is found", async () => {
+    const spawnSync: SpawnSyncFn = vi
+      .fn()
+      // First call: which claude
+      .mockReturnValueOnce(makeSpawnSyncResult(0, "/usr/local/bin/claude"))
+      // Second call: claude --version
+      .mockReturnValueOnce(makeSpawnSyncResult(0, "Claude CLI 1.2.3"));
+
+    const runner = new ClaudeRunner({ spawnSync });
+    const result = await runner.validate();
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("1.2.3");
+  });
+
+  it("parses version string with just digits", async () => {
+    const spawnSync: SpawnSyncFn = vi
+      .fn()
+      .mockReturnValueOnce(makeSpawnSyncResult(0, "/usr/bin/claude"))
+      .mockReturnValueOnce(makeSpawnSyncResult(0, "2.0.1"));
+
+    const runner = new ClaudeRunner({ spawnSync });
+    const result = await runner.validate();
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2.0.1");
+  });
+
+  it("returns ok: false when claude is not found on PATH", async () => {
+    const spawnSync: SpawnSyncFn = vi
+      .fn()
+      .mockReturnValueOnce(makeSpawnSyncResult(1, "", "claude not found"));
+
+    const runner = new ClaudeRunner({ spawnSync });
+    const result = await runner.validate();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("not found on PATH");
+  });
+
+  it("returns ok: false when --version fails", async () => {
+    const spawnSync: SpawnSyncFn = vi
+      .fn()
+      // which succeeds
+      .mockReturnValueOnce(makeSpawnSyncResult(0, "/usr/bin/claude"))
+      // --version fails
+      .mockReturnValueOnce(makeSpawnSyncResult(1, "", "permission denied"));
+
+    const runner = new ClaudeRunner({ spawnSync });
+    const result = await runner.validate();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("--version failed");
+  });
+});
+
+// ─── spawn() tests ────────────────────────────────────────────────────────────
+
+describe("ClaudeRunner.spawn()", () => {
+  it("parses JSONL output correctly", async () => {
+    const resultJson = JSON.stringify({ answer: "42" });
+    const jsonlOutput = makeJsonlOutput(resultJson, "sess-abc", 100, 200);
+
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    const result = await runner.spawn({ prompt: "What is the answer?" });
+
+    expect(result.stdout).toBe(resultJson);
+    expect(result.sessionHandle).toBe("sess-abc");
+    expect(result.tokensIn).toBe(100);
+    expect(result.tokensOut).toBe(200);
+  });
+
+  it("uses last result line if multiple present", async () => {
+    const firstResult = JSON.stringify({ answer: "first" });
+    const secondResult = JSON.stringify({ answer: "second" });
+    const jsonlOutput =
+      `${JSON.stringify({ type: "result", result: firstResult, session_id: "sess-1", usage: { input_tokens: 5, output_tokens: 5 } })}\n` +
+      `${JSON.stringify({ type: "result", result: secondResult, session_id: "sess-2", usage: { input_tokens: 10, output_tokens: 10 } })}\n`;
+
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    const result = await runner.spawn({ prompt: "test" });
+    expect(result.stdout).toBe(secondResult);
+    expect(result.sessionHandle).toBe("sess-2");
+  });
+
+  it("includes model flag when model is provided", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({ prompt: "test", model: "claude-opus-4-6" });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).toContain("--model");
+    expect(callArgs).toContain("claude-opus-4-6");
+  });
+
+  it("includes allowedTools when tools are provided", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({ prompt: "test", tools: ["bash", "read"] });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).toContain("--allowedTools");
+    expect(callArgs).toContain("bash,read");
+  });
+
+  it("includes resume flag when sessionHandle is provided", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({ prompt: "test", sessionHandle: "sess-xyz" });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).toContain("--resume");
+    expect(callArgs).toContain("sess-xyz");
+  });
+
+  it("does NOT include resume flag for empty sessionHandle", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({ prompt: "test", sessionHandle: "" });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).not.toContain("--resume");
+  });
+
+  it("includes disallowedTools for denied permissions", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({
+      prompt: "test",
+      permissions: { bash: false, read: true, write: false },
+    });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).toContain("--disallowedTools");
+    const disallowedIdx = callArgs.indexOf("--disallowedTools");
+    const disallowedValue = callArgs[disallowedIdx + 1] ?? "";
+    expect(disallowedValue).toContain("bash");
+    expect(disallowedValue).toContain("write");
+    expect(disallowedValue).not.toContain("read");
+  });
+
+  it("prepends system prompt before user prompt", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({
+      prompt: "User prompt here",
+      systemPrompt: "You are a helpful assistant",
+    });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    const lastArg = callArgs[callArgs.length - 1] ?? "";
+    expect(lastArg).toContain("You are a helpful assistant");
+    expect(lastArg).toContain("User prompt here");
+    // System prompt comes before user prompt
+    expect(lastArg.indexOf("You are a helpful assistant")).toBeLessThan(
+      lastArg.indexOf("User prompt here"),
+    );
+  });
+
+  it("throws ClaudeSubprocessError on non-zero exit code", async () => {
+    const spawnFn: SpawnFn = vi
+      .fn()
+      .mockReturnValue(makeSpawnResult("", 1, "permission denied"));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await expect(runner.spawn({ prompt: "test" })).rejects.toThrow(ClaudeSubprocessError);
+  });
+
+  it("throws ClaudeSubprocessError with stderr content", async () => {
+    const spawnFn: SpawnFn = vi
+      .fn()
+      .mockReturnValue(makeSpawnResult("", 2, "authentication failed"));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await expect(runner.spawn({ prompt: "test" })).rejects.toThrow("authentication failed");
+  });
+
+  it("throws AgentHitlConflictError on [y/n] in stdout", async () => {
+    const hitlOutput = "Do you want to proceed? [y/n]\n";
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(hitlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await expect(runner.spawn({ prompt: "test" })).rejects.toThrow(AgentHitlConflictError);
+  });
+
+  it("throws AgentHitlConflictError on (Y/n) in stdout", async () => {
+    const hitlOutput = "Continue? (Y/n)\n";
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(hitlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await expect(runner.spawn({ prompt: "test" })).rejects.toThrow(AgentHitlConflictError);
+  });
+
+  it("extracts session handle from result line", async () => {
+    const jsonlOutput = makeJsonlOutput("{}", "session-42");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    const result = await runner.spawn({ prompt: "test" });
+    expect(result.sessionHandle).toBe("session-42");
+  });
+
+  it("returns empty sessionHandle when no session_id in result", async () => {
+    const resultLine = JSON.stringify({
+      type: "result",
+      result: "{}",
+      usage: { input_tokens: 5, output_tokens: 5 },
+    });
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(resultLine));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    const result = await runner.spawn({ prompt: "test" });
+    expect(result.sessionHandle).toBe("");
+  });
+
+  it("handles output with no JSONL result line (raw stdout fallback)", async () => {
+    const rawOutput = "Some raw text without JSON\n";
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(rawOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    const result = await runner.spawn({ prompt: "test" });
+    expect(result.stdout).toBe(rawOutput);
+    expect(result.sessionHandle).toBe("");
+    expect(result.tokensIn).toBe(0);
+    expect(result.tokensOut).toBe(0);
+  });
+
+  it("does NOT throw AgentHitlConflictError when result content contains [y/n] text", async () => {
+    // Regression test for B1: HITL check must NOT scan the JSON result content.
+    // An agent response whose result field happens to say "answer [y/n]" is valid output.
+    const resultContent = JSON.stringify({ answer: "Please choose [y/n] to proceed" });
+    const jsonlOutput = makeJsonlOutput(resultContent, "sess-abc", 10, 20);
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    // Should succeed — [y/n] is inside JSON, not a bare interactive prompt
+    const result = await runner.spawn({ prompt: "test" });
+    expect(result.stdout).toBe(resultContent);
+  });
+
+  it("still throws AgentHitlConflictError when [y/n] appears as a bare non-JSON line", async () => {
+    // This simulates an actual interactive prompt leaking from stderr/non-JSON stdout
+    const barePromptOutput = 'Do you want to continue? [y/n]\n';
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(barePromptOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await expect(runner.spawn({ prompt: "test" })).rejects.toThrow(AgentHitlConflictError);
+  });
+
+  it("always includes --output-format json --print flags", async () => {
+    const jsonlOutput = makeJsonlOutput("{}");
+    const spawnFn: SpawnFn = vi.fn().mockReturnValue(makeSpawnResult(jsonlOutput));
+    const runner = new ClaudeRunner({ spawn: spawnFn });
+
+    await runner.spawn({ prompt: "test" });
+
+    const callArgs = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string[];
+    expect(callArgs).toContain("--output-format");
+    expect(callArgs).toContain("json");
+    expect(callArgs).toContain("--print");
+  });
+});

--- a/agentflow/packages/runners/claude/src/claude-runner.ts
+++ b/agentflow/packages/runners/claude/src/claude-runner.ts
@@ -1,0 +1,229 @@
+import { AgentFlowError, AgentHitlConflictError } from "@agentflow/core";
+import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@agentflow/core";
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class ClaudeSubprocessError extends AgentFlowError {
+  readonly code = "subprocess_error" as const;
+  constructor(
+    readonly exitCode: number,
+    readonly stderr: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Claude subprocess exited with code ${exitCode}: ${stderr}`, options);
+  }
+}
+
+// ─── JSONL result types ───────────────────────────────────────────────────────
+
+interface ClaudeResultLine {
+  type: "result";
+  result: string;
+  session_id?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+interface ClaudeJsonLine {
+  type: string;
+  [key: string]: unknown;
+}
+
+// ─── Injectable subprocess interface (enables testing without real Bun) ───────
+
+export interface SpawnSyncResult {
+  exitCode: number;
+  stdout: Uint8Array | ArrayBuffer;
+  stderr: Uint8Array | ArrayBuffer;
+}
+
+export interface SpawnResult {
+  stdout: ReadableStream<Uint8Array> | null;
+  stderr: ReadableStream<Uint8Array> | null;
+  exited: Promise<number>;
+}
+
+export type SpawnSyncFn = (cmd: string[], opts?: { stdout: string; stderr: string }) => SpawnSyncResult;
+export type SpawnFn = (cmd: string[], opts?: { stdout: string; stderr: string }) => SpawnResult;
+
+function defaultSpawnSync(cmd: string[], opts?: { stdout: string; stderr: string }): SpawnSyncResult {
+  const result = Bun.spawnSync(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: result.exitCode ?? 1,
+    stdout: result.stdout ?? new Uint8Array(),
+    stderr: result.stderr ?? new Uint8Array(),
+  };
+}
+
+function defaultSpawn(cmd: string[], opts?: { stdout: string; stderr: string }): SpawnResult {
+  const proc = Bun.spawn(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    stdout: proc.stdout as ReadableStream<Uint8Array>,
+    stderr: proc.stderr as ReadableStream<Uint8Array>,
+    exited: proc.exited,
+  };
+}
+
+// ─── ClaudeRunner ─────────────────────────────────────────────────────────────
+
+export interface ClaudeRunnerOptions {
+  /** Override spawn sync for testing */
+  spawnSync?: SpawnSyncFn;
+  /** Override spawn for testing */
+  spawn?: SpawnFn;
+}
+
+export class ClaudeRunner implements Runner {
+  private readonly _spawnSync: SpawnSyncFn;
+  private readonly _spawn: SpawnFn;
+
+  constructor(opts?: ClaudeRunnerOptions) {
+    this._spawnSync = opts?.spawnSync ?? defaultSpawnSync;
+    this._spawn = opts?.spawn ?? defaultSpawn;
+  }
+
+  async validate(): Promise<{ ok: boolean; version?: string; error?: string }> {
+    // Check if claude is on PATH
+    const whichResult = this._spawnSync(["which", "claude"]);
+
+    if (whichResult.exitCode !== 0) {
+      return {
+        ok: false,
+        error: "claude CLI not found on PATH. Install via: npm install -g @anthropic-ai/claude-code",
+      };
+    }
+
+    // Get version
+    const versionResult = this._spawnSync(["claude", "--version"]);
+
+    if (versionResult.exitCode !== 0) {
+      const stderr = new TextDecoder().decode(versionResult.stderr);
+      return { ok: false, error: `claude --version failed: ${stderr}` };
+    }
+
+    const versionOutput = new TextDecoder().decode(versionResult.stdout).trim();
+    // Parse version string — expect something like "1.2.3" or "Claude CLI v1.2.3"
+    const versionMatch = versionOutput.match(/(\d+\.\d+\.\d+)/);
+    const version = versionMatch?.[1] ?? versionOutput;
+
+    return { ok: true, version };
+  }
+
+  async spawn(args: RunnerSpawnArgs): Promise<RunnerSpawnResult> {
+    const cliArgs: string[] = ["--output-format", "json", "--print"];
+
+    if (args.model !== undefined) {
+      cliArgs.push("--model", args.model);
+    }
+
+    if (args.tools !== undefined && args.tools.length > 0) {
+      cliArgs.push("--allowedTools", args.tools.join(","));
+    }
+
+    if (args.sessionHandle !== undefined && args.sessionHandle !== "") {
+      cliArgs.push("--resume", args.sessionHandle);
+    }
+
+    // Build denied tools list from permissions map
+    if (args.permissions !== undefined) {
+      const deniedTools = Object.entries(args.permissions)
+        .filter(([, allowed]) => allowed === false)
+        .map(([tool]) => tool);
+      if (deniedTools.length > 0) {
+        cliArgs.push("--disallowedTools", deniedTools.join(","));
+      }
+    }
+
+    // Build final prompt: prepend system prompt if provided
+    let finalPrompt = args.prompt;
+    if (args.systemPrompt !== undefined && args.systemPrompt !== "") {
+      finalPrompt = `${args.systemPrompt}\n\n---\n\n${args.prompt}`;
+    }
+
+    const proc = this._spawn(["claude", ...cliArgs, finalPrompt]);
+
+    const stdoutStream = proc.stdout;
+    const stderrStream = proc.stderr;
+
+    const [stdoutBytes, stderrBytes, exitCode] = await Promise.all([
+      stdoutStream !== null
+        ? new Response(stdoutStream).arrayBuffer()
+        : Promise.resolve(new ArrayBuffer(0)),
+      stderrStream !== null
+        ? new Response(stderrStream).arrayBuffer()
+        : Promise.resolve(new ArrayBuffer(0)),
+      proc.exited,
+    ]);
+
+    const stdout = new TextDecoder().decode(stdoutBytes);
+    const stderr = new TextDecoder().decode(stderrBytes);
+
+    if (exitCode !== 0) {
+      throw new ClaudeSubprocessError(exitCode, stderr);
+    }
+
+    // Parse JSONL output: split on newlines, parse each line as JSON.
+    // Non-JSON lines are collected separately for HITL detection — this prevents
+    // false positives when the agent's result content contains "[y/n]" text.
+    const lines = stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+
+    let resultLine: ClaudeResultLine | undefined;
+    const nonJsonLines: string[] = [];
+
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as ClaudeJsonLine;
+        if (parsed["type"] === "result") {
+          resultLine = parsed as unknown as ClaudeResultLine;
+        }
+      } catch {
+        // Not valid JSON — collect for HITL detection below
+        nonJsonLines.push(line);
+      }
+    }
+
+    // Detect HITL prompts only in non-JSON output (interactive prompts are never
+    // valid JSON lines; checking full stdout would false-positive on result content).
+    const hitlCheck = nonJsonLines.join("\n");
+    if (
+      /\[y\/n\]/i.test(hitlCheck) ||
+      /\(Y\/n\)/i.test(hitlCheck) ||
+      /\(y\/N\)/i.test(hitlCheck)
+    ) {
+      throw new AgentHitlConflictError("unknown");
+    }
+
+    if (resultLine === undefined) {
+      // If no JSONL result line found, treat entire stdout as the result
+      return {
+        stdout,
+        sessionHandle: "",
+        tokensIn: 0,
+        tokensOut: 0,
+      };
+    }
+
+    const resultContent = resultLine.result;
+    const sessionHandle = resultLine.session_id ?? "";
+    const tokensIn = resultLine.usage?.input_tokens ?? 0;
+    const tokensOut = resultLine.usage?.output_tokens ?? 0;
+
+    return {
+      stdout: resultContent,
+      sessionHandle,
+      tokensIn,
+      tokensOut,
+    };
+  }
+}

--- a/agentflow/packages/runners/claude/src/index.ts
+++ b/agentflow/packages/runners/claude/src/index.ts
@@ -1,0 +1,1 @@
+export { ClaudeRunner, ClaudeSubprocessError } from "./claude-runner.js";

--- a/agentflow/packages/runners/claude/tsconfig.json
+++ b/agentflow/packages/runners/claude/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "types": ["bun"],
+    "paths": { "@agentflow/core": ["../../core/src/index.ts"] }
+  },
+  "references": [{ "path": "../../core" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
## Summary

- **`@agentflow/runner-claude`**: Claude CLI subprocess runner with injectable spawn for testing; JSONL parsing; HITL detection restricted to non-JSON stdout lines (false-positive fix)
- **`@agentflow/executor`**: DAG executor MVP — Kahn's topological sort, output parser (handles fenced JSON in prose), node retry with backoff, linear WorkflowExecutor with hooks + metrics
- **`@agentflow/core`** — `BoundCtx<D>` fix: `TaskDef.input` ctx now restricted to declared `dependsOn` keys only (was `any`-typed index, now key-safe with `as const`)

## Fixes from VERIFY

- **B1**: HITL regex moved from full stdout scan to non-JSON lines only — prevents false positive when agent result contains `[y/n]` text
- **B2**: `MARKDOWN_FENCE_RE` anchors removed — now extracts fenced JSON from inside prose output

## Test plan

- [x] `bun run test --force` — 172/172 passing (core 109, executor 41, runner-claude 22)
- [x] `bun run typecheck --force` — clean (strict + exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- [x] `bun run build --force` — clean
- [x] VERIFY: Reality Checker APPROVED (5/5), Code Reviewer APPROVED after blocker fixes

## Follow-up issues (non-blocking, logged separately)

- Missing `WorkflowExecutor` integration test (W1)
- Silent missing-dep in DAG resolver (W2)
- `sanitizeCtxData` anchor gap for leading-line injection (W3)
- `systemPrompt` JSON schema contract not generated (W4)
- Linear backoff zero-delay first retry (W5)