### PR TITLE
chore: rename @agentflow → @ageflow + npm trusted publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write  # required for npm OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agentflow
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: bun install
+      - run: bun run build
+
+      - name: Publish @ageflow/core
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/core
+
+      - name: Publish @ageflow/executor
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/executor
+
+      - name: Publish @ageflow/runner-claude
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/runners/claude
+
+      - name: Publish @ageflow/runner-codex
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/runners/codex
+
+      - name: Publish @ageflow/testing
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/testing
+
+      - name: Publish ageflow (CLI)
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/cli

--- a/agentflow/examples/bug-fix-pipeline/agents/analyze.ts
+++ b/agentflow/examples/bug-fix-pipeline/agents/analyze.ts
@@ -1,4 +1,4 @@
-import { defineAgent } from "@agentflow/core";
+import { defineAgent } from "@ageflow/core";
 import { z } from "zod";
 
 export const analyzeAgent = defineAgent({

--- a/agentflow/examples/bug-fix-pipeline/agents/eval.ts
+++ b/agentflow/examples/bug-fix-pipeline/agents/eval.ts
@@ -1,4 +1,4 @@
-import { defineAgent } from "@agentflow/core";
+import { defineAgent } from "@ageflow/core";
 import { z } from "zod";
 
 export const evalAgent = defineAgent({

--- a/agentflow/examples/bug-fix-pipeline/agents/fix.ts
+++ b/agentflow/examples/bug-fix-pipeline/agents/fix.ts
@@ -1,4 +1,4 @@
-import { defineAgent } from "@agentflow/core";
+import { defineAgent } from "@ageflow/core";
 import { z } from "zod";
 
 export const fixAgent = defineAgent({

--- a/agentflow/examples/bug-fix-pipeline/agents/summarize.ts
+++ b/agentflow/examples/bug-fix-pipeline/agents/summarize.ts
@@ -1,4 +1,4 @@
-import { defineAgent } from "@agentflow/core";
+import { defineAgent } from "@ageflow/core";
 import { z } from "zod";
 
 export const summarizeAgent = defineAgent({

--- a/agentflow/examples/bug-fix-pipeline/package.json
+++ b/agentflow/examples/bug-fix-pipeline/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/example-bug-fix-pipeline",
+  "name": "@ageflow/example-bug-fix-pipeline",
   "version": "0.1.0",
   "type": "module",
   "private": true,
@@ -9,9 +9,9 @@
     "smoke": "PATH=\"$PWD/__mocks__:$PATH\" agentwf run workflow.ts"
   },
   "dependencies": {
-    "@agentflow/core": "workspace:*",
-    "@agentflow/runner-claude": "workspace:*",
-    "@agentflow/testing": "workspace:*"
+    "@ageflow/core": "workspace:*",
+    "@ageflow/runner-claude": "workspace:*",
+    "@ageflow/testing": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agentflow/examples/bug-fix-pipeline/workflow.test.ts
+++ b/agentflow/examples/bug-fix-pipeline/workflow.test.ts
@@ -1,5 +1,5 @@
-import type { WorkflowDef } from "@agentflow/core";
-import { createTestHarness } from "@agentflow/testing";
+import type { WorkflowDef } from "@ageflow/core";
+import { createTestHarness } from "@ageflow/testing";
 import { describe, expect, it } from "vitest";
 import workflow from "./workflow.js";
 

--- a/agentflow/examples/bug-fix-pipeline/workflow.ts
+++ b/agentflow/examples/bug-fix-pipeline/workflow.ts
@@ -3,9 +3,9 @@ import {
   loop,
   registerRunner,
   sessionToken,
-} from "@agentflow/core";
-import type { CtxFor } from "@agentflow/core";
-import { ClaudeRunner } from "@agentflow/runner-claude";
+} from "@ageflow/core";
+import type { CtxFor } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
 import { analyzeAgent } from "./agents/analyze.js";
 import { evalAgent } from "./agents/eval.js";
 import { fixAgent } from "./agents/fix.js";

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentflow",
+  "name": "ageflow",
   "version": "0.1.0",
   "type": "module",
   "private": false,
@@ -15,8 +15,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@agentflow/core": "workspace:*",
-    "@agentflow/executor": "workspace:*",
+    "@ageflow/core": "workspace:*",
+    "@ageflow/executor": "workspace:*",
     "chalk": "^5.3.0",
     "ora": "^8.0.0",
     "boxen": "^8.0.0",

--- a/agentflow/packages/cli/src/__tests__/renderer.test.ts
+++ b/agentflow/packages/cli/src/__tests__/renderer.test.ts
@@ -1,4 +1,4 @@
-import type { TaskMetrics, WorkflowMetrics } from "@agentflow/core";
+import type { TaskMetrics, WorkflowMetrics } from "@ageflow/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatCliError } from "../output/errors.js";
 import {

--- a/agentflow/packages/cli/src/commands/dry-run.ts
+++ b/agentflow/packages/cli/src/commands/dry-run.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
-import { resolveAgentDef } from "@agentflow/core";
-import type { AgentDef, TaskDef, TasksMap, WorkflowDef } from "@agentflow/core";
-import { topologicalSort } from "@agentflow/executor";
+import { resolveAgentDef } from "@ageflow/core";
+import type { AgentDef, TaskDef, TasksMap, WorkflowDef } from "@ageflow/core";
+import { topologicalSort } from "@ageflow/executor";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { renderDryRunTask, renderError } from "../output/renderer.js";

--- a/agentflow/packages/cli/src/commands/init.ts
+++ b/agentflow/packages/cli/src/commands/init.ts
@@ -4,8 +4,8 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import { renderError } from "../output/renderer.js";
 
-const WORKFLOW_TEMPLATE = `import { defineAgent, defineWorkflow, registerRunner } from "@agentflow/core";
-import { ClaudeRunner } from "@agentflow/runner-claude";
+const WORKFLOW_TEMPLATE = `import { defineAgent, defineWorkflow, registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
 import { z } from "zod";
 
 // Register runners before the workflow is executed
@@ -85,9 +85,9 @@ export function registerInitCommand(program: Command): void {
               "dry-run": "agentwf dry-run workflow.ts",
             },
             dependencies: {
-              "@agentflow/core": "latest",
-              "@agentflow/executor": "latest",
-              "@agentflow/runner-claude": "latest",
+              "@ageflow/core": "latest",
+              "@ageflow/executor": "latest",
+              "@ageflow/runner-claude": "latest",
               zod: "^3.23.0",
             },
           },

--- a/agentflow/packages/cli/src/commands/run.ts
+++ b/agentflow/packages/cli/src/commands/run.ts
@@ -3,8 +3,8 @@ import type {
   TaskMetrics,
   WorkflowDef,
   WorkflowMetrics,
-} from "@agentflow/core";
-import { WorkflowExecutor } from "@agentflow/executor";
+} from "@ageflow/core";
+import { WorkflowExecutor } from "@ageflow/executor";
 import type { Command } from "commander";
 import {
   renderError,

--- a/agentflow/packages/cli/src/commands/validate.ts
+++ b/agentflow/packages/cli/src/commands/validate.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import type { WorkflowDef } from "@agentflow/core";
-import { runPreflight } from "@agentflow/executor";
+import type { WorkflowDef } from "@ageflow/core";
+import { runPreflight } from "@ageflow/executor";
 import chalk from "chalk";
 import type { Command } from "commander";
 import {

--- a/agentflow/packages/cli/src/output/renderer.ts
+++ b/agentflow/packages/cli/src/output/renderer.ts
@@ -1,4 +1,4 @@
-import type { TaskMetrics, WorkflowMetrics } from "@agentflow/core";
+import type { TaskMetrics, WorkflowMetrics } from "@ageflow/core";
 import chalk from "chalk";
 
 // ─── Header ───────────────────────────────────────────────────────────────────

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/core",
+  "name": "@ageflow/core",
   "version": "0.1.0",
   "type": "module",
   "private": false,

--- a/agentflow/packages/core/src/builders.ts
+++ b/agentflow/packages/core/src/builders.ts
@@ -163,7 +163,7 @@ export function shareSessionWith<
  * Must be called before running any workflow that uses this runner.
  *
  * @example
- * import { ClaudeRunner } from "@agentflow/runner-claude";
+ * import { ClaudeRunner } from "@ageflow/runner-claude";
  * registerRunner("claude", new ClaudeRunner());
  */
 export function registerRunner(name: string, runner: Runner): void {

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/executor",
+  "name": "@ageflow/executor",
   "version": "0.1.0",
   "type": "module",
   "private": false,
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@agentflow/core": "workspace:*" },
+  "dependencies": { "@ageflow/core": "workspace:*" },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",

--- a/agentflow/packages/executor/src/__tests__/budget-tracker.test.ts
+++ b/agentflow/packages/executor/src/__tests__/budget-tracker.test.ts
@@ -1,4 +1,4 @@
-import { BudgetExceededError } from "@agentflow/core";
+import { BudgetExceededError } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { BudgetTracker } from "../budget-tracker.js";
 

--- a/agentflow/packages/executor/src/__tests__/dag-resolver.test.ts
+++ b/agentflow/packages/executor/src/__tests__/dag-resolver.test.ts
@@ -1,5 +1,5 @@
-import { defineAgent, defineWorkflow } from "@agentflow/core";
-import type { TasksMap } from "@agentflow/core";
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import type { TasksMap } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { getReadyTasks, topologicalSort } from "../dag-resolver.js";

--- a/agentflow/packages/executor/src/__tests__/hitl-manager.test.ts
+++ b/agentflow/packages/executor/src/__tests__/hitl-manager.test.ts
@@ -1,4 +1,4 @@
-import type { WorkflowHooks } from "@agentflow/core";
+import type { WorkflowHooks } from "@ageflow/core";
 import { describe, expect, it, vi } from "vitest";
 import { HitlNotInteractiveError } from "../errors.js";
 import { HITLManager } from "../hitl-manager.js";

--- a/agentflow/packages/executor/src/__tests__/loop-executor.test.ts
+++ b/agentflow/packages/executor/src/__tests__/loop-executor.test.ts
@@ -1,6 +1,6 @@
-import { defineAgent, sessionToken } from "@agentflow/core";
-import type { LoopDef, TasksMap } from "@agentflow/core";
-import { LoopMaxIterationsError } from "@agentflow/core";
+import { defineAgent, sessionToken } from "@ageflow/core";
+import type { LoopDef, TasksMap } from "@ageflow/core";
+import { LoopMaxIterationsError } from "@ageflow/core";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { LoopExecutor } from "../loop-executor.js";

--- a/agentflow/packages/executor/src/__tests__/node-runner.test.ts
+++ b/agentflow/packages/executor/src/__tests__/node-runner.test.ts
@@ -2,8 +2,8 @@ import {
   AgentHitlConflictError,
   NodeMaxRetriesError,
   defineAgent,
-} from "@agentflow/core";
-import type { Runner, RunnerSpawnResult } from "@agentflow/core";
+} from "@ageflow/core";
+import type { Runner, RunnerSpawnResult } from "@ageflow/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { OutputValidationError } from "../errors.js";

--- a/agentflow/packages/executor/src/__tests__/preflight.test.ts
+++ b/agentflow/packages/executor/src/__tests__/preflight.test.ts
@@ -3,7 +3,7 @@ import {
   defineWorkflow,
   sessionToken,
   shareSessionWith,
-} from "@agentflow/core";
+} from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { runPreflight } from "../preflight.js";

--- a/agentflow/packages/executor/src/__tests__/session-manager.test.ts
+++ b/agentflow/packages/executor/src/__tests__/session-manager.test.ts
@@ -1,5 +1,5 @@
-import { defineAgent, sessionToken, shareSessionWith } from "@agentflow/core";
-import type { TasksMap } from "@agentflow/core";
+import { defineAgent, sessionToken, shareSessionWith } from "@ageflow/core";
+import type { TasksMap } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { SessionCycleError, UnresolvedSessionRefError } from "../errors.js";

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.test.ts
@@ -3,8 +3,8 @@ import {
   defineWorkflow,
   registerRunner,
   sessionToken,
-} from "@agentflow/core";
-import type { Runner, RunnerSpawnResult } from "@agentflow/core";
+} from "@ageflow/core";
+import type { Runner, RunnerSpawnResult } from "@ageflow/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { BudgetTracker } from "../budget-tracker.js";

--- a/agentflow/packages/executor/src/budget-tracker.ts
+++ b/agentflow/packages/executor/src/budget-tracker.ts
@@ -1,5 +1,5 @@
-import type { BudgetConfig } from "@agentflow/core";
-import { BudgetExceededError } from "@agentflow/core";
+import type { BudgetConfig } from "@ageflow/core";
+import { BudgetExceededError } from "@ageflow/core";
 
 /** Model pricing (USD per 1M tokens). Update when Anthropic/OpenAI change prices. */
 const MODEL_PRICES: Record<

--- a/agentflow/packages/executor/src/dag-resolver.ts
+++ b/agentflow/packages/executor/src/dag-resolver.ts
@@ -1,4 +1,4 @@
-import type { TasksMap } from "@agentflow/core";
+import type { TasksMap } from "@ageflow/core";
 import { CyclicDependencyError, UnresolvedDependencyError } from "./errors.js";
 
 /**

--- a/agentflow/packages/executor/src/errors.ts
+++ b/agentflow/packages/executor/src/errors.ts
@@ -1,4 +1,4 @@
-import { AgentFlowError } from "@agentflow/core";
+import { AgentFlowError } from "@ageflow/core";
 
 export class SessionCycleError extends AgentFlowError {
   readonly code = "session_cycle" as const;

--- a/agentflow/packages/executor/src/hitl-manager.ts
+++ b/agentflow/packages/executor/src/hitl-manager.ts
@@ -1,5 +1,5 @@
 import * as readline from "node:readline";
-import type { HITLConfig, WorkflowHooks } from "@agentflow/core";
+import type { HITLConfig, WorkflowHooks } from "@ageflow/core";
 import { HitlNotInteractiveError } from "./errors.js";
 
 export class HITLManager {

--- a/agentflow/packages/executor/src/loop-executor.ts
+++ b/agentflow/packages/executor/src/loop-executor.ts
@@ -1,5 +1,5 @@
-import type { LoopDef, TasksMap } from "@agentflow/core";
-import { LoopMaxIterationsError } from "@agentflow/core";
+import type { LoopDef, TasksMap } from "@ageflow/core";
+import { LoopMaxIterationsError } from "@ageflow/core";
 import { SessionManager } from "./session-manager.js";
 import type { CtxEntry, RunBatchesFn } from "./types-internal.js";
 

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -3,8 +3,8 @@ import {
   NodeMaxRetriesError,
   TimeoutError,
   resolveAgentDef,
-} from "@agentflow/core";
-import type { AgentDef, AttemptRecord, Runner, TaskDef } from "@agentflow/core";
+} from "@ageflow/core";
+import type { AgentDef, AttemptRecord, Runner, TaskDef } from "@ageflow/core";
 import type { ZodType } from "zod";
 import { OutputValidationError } from "./errors.js";
 import { parseAgentOutput } from "./output-parser.js";
@@ -120,7 +120,7 @@ export async function runNode<
 
       // Build spawn args — only include optional properties when defined
       // (exactOptionalPropertyTypes requires we not pass explicit undefined)
-      const spawnArgs: import("@agentflow/core").RunnerSpawnArgs = {
+      const spawnArgs: import("@ageflow/core").RunnerSpawnArgs = {
         prompt,
         taskName,
       };

--- a/agentflow/packages/executor/src/preflight.ts
+++ b/agentflow/packages/executor/src/preflight.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import type { TasksMap, WorkflowDef } from "@agentflow/core";
-import { validateStaticIdentifier } from "@agentflow/core";
+import type { TasksMap, WorkflowDef } from "@ageflow/core";
+import { validateStaticIdentifier } from "@ageflow/core";
 import { topologicalSort } from "./dag-resolver.js";
 import {
   CyclicDependencyError,

--- a/agentflow/packages/executor/src/session-manager.ts
+++ b/agentflow/packages/executor/src/session-manager.ts
@@ -1,4 +1,4 @@
-import type { TasksMap } from "@agentflow/core";
+import type { TasksMap } from "@ageflow/core";
 import { SessionCycleError, UnresolvedSessionRefError } from "./errors.js";
 
 /**

--- a/agentflow/packages/executor/src/types-internal.ts
+++ b/agentflow/packages/executor/src/types-internal.ts
@@ -1,4 +1,4 @@
-import type { TasksMap } from "@agentflow/core";
+import type { TasksMap } from "@ageflow/core";
 import type { SessionManager } from "./session-manager.js";
 
 /**

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -1,4 +1,4 @@
-import { getRunner, resolveAgentDef } from "@agentflow/core";
+import { getRunner, resolveAgentDef } from "@ageflow/core";
 import type {
   AgentDef,
   TaskDef,
@@ -6,7 +6,7 @@ import type {
   TasksMap,
   WorkflowDef,
   WorkflowMetrics,
-} from "@agentflow/core";
+} from "@ageflow/core";
 import { BudgetTracker } from "./budget-tracker.js";
 import { topologicalSort } from "./dag-resolver.js";
 import { RunnerNotRegisteredError } from "./errors.js";

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/runner-claude",
+  "name": "@ageflow/runner-claude",
   "version": "0.1.0",
   "type": "module",
   "private": false,
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@agentflow/core": "workspace:*" },
+  "dependencies": { "@ageflow/core": "workspace:*" },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",

--- a/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
+++ b/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
@@ -1,4 +1,4 @@
-import { AgentHitlConflictError } from "@agentflow/core";
+import { AgentHitlConflictError } from "@ageflow/core";
 import { describe, expect, it, vi } from "vitest";
 import { ClaudeRunner, ClaudeSubprocessError } from "../claude-runner.js";
 import type {

--- a/agentflow/packages/runners/claude/src/claude-runner.ts
+++ b/agentflow/packages/runners/claude/src/claude-runner.ts
@@ -1,9 +1,9 @@
-import { AgentFlowError, AgentHitlConflictError } from "@agentflow/core";
+import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
 import type {
   Runner,
   RunnerSpawnArgs,
   RunnerSpawnResult,
-} from "@agentflow/core";
+} from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/runners/codex/package.json
+++ b/agentflow/packages/runners/codex/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/runner-codex",
+  "name": "@ageflow/runner-codex",
   "version": "0.1.0",
   "type": "module",
   "private": false,
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@agentflow/core": "workspace:*" },
+  "dependencies": { "@ageflow/core": "workspace:*" },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",

--- a/agentflow/packages/runners/codex/src/__tests__/codex-runner.test.ts
+++ b/agentflow/packages/runners/codex/src/__tests__/codex-runner.test.ts
@@ -1,4 +1,4 @@
-import { AgentHitlConflictError } from "@agentflow/core";
+import { AgentHitlConflictError } from "@ageflow/core";
 import { describe, expect, it, vi } from "vitest";
 import { CodexRunner, CodexSubprocessError } from "../codex-runner.js";
 import type {

--- a/agentflow/packages/runners/codex/src/codex-runner.ts
+++ b/agentflow/packages/runners/codex/src/codex-runner.ts
@@ -1,9 +1,9 @@
-import { AgentFlowError, AgentHitlConflictError } from "@agentflow/core";
+import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
 import type {
   Runner,
   RunnerSpawnArgs,
   RunnerSpawnResult,
-} from "@agentflow/core";
+} from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentflow/testing",
+  "name": "@ageflow/testing",
   "version": "0.1.0",
   "type": "module",
   "private": false,
@@ -14,8 +14,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@agentflow/core": "workspace:*",
-    "@agentflow/executor": "workspace:*"
+    "@ageflow/core": "workspace:*",
+    "@ageflow/executor": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agentflow/packages/testing/src/__tests__/test-harness.test.ts
+++ b/agentflow/packages/testing/src/__tests__/test-harness.test.ts
@@ -4,8 +4,8 @@ import {
   getRunners,
   registerRunner,
   unregisterRunner,
-} from "@agentflow/core";
-import type { Runner, RunnerSpawnResult } from "@agentflow/core";
+} from "@ageflow/core";
+import type { Runner, RunnerSpawnResult } from "@ageflow/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 import { createTestHarness } from "../test-harness.js";

--- a/agentflow/packages/testing/src/test-harness.ts
+++ b/agentflow/packages/testing/src/test-harness.ts
@@ -1,13 +1,13 @@
-import { getRunners, registerRunner, unregisterRunner } from "@agentflow/core";
+import { getRunners, registerRunner, unregisterRunner } from "@ageflow/core";
 import type {
   Runner,
   RunnerSpawnArgs,
   TasksMap,
   WorkflowDef,
   WorkflowHooks,
-} from "@agentflow/core";
-import { WorkflowExecutor } from "@agentflow/executor";
-import type { WorkflowResult } from "@agentflow/executor";
+} from "@ageflow/core";
+import { WorkflowExecutor } from "@ageflow/executor";
+import type { WorkflowResult } from "@ageflow/executor";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -175,7 +175,7 @@ export function createTestHarness(workflow: WorkflowDef): TestHarness {
               onTaskComplete: (
                 taskName: string,
                 output: unknown,
-                metrics: import("@agentflow/core").TaskMetrics,
+                metrics: import("@ageflow/core").TaskMetrics,
               ) => {
                 workflowHooks.onTaskComplete?.(
                   taskName as never,


### PR DESCRIPTION
## Changes
- Rename all packages: `@agentflow/*` → `@ageflow/*`, CLI `agentflow` → `ageflow`
- Add `.github/workflows/publish.yml` — OIDC publishing via npm Trusted Publishers

## To publish
1. Configure Trusted Publisher on npmjs.com for each package (see below)
2. Push a tag: `git tag v0.1.0 && git push --tags`