### PR TITLE
docs: READMEs + package metadata for all packages

### DIFF
--- a/agentflow/README.md
+++ b/agentflow/README.md
@@ -1,0 +1,100 @@
+# ageflow
+
+[![npm](https://img.shields.io/npm/v/@ageflow/core)](https://www.npmjs.com/package/@ageflow/core)
+[![CI](https://github.com/Neftedollar/ageflow/actions/workflows/agentflow-ci.yml/badge.svg)](https://github.com/Neftedollar/ageflow/actions)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**TypeScript-first DSL for multi-agent AI workflows.** Define DAGs of AI agents with type-safe I/O, loops, sessions, and human-in-the-loop checkpoints — then run them locally or in CI with a single command.
+
+```ts
+import { defineAgent, defineWorkflow, registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+import { z } from "zod";
+
+registerRunner("claude", new ClaudeRunner());
+
+const reviewAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",
+  input: z.object({ code: z.string() }),
+  output: z.object({ issues: z.array(z.string()), approved: z.boolean() }),
+  prompt: ({ code }) => `Review this code and list issues:\n\n${code}`,
+});
+
+export default defineWorkflow({
+  name: "code-review",
+  tasks: {
+    review: { agent: reviewAgent, input: { code: "const x = eval(input)" } },
+  },
+});
+```
+
+```bash
+npx @ageflow/cli run workflow.ts
+```
+
+## Why ageflow?
+
+| Feature | What it means |
+|---|---|
+| **Type-safe I/O** | Zod schemas validate every agent's input and output — bad data never reaches the next task |
+| **DAG execution** | Tasks run in parallel when possible, in order when they depend on each other |
+| **Loops** | Iterative refinement (fix → evaluate → fix again) with persistent or fresh session context |
+| **Sessions** | Share conversation context between agents — the model remembers what it said earlier |
+| **HITL** | Pause a workflow for human approval before a task runs |
+| **Budget guard** | Set a max cost; the workflow stops before you overspend |
+| **Test harness** | Swap real CLI runners for mocks — test workflows in milliseconds, no API calls |
+| **Subprocess model** | No HTTP server. Agents are CLI subprocesses (`claude`, `codex`) — auth lives in the CLI |
+
+## Installation
+
+```bash
+# Core DSL + a runner
+bun add @ageflow/core @ageflow/runner-claude
+
+# CLI (global)
+bun add -g @ageflow/cli
+```
+
+## Quick start
+
+```bash
+# Scaffold a new project
+agentwf init my-workflow
+cd my-workflow
+bun install
+
+# Preview prompts without running agents
+agentwf dry-run workflow.ts
+
+# Validate DAG and runner availability
+agentwf validate workflow.ts
+
+# Run
+agentwf run workflow.ts
+```
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [`@ageflow/core`](packages/core) | Types, Zod schemas, DSL builders (`defineAgent`, `defineWorkflow`, `loop`, `sessionToken`) |
+| [`@ageflow/executor`](packages/executor) | DAG executor, loop runner, session manager, HITL, budget tracker, preflight |
+| [`@ageflow/runner-claude`](packages/runners/claude) | Claude CLI subprocess runner |
+| [`@ageflow/runner-codex`](packages/runners/codex) | OpenAI Codex CLI subprocess runner |
+| [`@ageflow/testing`](packages/testing) | Test harness — mock agents, inspect call counts, test workflows without API calls |
+| [`@ageflow/cli`](packages/cli) | `agentwf` CLI — `run`, `validate`, `dry-run`, `init` |
+
+## Examples
+
+- [`examples/bug-fix-pipeline`](examples/bug-fix-pipeline) — Full pipeline: analyze → fix (loop with session) → summarize. Demonstrates loops, HITL, session sharing, and type-safe `CtxFor`.
+
+## Requirements
+
+- [Bun](https://bun.sh) ≥ 1.0 (or Node.js ≥ 18)
+- [`claude` CLI](https://github.com/anthropics/claude-code) for Claude agents
+- [`codex` CLI](https://github.com/openai/codex) for Codex agents
+
+## License
+
+MIT

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -12,13 +12,12 @@
       },
     },
     "examples/bug-fix-pipeline": {
-      "name": "@agentflow/example-bug-fix-pipeline",
+      "name": "@ageflow/example-bug-fix-pipeline",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
-        "@agentflow/runner-claude": "workspace:*",
-        "@agentflow/testing": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/runner-claude": "workspace:*",
+        "@ageflow/testing": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -27,14 +26,14 @@
       },
     },
     "packages/cli": {
-      "name": "agentflow",
+      "name": "ageflow",
       "version": "0.1.0",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
         "boxen": "^8.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -47,7 +46,7 @@
       },
     },
     "packages/core": {
-      "name": "@agentflow/core",
+      "name": "@ageflow/core",
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -59,10 +58,10 @@
       },
     },
     "packages/executor": {
-      "name": "@agentflow/executor",
+      "name": "@ageflow/executor",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -71,10 +70,10 @@
       },
     },
     "packages/runners/claude": {
-      "name": "@agentflow/runner-claude",
+      "name": "@ageflow/runner-claude",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -83,10 +82,10 @@
       },
     },
     "packages/runners/codex": {
-      "name": "@agentflow/runner-codex",
+      "name": "@ageflow/runner-codex",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -95,11 +94,11 @@
       },
     },
     "packages/testing": {
-      "name": "@agentflow/testing",
+      "name": "@ageflow/testing",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -112,17 +111,17 @@
     "zod": "^3.23.0",
   },
   "packages": {
-    "@agentflow/core": ["@agentflow/core@workspace:packages/core"],
+    "@ageflow/core": ["@ageflow/core@workspace:packages/core"],
 
-    "@agentflow/example-bug-fix-pipeline": ["@agentflow/example-bug-fix-pipeline@workspace:examples/bug-fix-pipeline"],
+    "@ageflow/example-bug-fix-pipeline": ["@ageflow/example-bug-fix-pipeline@workspace:examples/bug-fix-pipeline"],
 
-    "@agentflow/executor": ["@agentflow/executor@workspace:packages/executor"],
+    "@ageflow/executor": ["@ageflow/executor@workspace:packages/executor"],
 
-    "@agentflow/runner-claude": ["@agentflow/runner-claude@workspace:packages/runners/claude"],
+    "@ageflow/runner-claude": ["@ageflow/runner-claude@workspace:packages/runners/claude"],
 
-    "@agentflow/runner-codex": ["@agentflow/runner-codex@workspace:packages/runners/codex"],
+    "@ageflow/runner-codex": ["@ageflow/runner-codex@workspace:packages/runners/codex"],
 
-    "@agentflow/testing": ["@agentflow/testing@workspace:packages/testing"],
+    "@ageflow/testing": ["@ageflow/testing@workspace:packages/testing"],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
@@ -272,7 +271,7 @@
 
     "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
-    "agentflow": ["agentflow@workspace:packages/cli"],
+    "ageflow": ["ageflow@workspace:packages/cli"],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 

--- a/agentflow/packages/cli/README.md
+++ b/agentflow/packages/cli/README.md
@@ -1,0 +1,90 @@
+# @ageflow/cli
+
+[![npm](https://img.shields.io/npm/v/@ageflow/cli)](https://www.npmjs.com/package/@ageflow/cli)
+
+CLI for [ageflow](../../README.md) — scaffold, validate, preview, and run multi-agent workflows.
+
+## Install
+
+```bash
+bun add -g @ageflow/cli
+# or
+npx @ageflow/cli <command>
+```
+
+## Commands
+
+### `agentwf init <project-name>`
+
+Scaffold a new workflow project:
+
+```bash
+agentwf init my-workflow
+cd my-workflow
+bun install
+agentwf run workflow.ts
+```
+
+Generates:
+```
+my-workflow/
+├── workflow.ts       ← ready-to-edit workflow definition
+├── agents/           ← put your agent files here
+└── package.json      ← run/validate/dry-run scripts
+```
+
+---
+
+### `agentwf validate <workflow-file>`
+
+Run preflight checks without executing any agents:
+
+```bash
+agentwf validate workflow.ts
+```
+
+Checks:
+- All runner CLIs are installed and on `PATH` (`claude`, `codex`)
+- DAG has no cycles
+- All `dependsOn` references exist
+- Session cross-provider conflicts (e.g. a `claude` session used by a `codex` agent)
+
+---
+
+### `agentwf dry-run <workflow-file>`
+
+Print the resolved execution plan and rendered prompts without running anything:
+
+```bash
+agentwf dry-run workflow.ts
+```
+
+Output shows:
+- Execution batches (which tasks run in parallel)
+- Each task's runner and rendered prompt (with placeholder inputs for dynamic prompts)
+- Loop structure
+
+---
+
+### `agentwf run <workflow-file>`
+
+Run the workflow end-to-end:
+
+```bash
+agentwf run workflow.ts
+```
+
+Options set in the workflow definition (not flags):
+- `budget` — max cost in USD; workflow halts if exceeded
+- `hooks.onCheckpoint` — HITL pause before a task
+- `retry` — per-task retry config
+
+## Requirements
+
+- Bun ≥ 1.0 or Node.js ≥ 18
+- [`claude` CLI](https://github.com/anthropics/claude-code) for Claude agents
+- [`codex` CLI](https://github.com/openai/codex) for Codex agents
+
+## License
+
+MIT

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,11 +1,18 @@
 {
   "name": "@ageflow/cli",
   "version": "0.1.0",
+  "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/cli",
   "type": "module",
   "private": false,
-  "bin": { "agentwf": "./dist/bin.js" },
+  "bin": {
+    "agentwf": "./dist/bin.js"
+  },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -26,5 +33,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ageflow",
+  "name": "@ageflow/cli",
   "version": "0.1.0",
   "type": "module",
   "private": false,

--- a/agentflow/packages/cli/src/commands/run.ts
+++ b/agentflow/packages/cli/src/commands/run.ts
@@ -1,9 +1,5 @@
 import path from "node:path";
-import type {
-  TaskMetrics,
-  WorkflowDef,
-  WorkflowMetrics,
-} from "@ageflow/core";
+import type { TaskMetrics, WorkflowDef, WorkflowMetrics } from "@ageflow/core";
 import { WorkflowExecutor } from "@ageflow/executor";
 import type { Command } from "commander";
 import {

--- a/agentflow/packages/core/README.md
+++ b/agentflow/packages/core/README.md
@@ -1,0 +1,147 @@
+# @ageflow/core
+
+[![npm](https://img.shields.io/npm/v/@ageflow/core)](https://www.npmjs.com/package/@ageflow/core)
+
+Core DSL for [ageflow](../../README.md) — types, Zod schemas, and builders for defining agents and workflows.
+
+## Install
+
+```bash
+bun add @ageflow/core zod
+```
+
+## API
+
+### `defineAgent(def)`
+
+Define a typed agent. The `input` and `output` Zod schemas are the contract — ageflow validates every call.
+
+```ts
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+const summaryAgent = defineAgent({
+  runner: "claude",            // matches a registered Runner
+  model: "claude-sonnet-4-6",
+  input: z.object({
+    text: z.string(),
+    maxWords: z.number().optional(),
+  }),
+  output: z.object({
+    summary: z.string(),
+    wordCount: z.number(),
+  }),
+  prompt: ({ text, maxWords }) =>
+    `Summarize in ${maxWords ?? 100} words:\n\n${text}`,
+});
+```
+
+### `defineWorkflow(def)`
+
+Compose agents into a DAG. Tasks with no `dependsOn` run in parallel.
+
+```ts
+import { defineWorkflow } from "@ageflow/core";
+
+export default defineWorkflow({
+  name: "summarize-and-translate",
+  tasks: {
+    summarize: {
+      agent: summaryAgent,
+      input: { text: "...", maxWords: 50 },
+    },
+    translate: {
+      agent: translateAgent,
+      dependsOn: ["summarize"],   // runs after summarize
+      input: (ctx) => ({
+        text: ctx.summarize.output.summary,
+        targetLang: "es",
+      }),
+    },
+  },
+});
+```
+
+### `loop(def)`
+
+Run a sub-workflow repeatedly until a condition is met.
+
+```ts
+import { loop } from "@ageflow/core";
+
+const refineLoop = loop({
+  dependsOn: ["draft"] as const,
+  max: 5,
+  until: (ctx) => ctx.grade?.output?.score >= 9,
+  tasks: {
+    improve: { agent: improveAgent, dependsOn: [], input: ... },
+    grade:   { agent: gradeAgent,   dependsOn: ["improve"], input: ... },
+  },
+});
+```
+
+### `sessionToken(name, runner)`
+
+Share conversation context between agents. Both agents send messages to the same model session.
+
+```ts
+import { sessionToken } from "@ageflow/core";
+
+const sharedCtx = sessionToken("my-session", "claude");
+
+// Use in agent definitions:
+const agentA = defineAgent({ ..., session: sharedCtx });
+const agentB = defineAgent({ ..., session: sharedCtx }); // same conversation
+```
+
+### `registerRunner(name, runner)` / `getRunner(name)`
+
+Register CLI subprocess runners before running a workflow.
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+
+registerRunner("claude", new ClaudeRunner());
+```
+
+### `safePath`
+
+Zod refinement that rejects path traversal (`../`, absolute paths). Use it on any file path input.
+
+```ts
+import { safePath } from "@ageflow/core";
+import { z } from "zod";
+
+const input = z.object({
+  filePath: z.string().superRefine(safePath),
+});
+```
+
+### `CtxFor<Tasks, TaskName>`
+
+Type-safe context accessor — infer the exact output type of upstream tasks.
+
+```ts
+import type { CtxFor } from "@ageflow/core";
+
+type MyCtx = CtxFor<WorkflowTasks, "summarize">;
+// → { draft: { output: DraftOutput }, translate: { output: TranslateOutput } }
+```
+
+## Error types
+
+All errors extend `AgentFlowError`. Import individually or catch by base class:
+
+```ts
+import {
+  BudgetExceededError,
+  LoopMaxIterationsError,
+  NodeMaxRetriesError,
+  ValidationError,
+} from "@ageflow/core";
+```
+
+## License
+
+MIT

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@ageflow/core",
   "version": "0.1.0",
+  "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/core",
   "type": "module",
   "private": false,
   "sideEffects": false,
@@ -25,5 +27,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/executor",
   "version": "0.1.0",
+  "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/executor",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/claude/README.md
+++ b/agentflow/packages/runners/claude/README.md
@@ -1,0 +1,60 @@
+# @ageflow/runner-claude
+
+[![npm](https://img.shields.io/npm/v/@ageflow/runner-claude)](https://www.npmjs.com/package/@ageflow/runner-claude)
+
+Claude CLI runner for [ageflow](../../../README.md). Spawns the [`claude`](https://github.com/anthropics/claude-code) CLI as a subprocess and parses its JSON output.
+
+## Install
+
+```bash
+bun add @ageflow/runner-claude
+```
+
+Requires the Claude CLI to be installed and authenticated:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version  # verify
+```
+
+## Usage
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+
+registerRunner("claude", new ClaudeRunner());
+```
+
+Then use `runner: "claude"` in any `defineAgent` call:
+
+```ts
+const myAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",   // or "claude-opus-4-6", "claude-haiku-4-5"
+  input: z.object({ prompt: z.string() }),
+  output: z.object({ result: z.string() }),
+  prompt: ({ prompt }) => prompt,
+});
+```
+
+## Features
+
+- **Session continuity** — when an agent uses `sessionToken`, the runner passes `--resume <session_id>` to the CLI, preserving conversation context across calls
+- **HITL detection** — if Claude requests a tool the workflow hasn't approved, the runner surfaces a `HITLRequest` instead of throwing
+- **Automatic retries** — handled by the executor; the runner itself is stateless per call
+- **JSON output** — parses Claude's `--output-format json` JSONL stream, extracts the result line
+
+## Supported models
+
+Any model supported by your `claude` CLI version. Common values:
+
+| Model | ID |
+|---|---|
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` |
+| Claude Opus 4.6 | `claude-opus-4-6` |
+| Claude Haiku 4.5 | `claude-haiku-4-5` |
+
+## License
+
+MIT

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/runner-claude",
   "version": "0.1.0",
+  "description": "Claude CLI subprocess runner for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/claude",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/claude/src/claude-runner.ts
+++ b/agentflow/packages/runners/claude/src/claude-runner.ts
@@ -1,9 +1,5 @@
 import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
-import type {
-  Runner,
-  RunnerSpawnArgs,
-  RunnerSpawnResult,
-} from "@ageflow/core";
+import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/runners/codex/README.md
+++ b/agentflow/packages/runners/codex/README.md
@@ -1,0 +1,58 @@
+# @ageflow/runner-codex
+
+[![npm](https://img.shields.io/npm/v/@ageflow/runner-codex)](https://www.npmjs.com/package/@ageflow/runner-codex)
+
+OpenAI Codex CLI runner for [ageflow](../../../README.md). Spawns the [`codex`](https://github.com/openai/codex) CLI as a subprocess and parses its event stream output.
+
+## Install
+
+```bash
+bun add @ageflow/runner-codex
+```
+
+Requires the Codex CLI to be installed and authenticated:
+
+```bash
+npm install -g @openai/codex
+codex --version  # verify
+```
+
+## Usage
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { CodexRunner } from "@ageflow/runner-codex";
+
+registerRunner("codex", new CodexRunner());
+```
+
+Then use `runner: "codex"` in any `defineAgent` call:
+
+```ts
+const codeAgent = defineAgent({
+  runner: "codex",
+  model: "o4-mini",   // or "o3"
+  input: z.object({ task: z.string() }),
+  output: z.object({ code: z.string() }),
+  prompt: ({ task }) => `Write TypeScript code that: ${task}`,
+});
+```
+
+## Features
+
+- **Session continuity** — when an agent uses `sessionToken`, the runner passes `resume <thread_id>` to continue an existing Codex thread
+- **Event stream parsing** — handles `thread.started`, `item.completed`, and `turn.completed` events from the Codex JSON stream
+- **Token tracking** — extracts input/output token counts from `turn.completed` for budget tracking
+
+## Supported models
+
+Any model supported by your `codex` CLI version:
+
+| Model | ID |
+|---|---|
+| o4-mini | `o4-mini` |
+| o3 | `o3` |
+
+## License
+
+MIT

--- a/agentflow/packages/runners/codex/package.json
+++ b/agentflow/packages/runners/codex/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/runner-codex",
   "version": "0.1.0",
+  "description": "OpenAI Codex CLI subprocess runner for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/codex",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/codex/src/codex-runner.ts
+++ b/agentflow/packages/runners/codex/src/codex-runner.ts
@@ -1,9 +1,5 @@
 import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
-import type {
-  Runner,
-  RunnerSpawnArgs,
-  RunnerSpawnResult,
-} from "@ageflow/core";
+import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/testing/README.md
+++ b/agentflow/packages/testing/README.md
@@ -1,0 +1,120 @@
+# @ageflow/testing
+
+[![npm](https://img.shields.io/npm/v/@ageflow/testing)](https://www.npmjs.com/package/@ageflow/testing)
+
+Test harness for [ageflow](../../README.md) workflows. Mock agents return predetermined responses — no CLI installed, no API calls, tests run in milliseconds.
+
+## Install
+
+```bash
+bun add -D @ageflow/testing
+```
+
+## Quick example
+
+```ts
+import { createTestHarness } from "@ageflow/testing";
+import { describe, expect, it } from "vitest";
+import myWorkflow from "./workflow.js";
+
+describe("my workflow", () => {
+  it("runs end-to-end with mocked agents", async () => {
+    const harness = createTestHarness(myWorkflow);
+
+    harness.mockAgent("analyze", {
+      issues: [{ id: "1", file: "src/app.ts", description: "unused var" }],
+    });
+    harness.mockAgent("fix", { patch: "- const x\n+ const _x" });
+
+    const result = await harness.run();
+
+    expect(result.outputs["fix"]).toEqual({ patch: "- const x\n+ const _x" });
+  });
+});
+```
+
+## API
+
+### `createTestHarness(workflow)`
+
+Returns a `TestHarness` for the given workflow definition.
+
+```ts
+const harness = createTestHarness(workflow);
+```
+
+### `harness.mockAgent(taskName, response)`
+
+Register a mock response for a task. Three forms:
+
+```ts
+// Always return the same response
+harness.mockAgent("classify", { label: "positive", confidence: 0.97 });
+
+// Return different responses on successive calls
+harness.mockAgent("fix", [
+  { patch: "attempt 1" },  // call 1
+  { patch: "attempt 2" },  // call 2 — last element repeats if exhausted
+]);
+
+// Simulate a failure (triggers retry logic)
+harness.mockAgent("validate", { throws: new Error("syntax error") });
+```
+
+### `harness.run(input?)`
+
+Run the workflow with all mocked runners. Returns `WorkflowResult`.
+
+```ts
+const result = await harness.run();
+// result.outputs["taskName"] — typed output of each task
+```
+
+Pass an input if your workflow expects one:
+
+```ts
+const result = await harness.run({ repo: "my-org/my-repo" });
+```
+
+### `harness.getTask(name)`
+
+Inspect call statistics after `run()`:
+
+```ts
+const stats = harness.getTask("fix");
+// stats.callCount  — total spawn calls (includes retried attempts)
+// stats.retryCount — how many times the task was retried
+// stats.outputs    — all successful outputs, in call order
+```
+
+## Testing loops
+
+Loops call inner tasks repeatedly. Use an array mock to return different responses per iteration:
+
+```ts
+harness.mockAgent("eval", [
+  { satisfied: false },  // iteration 1 — keep looping
+  { satisfied: false },  // iteration 2
+  { satisfied: true },   // iteration 3 — loop exits
+]);
+```
+
+## Testing HITL workflows
+
+The harness bypasses HITL checkpoints by default (auto-approves). To override:
+
+```ts
+const harness = createTestHarness({
+  ...myWorkflow,
+  hooks: {
+    onCheckpoint: async (taskName) => {
+      // return false to simulate rejection
+      return taskName !== "deploy";
+    },
+  },
+});
+```
+
+## License
+
+MIT

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/testing",
   "version": "0.1.0",
+  "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/testing",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -21,5 +26,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
## What
- `agentflow/README.md` — project overview, quick start, package table, badges
- README for each of 6 packages with API reference and examples
- `description`, `homepage`, `repository`, `keywords`, `license` in all `package.json` files

## Impact
- github.com/Neftedollar/ageflow now has a proper landing page
- npmjs.com pages for all 6 packages show description + keywords
- Time-to-first-success for new developers drops significantly