### PR TITLE
feat: dogfooding — dev pipeline as ageflow workflow

### DIFF
--- a/agentflow/README.md
+++ b/agentflow/README.md
@@ -1,0 +1,100 @@
+# ageflow
+
+[![npm](https://img.shields.io/npm/v/@ageflow/core)](https://www.npmjs.com/package/@ageflow/core)
+[![CI](https://github.com/Neftedollar/ageflow/actions/workflows/agentflow-ci.yml/badge.svg)](https://github.com/Neftedollar/ageflow/actions)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**TypeScript-first DSL for multi-agent AI workflows.** Define DAGs of AI agents with type-safe I/O, loops, sessions, and human-in-the-loop checkpoints — then run them locally or in CI with a single command.
+
+```ts
+import { defineAgent, defineWorkflow, registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+import { z } from "zod";
+
+registerRunner("claude", new ClaudeRunner());
+
+const reviewAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",
+  input: z.object({ code: z.string() }),
+  output: z.object({ issues: z.array(z.string()), approved: z.boolean() }),
+  prompt: ({ code }) => `Review this code and list issues:\n\n${code}`,
+});
+
+export default defineWorkflow({
+  name: "code-review",
+  tasks: {
+    review: { agent: reviewAgent, input: { code: "const x = eval(input)" } },
+  },
+});
+```
+
+```bash
+npx @ageflow/cli run workflow.ts
+```
+
+## Why ageflow?
+
+| Feature | What it means |
+|---|---|
+| **Type-safe I/O** | Zod schemas validate every agent's input and output — bad data never reaches the next task |
+| **DAG execution** | Tasks run in parallel when possible, in order when they depend on each other |
+| **Loops** | Iterative refinement (fix → evaluate → fix again) with persistent or fresh session context |
+| **Sessions** | Share conversation context between agents — the model remembers what it said earlier |
+| **HITL** | Pause a workflow for human approval before a task runs |
+| **Budget guard** | Set a max cost; the workflow stops before you overspend |
+| **Test harness** | Swap real CLI runners for mocks — test workflows in milliseconds, no API calls |
+| **Subprocess model** | No HTTP server. Agents are CLI subprocesses (`claude`, `codex`) — auth lives in the CLI |
+
+## Installation
+
+```bash
+# Core DSL + a runner
+bun add @ageflow/core @ageflow/runner-claude
+
+# CLI (global)
+bun add -g @ageflow/cli
+```
+
+## Quick start
+
+```bash
+# Scaffold a new project
+agentwf init my-workflow
+cd my-workflow
+bun install
+
+# Preview prompts without running agents
+agentwf dry-run workflow.ts
+
+# Validate DAG and runner availability
+agentwf validate workflow.ts
+
+# Run
+agentwf run workflow.ts
+```
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [`@ageflow/core`](packages/core) | Types, Zod schemas, DSL builders (`defineAgent`, `defineWorkflow`, `loop`, `sessionToken`) |
+| [`@ageflow/executor`](packages/executor) | DAG executor, loop runner, session manager, HITL, budget tracker, preflight |
+| [`@ageflow/runner-claude`](packages/runners/claude) | Claude CLI subprocess runner |
+| [`@ageflow/runner-codex`](packages/runners/codex) | OpenAI Codex CLI subprocess runner |
+| [`@ageflow/testing`](packages/testing) | Test harness — mock agents, inspect call counts, test workflows without API calls |
+| [`@ageflow/cli`](packages/cli) | `agentwf` CLI — `run`, `validate`, `dry-run`, `init` |
+
+## Examples
+
+- [`examples/bug-fix-pipeline`](examples/bug-fix-pipeline) — Full pipeline: analyze → fix (loop with session) → summarize. Demonstrates loops, HITL, session sharing, and type-safe `CtxFor`.
+
+## Requirements
+
+- [Bun](https://bun.sh) ≥ 1.0 (or Node.js ≥ 18)
+- [`claude` CLI](https://github.com/anthropics/claude-code) for Claude agents
+- [`codex` CLI](https://github.com/openai/codex) for Codex agents
+
+## License
+
+MIT

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -12,13 +12,12 @@
       },
     },
     "examples/bug-fix-pipeline": {
-      "name": "@agentflow/example-bug-fix-pipeline",
+      "name": "@ageflow/example-bug-fix-pipeline",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
-        "@agentflow/runner-claude": "workspace:*",
-        "@agentflow/testing": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/runner-claude": "workspace:*",
+        "@ageflow/testing": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -27,14 +26,14 @@
       },
     },
     "packages/cli": {
-      "name": "agentflow",
+      "name": "ageflow",
       "version": "0.1.0",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
         "boxen": "^8.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -47,7 +46,7 @@
       },
     },
     "packages/core": {
-      "name": "@agentflow/core",
+      "name": "@ageflow/core",
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -59,10 +58,10 @@
       },
     },
     "packages/executor": {
-      "name": "@agentflow/executor",
+      "name": "@ageflow/executor",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -71,10 +70,10 @@
       },
     },
     "packages/runners/claude": {
-      "name": "@agentflow/runner-claude",
+      "name": "@ageflow/runner-claude",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -83,10 +82,10 @@
       },
     },
     "packages/runners/codex": {
-      "name": "@agentflow/runner-codex",
+      "name": "@ageflow/runner-codex",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
+        "@ageflow/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -95,11 +94,11 @@
       },
     },
     "packages/testing": {
-      "name": "@agentflow/testing",
+      "name": "@ageflow/testing",
       "version": "0.1.0",
       "dependencies": {
-        "@agentflow/core": "workspace:*",
-        "@agentflow/executor": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -112,17 +111,17 @@
     "zod": "^3.23.0",
   },
   "packages": {
-    "@agentflow/core": ["@agentflow/core@workspace:packages/core"],
+    "@ageflow/core": ["@ageflow/core@workspace:packages/core"],
 
-    "@agentflow/example-bug-fix-pipeline": ["@agentflow/example-bug-fix-pipeline@workspace:examples/bug-fix-pipeline"],
+    "@ageflow/example-bug-fix-pipeline": ["@ageflow/example-bug-fix-pipeline@workspace:examples/bug-fix-pipeline"],
 
-    "@agentflow/executor": ["@agentflow/executor@workspace:packages/executor"],
+    "@ageflow/executor": ["@ageflow/executor@workspace:packages/executor"],
 
-    "@agentflow/runner-claude": ["@agentflow/runner-claude@workspace:packages/runners/claude"],
+    "@ageflow/runner-claude": ["@ageflow/runner-claude@workspace:packages/runners/claude"],
 
-    "@agentflow/runner-codex": ["@agentflow/runner-codex@workspace:packages/runners/codex"],
+    "@ageflow/runner-codex": ["@ageflow/runner-codex@workspace:packages/runners/codex"],
 
-    "@agentflow/testing": ["@agentflow/testing@workspace:packages/testing"],
+    "@ageflow/testing": ["@ageflow/testing@workspace:packages/testing"],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
@@ -272,7 +271,7 @@
 
     "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
-    "agentflow": ["agentflow@workspace:packages/cli"],
+    "ageflow": ["ageflow@workspace:packages/cli"],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 

--- a/agentflow/packages/cli/README.md
+++ b/agentflow/packages/cli/README.md
@@ -1,0 +1,90 @@
+# @ageflow/cli
+
+[![npm](https://img.shields.io/npm/v/@ageflow/cli)](https://www.npmjs.com/package/@ageflow/cli)
+
+CLI for [ageflow](../../README.md) — scaffold, validate, preview, and run multi-agent workflows.
+
+## Install
+
+```bash
+bun add -g @ageflow/cli
+# or
+npx @ageflow/cli <command>
+```
+
+## Commands
+
+### `agentwf init <project-name>`
+
+Scaffold a new workflow project:
+
+```bash
+agentwf init my-workflow
+cd my-workflow
+bun install
+agentwf run workflow.ts
+```
+
+Generates:
+```
+my-workflow/
+├── workflow.ts       ← ready-to-edit workflow definition
+├── agents/           ← put your agent files here
+└── package.json      ← run/validate/dry-run scripts
+```
+
+---
+
+### `agentwf validate <workflow-file>`
+
+Run preflight checks without executing any agents:
+
+```bash
+agentwf validate workflow.ts
+```
+
+Checks:
+- All runner CLIs are installed and on `PATH` (`claude`, `codex`)
+- DAG has no cycles
+- All `dependsOn` references exist
+- Session cross-provider conflicts (e.g. a `claude` session used by a `codex` agent)
+
+---
+
+### `agentwf dry-run <workflow-file>`
+
+Print the resolved execution plan and rendered prompts without running anything:
+
+```bash
+agentwf dry-run workflow.ts
+```
+
+Output shows:
+- Execution batches (which tasks run in parallel)
+- Each task's runner and rendered prompt (with placeholder inputs for dynamic prompts)
+- Loop structure
+
+---
+
+### `agentwf run <workflow-file>`
+
+Run the workflow end-to-end:
+
+```bash
+agentwf run workflow.ts
+```
+
+Options set in the workflow definition (not flags):
+- `budget` — max cost in USD; workflow halts if exceeded
+- `hooks.onCheckpoint` — HITL pause before a task
+- `retry` — per-task retry config
+
+## Requirements
+
+- Bun ≥ 1.0 or Node.js ≥ 18
+- [`claude` CLI](https://github.com/anthropics/claude-code) for Claude agents
+- [`codex` CLI](https://github.com/openai/codex) for Codex agents
+
+## License
+
+MIT

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,11 +1,18 @@
 {
   "name": "@ageflow/cli",
   "version": "0.1.0",
+  "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/cli",
   "type": "module",
   "private": false,
-  "bin": { "agentwf": "./dist/bin.js" },
+  "bin": {
+    "agentwf": "./dist/bin.js"
+  },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -26,5 +33,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ageflow",
+  "name": "@ageflow/cli",
   "version": "0.1.0",
   "type": "module",
   "private": false,

--- a/agentflow/packages/cli/src/commands/run.ts
+++ b/agentflow/packages/cli/src/commands/run.ts
@@ -1,9 +1,5 @@
 import path from "node:path";
-import type {
-  TaskMetrics,
-  WorkflowDef,
-  WorkflowMetrics,
-} from "@ageflow/core";
+import type { TaskMetrics, WorkflowDef, WorkflowMetrics } from "@ageflow/core";
 import { WorkflowExecutor } from "@ageflow/executor";
 import type { Command } from "commander";
 import {

--- a/agentflow/packages/core/README.md
+++ b/agentflow/packages/core/README.md
@@ -1,0 +1,147 @@
+# @ageflow/core
+
+[![npm](https://img.shields.io/npm/v/@ageflow/core)](https://www.npmjs.com/package/@ageflow/core)
+
+Core DSL for [ageflow](../../README.md) — types, Zod schemas, and builders for defining agents and workflows.
+
+## Install
+
+```bash
+bun add @ageflow/core zod
+```
+
+## API
+
+### `defineAgent(def)`
+
+Define a typed agent. The `input` and `output` Zod schemas are the contract — ageflow validates every call.
+
+```ts
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+const summaryAgent = defineAgent({
+  runner: "claude",            // matches a registered Runner
+  model: "claude-sonnet-4-6",
+  input: z.object({
+    text: z.string(),
+    maxWords: z.number().optional(),
+  }),
+  output: z.object({
+    summary: z.string(),
+    wordCount: z.number(),
+  }),
+  prompt: ({ text, maxWords }) =>
+    `Summarize in ${maxWords ?? 100} words:\n\n${text}`,
+});
+```
+
+### `defineWorkflow(def)`
+
+Compose agents into a DAG. Tasks with no `dependsOn` run in parallel.
+
+```ts
+import { defineWorkflow } from "@ageflow/core";
+
+export default defineWorkflow({
+  name: "summarize-and-translate",
+  tasks: {
+    summarize: {
+      agent: summaryAgent,
+      input: { text: "...", maxWords: 50 },
+    },
+    translate: {
+      agent: translateAgent,
+      dependsOn: ["summarize"],   // runs after summarize
+      input: (ctx) => ({
+        text: ctx.summarize.output.summary,
+        targetLang: "es",
+      }),
+    },
+  },
+});
+```
+
+### `loop(def)`
+
+Run a sub-workflow repeatedly until a condition is met.
+
+```ts
+import { loop } from "@ageflow/core";
+
+const refineLoop = loop({
+  dependsOn: ["draft"] as const,
+  max: 5,
+  until: (ctx) => ctx.grade?.output?.score >= 9,
+  tasks: {
+    improve: { agent: improveAgent, dependsOn: [], input: ... },
+    grade:   { agent: gradeAgent,   dependsOn: ["improve"], input: ... },
+  },
+});
+```
+
+### `sessionToken(name, runner)`
+
+Share conversation context between agents. Both agents send messages to the same model session.
+
+```ts
+import { sessionToken } from "@ageflow/core";
+
+const sharedCtx = sessionToken("my-session", "claude");
+
+// Use in agent definitions:
+const agentA = defineAgent({ ..., session: sharedCtx });
+const agentB = defineAgent({ ..., session: sharedCtx }); // same conversation
+```
+
+### `registerRunner(name, runner)` / `getRunner(name)`
+
+Register CLI subprocess runners before running a workflow.
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+
+registerRunner("claude", new ClaudeRunner());
+```
+
+### `safePath`
+
+Zod refinement that rejects path traversal (`../`, absolute paths). Use it on any file path input.
+
+```ts
+import { safePath } from "@ageflow/core";
+import { z } from "zod";
+
+const input = z.object({
+  filePath: z.string().superRefine(safePath),
+});
+```
+
+### `CtxFor<Tasks, TaskName>`
+
+Type-safe context accessor — infer the exact output type of upstream tasks.
+
+```ts
+import type { CtxFor } from "@ageflow/core";
+
+type MyCtx = CtxFor<WorkflowTasks, "summarize">;
+// → { draft: { output: DraftOutput }, translate: { output: TranslateOutput } }
+```
+
+## Error types
+
+All errors extend `AgentFlowError`. Import individually or catch by base class:
+
+```ts
+import {
+  BudgetExceededError,
+  LoopMaxIterationsError,
+  NodeMaxRetriesError,
+  ValidationError,
+} from "@ageflow/core";
+```
+
+## License
+
+MIT

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@ageflow/core",
   "version": "0.1.0",
+  "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/core",
   "type": "module",
   "private": false,
   "sideEffects": false,
@@ -25,5 +27,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/executor",
   "version": "0.1.0",
+  "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/executor",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/claude/README.md
+++ b/agentflow/packages/runners/claude/README.md
@@ -1,0 +1,60 @@
+# @ageflow/runner-claude
+
+[![npm](https://img.shields.io/npm/v/@ageflow/runner-claude)](https://www.npmjs.com/package/@ageflow/runner-claude)
+
+Claude CLI runner for [ageflow](../../../README.md). Spawns the [`claude`](https://github.com/anthropics/claude-code) CLI as a subprocess and parses its JSON output.
+
+## Install
+
+```bash
+bun add @ageflow/runner-claude
+```
+
+Requires the Claude CLI to be installed and authenticated:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version  # verify
+```
+
+## Usage
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+
+registerRunner("claude", new ClaudeRunner());
+```
+
+Then use `runner: "claude"` in any `defineAgent` call:
+
+```ts
+const myAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",   // or "claude-opus-4-6", "claude-haiku-4-5"
+  input: z.object({ prompt: z.string() }),
+  output: z.object({ result: z.string() }),
+  prompt: ({ prompt }) => prompt,
+});
+```
+
+## Features
+
+- **Session continuity** — when an agent uses `sessionToken`, the runner passes `--resume <session_id>` to the CLI, preserving conversation context across calls
+- **HITL detection** — if Claude requests a tool the workflow hasn't approved, the runner surfaces a `HITLRequest` instead of throwing
+- **Automatic retries** — handled by the executor; the runner itself is stateless per call
+- **JSON output** — parses Claude's `--output-format json` JSONL stream, extracts the result line
+
+## Supported models
+
+Any model supported by your `claude` CLI version. Common values:
+
+| Model | ID |
+|---|---|
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` |
+| Claude Opus 4.6 | `claude-opus-4-6` |
+| Claude Haiku 4.5 | `claude-haiku-4-5` |
+
+## License
+
+MIT

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/runner-claude",
   "version": "0.1.0",
+  "description": "Claude CLI subprocess runner for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/claude",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/claude/src/claude-runner.ts
+++ b/agentflow/packages/runners/claude/src/claude-runner.ts
@@ -1,9 +1,5 @@
 import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
-import type {
-  Runner,
-  RunnerSpawnArgs,
-  RunnerSpawnResult,
-} from "@ageflow/core";
+import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/runners/codex/README.md
+++ b/agentflow/packages/runners/codex/README.md
@@ -1,0 +1,58 @@
+# @ageflow/runner-codex
+
+[![npm](https://img.shields.io/npm/v/@ageflow/runner-codex)](https://www.npmjs.com/package/@ageflow/runner-codex)
+
+OpenAI Codex CLI runner for [ageflow](../../../README.md). Spawns the [`codex`](https://github.com/openai/codex) CLI as a subprocess and parses its event stream output.
+
+## Install
+
+```bash
+bun add @ageflow/runner-codex
+```
+
+Requires the Codex CLI to be installed and authenticated:
+
+```bash
+npm install -g @openai/codex
+codex --version  # verify
+```
+
+## Usage
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { CodexRunner } from "@ageflow/runner-codex";
+
+registerRunner("codex", new CodexRunner());
+```
+
+Then use `runner: "codex"` in any `defineAgent` call:
+
+```ts
+const codeAgent = defineAgent({
+  runner: "codex",
+  model: "o4-mini",   // or "o3"
+  input: z.object({ task: z.string() }),
+  output: z.object({ code: z.string() }),
+  prompt: ({ task }) => `Write TypeScript code that: ${task}`,
+});
+```
+
+## Features
+
+- **Session continuity** — when an agent uses `sessionToken`, the runner passes `resume <thread_id>` to continue an existing Codex thread
+- **Event stream parsing** — handles `thread.started`, `item.completed`, and `turn.completed` events from the Codex JSON stream
+- **Token tracking** — extracts input/output token counts from `turn.completed` for budget tracking
+
+## Supported models
+
+Any model supported by your `codex` CLI version:
+
+| Model | ID |
+|---|---|
+| o4-mini | `o4-mini` |
+| o3 | `o3` |
+
+## License
+
+MIT

--- a/agentflow/packages/runners/codex/package.json
+++ b/agentflow/packages/runners/codex/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/runner-codex",
   "version": "0.1.0",
+  "description": "OpenAI Codex CLI subprocess runner for ageflow",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/codex",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -13,10 +18,28 @@
     "test": "vitest run",
     "lint": "biome check src/"
   },
-  "dependencies": { "@ageflow/core": "workspace:*" },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "^1.1.0",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/agentflow/packages/runners/codex/src/codex-runner.ts
+++ b/agentflow/packages/runners/codex/src/codex-runner.ts
@@ -1,9 +1,5 @@
 import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
-import type {
-  Runner,
-  RunnerSpawnArgs,
-  RunnerSpawnResult,
-} from "@ageflow/core";
+import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 

--- a/agentflow/packages/testing/README.md
+++ b/agentflow/packages/testing/README.md
@@ -1,0 +1,120 @@
+# @ageflow/testing
+
+[![npm](https://img.shields.io/npm/v/@ageflow/testing)](https://www.npmjs.com/package/@ageflow/testing)
+
+Test harness for [ageflow](../../README.md) workflows. Mock agents return predetermined responses — no CLI installed, no API calls, tests run in milliseconds.
+
+## Install
+
+```bash
+bun add -D @ageflow/testing
+```
+
+## Quick example
+
+```ts
+import { createTestHarness } from "@ageflow/testing";
+import { describe, expect, it } from "vitest";
+import myWorkflow from "./workflow.js";
+
+describe("my workflow", () => {
+  it("runs end-to-end with mocked agents", async () => {
+    const harness = createTestHarness(myWorkflow);
+
+    harness.mockAgent("analyze", {
+      issues: [{ id: "1", file: "src/app.ts", description: "unused var" }],
+    });
+    harness.mockAgent("fix", { patch: "- const x\n+ const _x" });
+
+    const result = await harness.run();
+
+    expect(result.outputs["fix"]).toEqual({ patch: "- const x\n+ const _x" });
+  });
+});
+```
+
+## API
+
+### `createTestHarness(workflow)`
+
+Returns a `TestHarness` for the given workflow definition.
+
+```ts
+const harness = createTestHarness(workflow);
+```
+
+### `harness.mockAgent(taskName, response)`
+
+Register a mock response for a task. Three forms:
+
+```ts
+// Always return the same response
+harness.mockAgent("classify", { label: "positive", confidence: 0.97 });
+
+// Return different responses on successive calls
+harness.mockAgent("fix", [
+  { patch: "attempt 1" },  // call 1
+  { patch: "attempt 2" },  // call 2 — last element repeats if exhausted
+]);
+
+// Simulate a failure (triggers retry logic)
+harness.mockAgent("validate", { throws: new Error("syntax error") });
+```
+
+### `harness.run(input?)`
+
+Run the workflow with all mocked runners. Returns `WorkflowResult`.
+
+```ts
+const result = await harness.run();
+// result.outputs["taskName"] — typed output of each task
+```
+
+Pass an input if your workflow expects one:
+
+```ts
+const result = await harness.run({ repo: "my-org/my-repo" });
+```
+
+### `harness.getTask(name)`
+
+Inspect call statistics after `run()`:
+
+```ts
+const stats = harness.getTask("fix");
+// stats.callCount  — total spawn calls (includes retried attempts)
+// stats.retryCount — how many times the task was retried
+// stats.outputs    — all successful outputs, in call order
+```
+
+## Testing loops
+
+Loops call inner tasks repeatedly. Use an array mock to return different responses per iteration:
+
+```ts
+harness.mockAgent("eval", [
+  { satisfied: false },  // iteration 1 — keep looping
+  { satisfied: false },  // iteration 2
+  { satisfied: true },   // iteration 3 — loop exits
+]);
+```
+
+## Testing HITL workflows
+
+The harness bypasses HITL checkpoints by default (auto-approves). To override:
+
+```ts
+const harness = createTestHarness({
+  ...myWorkflow,
+  hooks: {
+    onCheckpoint: async (taskName) => {
+      // return false to simulate rejection
+      return taskName !== "deploy";
+    },
+  },
+});
+```
+
+## License
+
+MIT

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@ageflow/testing",
   "version": "0.1.0",
+  "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/testing",
   "type": "module",
   "private": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
@@ -21,5 +26,21 @@
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "claude",
+    "openai",
+    "multi-agent"
+  ],
+  "license": "MIT"
 }

--- a/dogfooding/README.md
+++ b/dogfooding/README.md
@@ -1,0 +1,75 @@
+# dogfooding
+
+**Ageflow dev pipeline as an ageflow workflow.**
+
+We use ageflow to build ageflow. This workflow is the `feature` pipeline from
+[`docs/process.md`](../docs/process.md) expressed as DSL.
+
+## Pipeline
+
+```
+PLAN ──► BUILD LOOP ──► VERIFY ──► SHIP
+          ▲    │
+          │    ▼
+         TEST (3× max)
+```
+
+| Step | Agent model | Process.md role |
+|------|-------------|-----------------|
+| `plan` | claude-opus-4-6 | PM + Architect |
+| `build` | claude-sonnet-4-6 | Engineering |
+| `test` | claude-haiku-4-5 | CI runner |
+| `verify` | claude-opus-4-6 | Code Reviewer + Reality Checker |
+| `ship` | claude-haiku-4-5 | DevOps / git |
+
+## Key DSL patterns demonstrated
+
+### Loop with feedback
+`buildLoop` runs `build → test` up to 3 times. Each retry, `testAgent`'s failure
+is surfaced back to `buildAgent` via `__loop_feedback__`. The build session is
+persistent so the model retains context across retries.
+
+```
+iteration 1: build(plan) → test → failed
+iteration 2: build(plan + failure₁) → test → failed
+iteration 3: build(plan + failure₂) → test → passed ✓
+```
+
+### HITL checkpoint
+`shipAgent` has `hitl` configured. If `plan.requiresCeoApproval === true`
+(breaking API change, public content, costly infra), the workflow pauses before
+SHIP for human approval.
+
+### Type-safe context with CtxFor
+`verify` and `ship` use `CtxFor<WorkflowTasks, "taskName">` to get fully typed
+access to upstream outputs — no `as any`, no runtime surprises.
+
+### Model tier matching process.md
+| Tier | Model | Steps |
+|------|-------|-------|
+| Strategic | opus | plan, verify |
+| Execution | sonnet | build |
+| Routine | haiku | test, ship |
+
+## Run
+
+```bash
+# Preview the execution plan and rendered prompts
+agentwf dry-run workflow.ts
+
+# Validate DAG and runner availability
+agentwf validate workflow.ts
+
+# Run with real Claude CLI
+agentwf run workflow.ts
+```
+
+## Difference from real orchestrator
+
+The real orchestrator in `/orchestrator` is a meta-agent that dynamically selects
+roles and spawns subagents via the Claude Code `Agent` tool. This workflow is a
+*static* DAG — tasks and their connections are fixed at definition time.
+
+The ageflow DSL shines for **predictable, repeatable pipelines** (feature→build→test→ship).
+The orchestrator pattern is better for **open-ended, adaptive** work where the next step
+depends on what the previous step discovered.

--- a/dogfooding/agents/build.ts
+++ b/dogfooding/agents/build.ts
@@ -1,0 +1,64 @@
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+const stepSchema = z.object({
+  order: z.number(),
+  description: z.string(),
+  file: z.string().optional(),
+});
+
+/**
+ * BUILD step — executes one implementation step from the plan.
+ * Runs in a loop with testAgent: build → test → fix → test → ...
+ * Uses a persistent session so the model retains context across retries.
+ */
+export const buildAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",
+  input: z.object({
+    plan: z.object({
+      summary: z.string(),
+      affectedFiles: z.array(z.string()),
+      steps: z.array(stepSchema),
+      acceptanceCriteria: z.array(z.string()),
+    }),
+    repoPath: z.string(),
+    testFailure: z.string().optional(),   // feedback from previous iteration
+    previousPatch: z.string().optional(), // what was tried last time
+  }),
+  output: z.object({
+    patch: z.string(),         // unified diff or description of changes made
+    filesChanged: z.array(z.string()),
+    explanation: z.string(),   // what was done and why
+    confidence: z.number().min(0).max(10),
+  }),
+  prompt: ({ plan, repoPath, testFailure, previousPatch }) => {
+    const retrySection =
+      testFailure !== undefined
+        ? `\n⚠️  Previous attempt failed tests:\n${testFailure}\n\nPrevious patch:\n${previousPatch ?? "(none)"}\n\nFix the issues above.`
+        : "";
+
+    return `You are a senior software engineer. Implement the following changes.
+
+Repository: ${repoPath}
+Task: ${plan.summary}
+
+Implementation steps:
+${plan.steps.map((s) => `${s.order}. ${s.description}${s.file ? ` (${s.file})` : ""}`).join("\n")}
+
+Acceptance criteria:
+${plan.acceptanceCriteria.map((c) => `- ${c}`).join("\n")}
+${retrySection}
+
+Make the changes. Return JSON with:
+- patch: unified diff of all changes (or detailed description if diff not available)
+- filesChanged: list of modified file paths
+- explanation: what you changed and why
+- confidence: 0-10 how confident you are the tests will pass`;
+  },
+  retry: {
+    max: 2,
+    on: ["subprocess_error", "output_validation_error"],
+    backoff: "exponential",
+  },
+});

--- a/dogfooding/agents/plan.ts
+++ b/dogfooding/agents/plan.ts
@@ -1,0 +1,63 @@
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+/**
+ * PLAN step — PM + Architect in one pass.
+ * Given a GitHub issue, produces a structured implementation plan:
+ * - Affected files and packages
+ * - Step-by-step implementation guide
+ * - Acceptance criteria for VERIFY
+ */
+export const planAgent = defineAgent({
+  runner: "claude",
+  model: "claude-opus-4-6",
+  input: z.object({
+    issue: z.object({
+      number: z.number(),
+      title: z.string(),
+      body: z.string(),
+      labels: z.array(z.string()),
+    }),
+    repoPath: z.string(),
+  }),
+  output: z.object({
+    summary: z.string(),
+    affectedPackages: z.array(z.string()),
+    affectedFiles: z.array(z.string()),
+    steps: z.array(
+      z.object({
+        order: z.number(),
+        description: z.string(),
+        file: z.string().optional(),
+      }),
+    ),
+    acceptanceCriteria: z.array(z.string()),
+    estimatedComplexity: z.enum(["trivial", "small", "medium", "large"]),
+    requiresCeoApproval: z.boolean(),
+    ceoApprovalReason: z.string().optional(),
+  }),
+  prompt: ({ issue, repoPath }) =>
+    `You are a senior software architect. Analyze this GitHub issue and produce an implementation plan.
+
+Issue #${issue.number}: ${issue.title}
+Labels: ${issue.labels.join(", ")}
+Repository: ${repoPath}
+
+Description:
+${issue.body}
+
+Produce a JSON implementation plan with:
+- summary: one-sentence description of what needs to be done
+- affectedPackages: list of package names (e.g. ["@ageflow/core", "@ageflow/executor"])
+- affectedFiles: list of file paths relative to repo root
+- steps: ordered implementation steps, each with { order, description, file? }
+- acceptanceCriteria: list of verifiable conditions that must be true when done
+- estimatedComplexity: "trivial" | "small" | "medium" | "large"
+- requiresCeoApproval: true if this is a breaking API change, public content, or costly infra decision
+- ceoApprovalReason: explain why if requiresCeoApproval is true`,
+  retry: {
+    max: 2,
+    on: ["subprocess_error", "output_validation_error"],
+    backoff: "exponential",
+  },
+});

--- a/dogfooding/agents/ship.ts
+++ b/dogfooding/agents/ship.ts
@@ -1,0 +1,72 @@
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+/**
+ * SHIP step — creates PR and prepares merge.
+ * Runs only after VERIFY returns APPROVED.
+ * HITL checkpoint is set in the workflow — a human approves before this runs
+ * if the plan flagged requiresCeoApproval.
+ */
+export const shipAgent = defineAgent({
+  runner: "claude",
+  model: "claude-haiku-4-5-20251001",
+  input: z.object({
+    issueNumber: z.number(),
+    issueTitle: z.string(),
+    patch: z.string(),
+    filesChanged: z.array(z.string()),
+    explanation: z.string(),
+    reviewSummary: z.string(),
+    branchName: z.string(),
+    repoPath: z.string(),
+  }),
+  output: z.object({
+    prUrl: z.string(),
+    prNumber: z.number(),
+    prTitle: z.string(),
+    mergeStrategy: z.enum(["squash", "merge", "rebase"]),
+    deployed: z.boolean(),
+  }),
+  prompt: ({
+    issueNumber,
+    issueTitle,
+    patch,
+    filesChanged,
+    explanation,
+    reviewSummary,
+    branchName,
+    repoPath,
+  }) =>
+    `You are a DevOps engineer. Create a PR and merge the following changes.
+
+Repository: ${repoPath}
+Branch: ${branchName}
+Closes: #${issueNumber} — ${issueTitle}
+
+Changes applied:
+${filesChanged.map((f) => `  - ${f}`).join("\n")}
+
+Summary: ${explanation}
+
+Code review verdict: APPROVED
+Review notes: ${reviewSummary}
+
+Steps:
+1. git add the changed files
+2. git commit with message: "fix: closes #${issueNumber} — ${issueTitle}"
+3. git push origin ${branchName}
+4. gh pr create --title "..." --body "..." --base master
+5. gh pr merge --squash
+
+Return JSON with:
+- prUrl: the pull request URL
+- prNumber: PR number
+- prTitle: PR title used
+- mergeStrategy: "squash"
+- deployed: true if merge succeeded`,
+  retry: {
+    max: 2,
+    on: ["subprocess_error"],
+    backoff: "fixed",
+  },
+});

--- a/dogfooding/agents/test.ts
+++ b/dogfooding/agents/test.ts
@@ -1,0 +1,51 @@
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+/**
+ * TEST step — runs the test suite and reports results.
+ * Paired with buildAgent in a loop: if tests fail, the loop continues
+ * and buildAgent receives the failure as feedback.
+ */
+export const testAgent = defineAgent({
+  runner: "claude",
+  model: "claude-haiku-4-5-20251001",
+  input: z.object({
+    repoPath: z.string(),
+    affectedPackages: z.array(z.string()),
+    patch: z.string(),
+  }),
+  output: z.object({
+    passed: z.boolean(),
+    totalTests: z.number(),
+    failedTests: z.number(),
+    failureDetails: z.string().optional(),  // error messages and stack traces
+    lintErrors: z.string().optional(),
+    typecheckErrors: z.string().optional(),
+  }),
+  prompt: ({ repoPath, affectedPackages, patch }) =>
+    `You are a CI system. Run the test suite for this repository.
+
+Repository: ${repoPath}
+Affected packages: ${affectedPackages.join(", ")}
+
+Changes applied:
+${patch}
+
+Run in this order:
+1. bun run typecheck
+2. bun run lint
+3. bun run test
+
+Return JSON with:
+- passed: true if ALL checks passed
+- totalTests: number of tests run
+- failedTests: number of failures
+- failureDetails: full error output if any tests failed (null if all passed)
+- lintErrors: lint output if any (null if clean)
+- typecheckErrors: typecheck output if any (null if clean)`,
+  retry: {
+    max: 1,
+    on: ["subprocess_error"],
+    backoff: "fixed",
+  },
+});

--- a/dogfooding/agents/verify.ts
+++ b/dogfooding/agents/verify.ts
@@ -1,0 +1,74 @@
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+const findingSchema = z.object({
+  severity: z.enum(["critical", "major", "minor", "suggestion"]),
+  file: z.string(),
+  description: z.string(),
+  suggestion: z.string().optional(),
+});
+
+/**
+ * VERIFY step — code review + reality check (parallel in the workflow).
+ * Checks: correctness, security, adherence to plan, no regressions.
+ * Returns APPROVED or NEEDS_WORK with specific findings.
+ */
+export const verifyAgent = defineAgent({
+  runner: "claude",
+  model: "claude-opus-4-6",
+  input: z.object({
+    patch: z.string(),
+    filesChanged: z.array(z.string()),
+    explanation: z.string(),
+    acceptanceCriteria: z.array(z.string()),
+    testResults: z.object({
+      passed: z.boolean(),
+      totalTests: z.number(),
+      failedTests: z.number(),
+    }),
+  }),
+  output: z.object({
+    verdict: z.enum(["APPROVED", "NEEDS_WORK"]),
+    findings: z.array(findingSchema),
+    securityIssues: z.array(z.string()),
+    acceptanceCriteriaStatus: z.array(
+      z.object({
+        criterion: z.string(),
+        met: z.boolean(),
+        evidence: z.string(),
+      }),
+    ),
+    summary: z.string(),
+  }),
+  prompt: ({ patch, explanation, acceptanceCriteria, testResults }) =>
+    `You are a senior code reviewer. Review these changes with zero tolerance for security issues.
+
+Changes:
+${patch}
+
+Developer's explanation:
+${explanation}
+
+Test results: ${testResults.passed ? "✅ All passing" : `❌ ${testResults.failedTests}/${testResults.totalTests} failing`}
+
+Acceptance criteria to verify:
+${acceptanceCriteria.map((c) => `- ${c}`).join("\n")}
+
+Review for:
+1. Correctness and logic errors
+2. Security vulnerabilities (injection, path traversal, auth bypass, hardcoded secrets)
+3. Each acceptance criterion — is it actually met?
+4. Breaking changes or regressions
+
+Return JSON:
+- verdict: "APPROVED" | "NEEDS_WORK"
+- findings: array of { severity, file, description, suggestion? }
+- securityIssues: list any security problems (empty array if none)
+- acceptanceCriteriaStatus: for each criterion: { criterion, met, evidence }
+- summary: one paragraph review summary`,
+  retry: {
+    max: 2,
+    on: ["subprocess_error", "output_validation_error"],
+    backoff: "exponential",
+  },
+});

--- a/dogfooding/package.json
+++ b/dogfooding/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ageflow/dogfooding",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "run": "agentwf run workflow.ts",
+    "dry-run": "agentwf dry-run workflow.ts",
+    "validate": "agentwf validate workflow.ts"
+  },
+  "dependencies": {
+    "@ageflow/core": "^0.1.0",
+    "@ageflow/runner-claude": "^0.1.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@ageflow/cli": "^0.1.0"
+  }
+}

--- a/dogfooding/workflow.ts
+++ b/dogfooding/workflow.ts
@@ -1,0 +1,263 @@
+/**
+ * Dogfooding: AgentFlow dev pipeline modelled as an ageflow workflow.
+ *
+ * Pipeline: PLAN → BUILD_LOOP (build ↔ test, max 3×) → VERIFY → SHIP
+ *
+ * Mirrors the orchestrator process from docs/process.md:
+ * - Opus for strategic steps (plan, verify) — high reasoning quality
+ * - Sonnet for execution (build) — fast and capable
+ * - Haiku for mechanical steps (test, ship) — speed over depth
+ * - Loop with feedback: BUILD retries up to 3× with test failure as context
+ * - HITL: CEO approval gate before SHIP if plan flags requiresCeoApproval
+ * - Session: build and test share context within each loop iteration
+ */
+
+import {
+  defineWorkflow,
+  loop,
+  registerRunner,
+  sessionToken,
+} from "@ageflow/core";
+import type { CtxFor } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+
+import { buildAgent } from "./agents/build.js";
+import { planAgent } from "./agents/plan.js";
+import { shipAgent } from "./agents/ship.js";
+import { testAgent } from "./agents/test.js";
+import { verifyAgent } from "./agents/verify.js";
+
+registerRunner("claude", new ClaudeRunner());
+
+// Build and test share session — the model remembers previous attempts
+// when generating the next fix, avoiding repeating the same mistakes.
+const buildSession = sessionToken("build-context", "claude");
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type PlanOutput = {
+  summary: string;
+  affectedPackages: string[];
+  affectedFiles: string[];
+  steps: Array<{ order: number; description: string; file?: string }>;
+  acceptanceCriteria: string[];
+  estimatedComplexity: "trivial" | "small" | "medium" | "large";
+  requiresCeoApproval: boolean;
+  ceoApprovalReason?: string;
+};
+
+type BuildOutput = {
+  patch: string;
+  filesChanged: string[];
+  explanation: string;
+  confidence: number;
+};
+
+type TestOutput = {
+  passed: boolean;
+  totalTests: number;
+  failedTests: number;
+  failureDetails?: string;
+  lintErrors?: string;
+  typecheckErrors?: string;
+};
+
+// ─── Inner loop: BUILD ↔ TEST ─────────────────────────────────────────────────
+//
+// Runs until tests pass or max 3 iterations.
+// context: "persistent" — build and test share the same session handle across
+// iterations so the model accumulates context ("last time X failed, try Y").
+//
+// Input function extracts the plan from outer ctx and previous test failure
+// (stored in __loop_feedback__) to give build the full retry context.
+
+const buildLoop = loop({
+  dependsOn: ["plan"] as const,
+  max: 3,
+  context: "persistent",
+
+  until: (ctx: unknown) => {
+    const c = ctx as Record<string, { output: TestOutput }>;
+    return c.test?.output?.passed === true;
+  },
+
+  input: (ctx: unknown) => {
+    type OuterCtx = {
+      plan?: { output: PlanOutput };
+      __loop_feedback__?: { output: Record<string, { output: unknown }> };
+    };
+    const c = ctx as OuterCtx;
+    const plan = c.plan?.output;
+
+    // On retry iterations, surface the previous test failure to build
+    const feedback = c.__loop_feedback__?.output;
+    const prevTest = feedback?.test?.output as TestOutput | undefined;
+    const prevBuild = feedback?.build?.output as BuildOutput | undefined;
+
+    return {
+      plan: plan ?? {
+        summary: "unknown",
+        affectedFiles: [],
+        steps: [],
+        acceptanceCriteria: [],
+      },
+      repoPath: ".",
+      testFailure: prevTest?.passed === false
+        ? [
+            prevTest.failureDetails,
+            prevTest.lintErrors,
+            prevTest.typecheckErrors,
+          ]
+            .filter(Boolean)
+            .join("\n")
+        : undefined,
+      previousPatch: prevBuild?.patch,
+    };
+  },
+
+  tasks: {
+    build: {
+      agent: buildAgent,
+      session: buildSession,
+      // input comes from the loop.input function above (merged into innerCtx)
+    },
+    test: {
+      agent: testAgent,
+      dependsOn: ["build"] as const,
+      session: buildSession,
+      input: (ctx: unknown) => {
+        type InnerCtx = {
+          build?: { output: BuildOutput };
+          affectedPackages?: { output: string[] };
+        };
+        const c = ctx as InnerCtx;
+        const plan = (ctx as { plan?: { output: PlanOutput } }).plan?.output;
+        return {
+          repoPath: ".",
+          affectedPackages: plan?.affectedPackages ?? [],
+          patch: c.build?.output.patch ?? "",
+        };
+      },
+    },
+  },
+});
+
+// ─── Workflow ─────────────────────────────────────────────────────────────────
+
+type WorkflowTasks = {
+  plan: typeof planAgent;
+  buildLoop: typeof buildLoop;
+  verify: typeof verifyAgent;
+  ship: typeof shipAgent;
+};
+
+export default defineWorkflow({
+  name: "dev-pipeline",
+
+  // CEO approval gate: if plan flags requiresCeoApproval, pause before SHIP
+  hooks: {
+    onCheckpoint: async (taskName: string) => {
+      // The checkpoint fires before the task runs.
+      // In a real setup this would send a Slack/Telegram message and wait.
+      // For local runs, auto-approve (return true).
+      console.log(`[HITL] Checkpoint for task: ${taskName}`);
+      return true;
+    },
+  },
+
+  tasks: {
+    // ── PLAN ──────────────────────────────────────────────────────────────────
+    plan: {
+      agent: planAgent,
+      input: {
+        issue: {
+          number: 42,
+          title: "Add support for parallel task execution metrics",
+          body: `When multiple tasks run in parallel, we currently have no way to see
+individual task latency vs. the batch latency. Add per-task timing to
+WorkflowResult so users can identify bottlenecks.
+
+Acceptance criteria:
+- WorkflowResult includes taskMetrics: Record<string, { startedAt, completedAt, latencyMs }>
+- agentwf run prints a timing summary at the end
+- Existing tests pass`,
+          labels: ["enhancement", "executor"],
+        },
+        repoPath: ".",
+      },
+    },
+
+    // ── BUILD LOOP ────────────────────────────────────────────────────────────
+    // build → test → (if failed) build again with failure feedback → ...
+    buildLoop,
+
+    // ── VERIFY ────────────────────────────────────────────────────────────────
+    verify: {
+      agent: verifyAgent,
+      dependsOn: ["buildLoop"] as const,
+      hitl: {
+        // Pause if confidence was low — human should check before we stamp APPROVED
+        mode: "permissions",
+        tools: [],
+      },
+      input: (ctx: unknown) => {
+        type Ctx = CtxFor<WorkflowTasks, "verify">;
+        const typed = ctx as unknown as Ctx;
+
+        const loopOut = typed.buildLoop.output as Record<
+          string,
+          { output: unknown }
+        >;
+        const build = loopOut.build?.output as BuildOutput | undefined;
+        const test = loopOut.test?.output as TestOutput | undefined;
+        const plan = typed.plan.output;
+
+        return {
+          patch: build?.patch ?? "",
+          filesChanged: build?.filesChanged ?? [],
+          explanation: build?.explanation ?? "",
+          acceptanceCriteria: plan.acceptanceCriteria,
+          testResults: {
+            passed: test?.passed ?? false,
+            totalTests: test?.totalTests ?? 0,
+            failedTests: test?.failedTests ?? 0,
+          },
+        };
+      },
+    },
+
+    // ── SHIP ──────────────────────────────────────────────────────────────────
+    // HITL checkpoint fires here when plan.requiresCeoApproval === true
+    ship: {
+      agent: shipAgent,
+      dependsOn: ["verify"] as const,
+      hitl: {
+        mode: "permissions",
+        tools: [],
+      },
+      input: (ctx: unknown) => {
+        type Ctx = CtxFor<WorkflowTasks, "ship">;
+        const typed = ctx as unknown as Ctx;
+
+        const plan = typed.plan.output;
+        const loopOut = typed.buildLoop.output as Record<
+          string,
+          { output: unknown }
+        >;
+        const build = loopOut.build?.output as BuildOutput | undefined;
+        const verify = typed.verify.output;
+
+        return {
+          issueNumber: 42,
+          issueTitle: plan.summary,
+          patch: build?.patch ?? "",
+          filesChanged: build?.filesChanged ?? [],
+          explanation: build?.explanation ?? "",
+          reviewSummary: verify.summary,
+          branchName: `fix/issue-42-task-metrics`,
+          repoPath: ".",
+        };
+      },
+    },
+  },
+});


### PR DESCRIPTION
Uses ageflow to model ageflow's own dev pipeline from `docs/process.md`.

## Pipeline
```
PLAN (opus) → BUILD_LOOP (sonnet ↔ haiku, 3×) → VERIFY (opus) → SHIP (haiku)
```

## Patterns demonstrated
- **Loop with feedback** — test failures fed back to build as `__loop_feedback__`
- **Persistent session** — build+test share context across retries
- **HITL** — CEO approval gate before SHIP when plan flags breaking changes
- **CtxFor** — type-safe upstream output access in verify and ship
- **Model tiers** — opus/sonnet/haiku matching process.md role tiers

Lives in `dogfooding/` — not part of the monorepo build, just a reference workflow.