### PR TITLE
feat(mcp-server): Phase 3-5 — pure unit modules (Tasks 4-8)

### DIFF
--- a/agentflow/packages/mcp-server/src/__tests__/ceiling-resolver.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/ceiling-resolver.test.ts
@@ -1,0 +1,56 @@
+import type { ResolvedMcpConfig } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { composeCeilings } from "../ceiling-resolver.js";
+
+const baseWorkflow: ResolvedMcpConfig = {
+  description: undefined,
+  maxCostUsd: 10,
+  maxDurationSec: 1800,
+  maxTurns: 100,
+  inputTask: undefined,
+  outputTask: undefined,
+};
+
+describe("composeCeilings", () => {
+  it("takes workflow value when CLI not set", () => {
+    const result = composeCeilings(baseWorkflow, {});
+    expect(result.maxCostUsd).toBe(10);
+    expect(result.maxDurationSec).toBe(1800);
+    expect(result.maxTurns).toBe(100);
+  });
+
+  it("operator can lower ceiling", () => {
+    const result = composeCeilings(baseWorkflow, { maxCostUsd: 5 });
+    expect(result.maxCostUsd).toBe(5);
+  });
+
+  it("operator cannot raise ceiling (clamps + warns)", () => {
+    const warnings: string[] = [];
+    const result = composeCeilings(baseWorkflow, { maxCostUsd: 50 }, (w) =>
+      warnings.push(w),
+    );
+    expect(result.maxCostUsd).toBe(10);
+    expect(warnings[0]).toMatch(/clamped/);
+  });
+
+  it("null workflow ceiling = +Infinity, CLI value wins", () => {
+    const w = { ...baseWorkflow, maxCostUsd: null };
+    const result = composeCeilings(w, { maxCostUsd: 5 });
+    expect(result.maxCostUsd).toBe(5);
+  });
+
+  it("null CLI ceiling (--no-max-cost) ignored if workflow set", () => {
+    const warnings: string[] = [];
+    const result = composeCeilings(baseWorkflow, { maxCostUsd: null }, (w) =>
+      warnings.push(w),
+    );
+    expect(result.maxCostUsd).toBe(10);
+    expect(warnings[0]).toMatch(/ignored/);
+  });
+
+  it("both null = unlimited", () => {
+    const w = { ...baseWorkflow, maxCostUsd: null };
+    const result = composeCeilings(w, { maxCostUsd: null });
+    expect(result.maxCostUsd).toBeNull();
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/dag-boundary.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/dag-boundary.test.ts
@@ -1,0 +1,72 @@
+import type { TasksMap } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { findBoundaryTasks } from "../dag-boundary.js";
+
+// Minimal TaskDef stubs for testing; actual implementation only reads dependsOn.
+// biome-ignore lint/suspicious/noExplicitAny: narrow test stub
+const mkTask = (deps?: string[]): any => ({
+  agent: { input: {}, output: {} },
+  dependsOn: deps,
+});
+
+describe("findBoundaryTasks", () => {
+  it("finds unique root and leaf in linear DAG", () => {
+    const tasks: TasksMap = {
+      a: mkTask(),
+      b: mkTask(["a"]),
+      c: mkTask(["b"]),
+    };
+    expect(findBoundaryTasks(tasks, undefined, undefined)).toEqual({
+      inputTask: "a",
+      outputTask: "c",
+    });
+  });
+
+  it("uses explicit inputTask/outputTask overrides", () => {
+    const tasks: TasksMap = {
+      a: mkTask(),
+      b: mkTask(["a"]),
+      c: mkTask(["b"]),
+    };
+    expect(findBoundaryTasks(tasks, "b", "c")).toEqual({
+      inputTask: "b",
+      outputTask: "c",
+    });
+  });
+
+  it("throws if DAG has >1 root and no inputTask", () => {
+    const tasks: TasksMap = {
+      a: mkTask(),
+      b: mkTask(),
+      c: mkTask(["a", "b"]),
+    };
+    expect(() => findBoundaryTasks(tasks, undefined, "c")).toThrow(
+      /multiple root tasks/,
+    );
+  });
+
+  it("throws if DAG has >1 leaf and no outputTask", () => {
+    const tasks: TasksMap = {
+      a: mkTask(),
+      b: mkTask(["a"]),
+      c: mkTask(["a"]),
+    };
+    expect(() => findBoundaryTasks(tasks, "a", undefined)).toThrow(
+      /multiple leaf tasks/,
+    );
+  });
+
+  it("throws if inputTask not in tasks", () => {
+    const tasks: TasksMap = { a: mkTask() };
+    expect(() => findBoundaryTasks(tasks, "nonexistent", "a")).toThrow(
+      /inputTask "nonexistent" not found/,
+    );
+  });
+
+  it("throws if outputTask not in tasks", () => {
+    const tasks: TasksMap = { a: mkTask() };
+    expect(() => findBoundaryTasks(tasks, "a", "nonexistent")).toThrow(
+      /outputTask "nonexistent" not found/,
+    );
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCode, McpServerError, formatErrorResult } from "../errors.js";
+
+describe("McpServerError + formatErrorResult", () => {
+  it("creates a structured error result", () => {
+    const err = new McpServerError(ErrorCode.BUDGET_EXCEEDED, "spent $1.23", {
+      spent: 1.23,
+      limit: 1.0,
+      lastTask: "verify",
+    });
+    const result = formatErrorResult(err);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({
+      errorCode: "BUDGET_EXCEEDED",
+      message: "spent $1.23",
+      context: { spent: 1.23, limit: 1.0, lastTask: "verify" },
+    });
+    expect(result.content[0]?.text).toContain("spent $1.23");
+  });
+
+  it("wraps unknown errors as WORKFLOW_FAILED", () => {
+    const err = new Error("something broke");
+    const result = formatErrorResult(err);
+    expect(result.structuredContent.errorCode).toBe("WORKFLOW_FAILED");
+    expect(result.structuredContent.message).toBe("something broke");
+  });
+
+  it("handles non-Error values safely", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing non-Error input
+    const result = formatErrorResult("string error" as any);
+    expect(result.structuredContent.errorCode).toBe("WORKFLOW_FAILED");
+    expect(result.structuredContent.message).toBe("string error");
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/progress-streamer.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/progress-streamer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { ProgressStreamer } from "../progress-streamer.js";
+
+describe("ProgressStreamer", () => {
+  it("emits task_started with progressToken", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, "tok-123");
+    streamer.taskStarted("plan");
+    expect(send).toHaveBeenCalledWith({
+      progressToken: "tok-123",
+      progress: 0,
+      message: expect.stringContaining("task_started"),
+      meta: { phase: "task_started", task: "plan" },
+    });
+  });
+
+  it("emits task_completed with metrics", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, "tok-123");
+    streamer.taskCompleted("plan", {
+      costUsd: 0.27,
+      tokensIn: 8000,
+      tokensOut: 2000,
+    });
+    const payload = send.mock.calls[0]?.[0];
+    expect(payload.meta).toMatchObject({
+      phase: "task_completed",
+      task: "plan",
+      metrics: { costUsd: 0.27 },
+    });
+  });
+
+  it("emits task_failed", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, "tok-123");
+    streamer.taskFailed("build", "TypeError: x");
+    expect(send.mock.calls[0]?.[0].meta.phase).toBe("task_failed");
+  });
+
+  it("emits loop_iteration", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, "tok-123");
+    streamer.loopIteration(2);
+    expect(send.mock.calls[0]?.[0].meta).toEqual({
+      phase: "loop_iteration",
+      iteration: 2,
+    });
+  });
+
+  it("emits awaiting_elicitation", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, "tok-123");
+    streamer.awaitingElicitation("verify", "Approve to ship?");
+    expect(send.mock.calls[0]?.[0].meta).toMatchObject({
+      phase: "awaiting_elicitation",
+      task: "verify",
+    });
+  });
+
+  it("no-ops when progressToken is undefined", () => {
+    const send = vi.fn();
+    const streamer = new ProgressStreamer(send, undefined);
+    streamer.taskStarted("plan");
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/schema-convert.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/schema-convert.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { zodToMcpSchema } from "../schema-convert.js";
+
+describe("zodToMcpSchema", () => {
+  it("converts a simple object schema", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const result = zodToMcpSchema(schema);
+    expect(result.type).toBe("object");
+    expect(result.properties?.name).toEqual({ type: "string" });
+    expect(result.required).toContain("name");
+  });
+
+  it("handles optional fields", () => {
+    const schema = z.object({ a: z.string(), b: z.string().optional() });
+    const result = zodToMcpSchema(schema);
+    expect(result.required).toEqual(["a"]);
+  });
+
+  it("handles arrays", () => {
+    const schema = z.object({ items: z.array(z.string()) });
+    const result = zodToMcpSchema(schema);
+    expect(result.properties?.items).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
+  });
+
+  it("handles enums", () => {
+    const schema = z.object({ status: z.enum(["ok", "fail"]) });
+    const result = zodToMcpSchema(schema);
+    expect(result.properties?.status).toMatchObject({ enum: ["ok", "fail"] });
+  });
+
+  it("strips $schema key", () => {
+    const schema = z.object({ a: z.string() });
+    const result = zodToMcpSchema(schema);
+    // biome-ignore lint/suspicious/noExplicitAny: checking runtime shape
+    expect((result as any).$schema).toBeUndefined();
+  });
+
+  it("returns empty object for non-object schemas", () => {
+    const schema = z.string();
+    const result = zodToMcpSchema(schema);
+    expect(result.type).toBe("object");
+  });
+});

--- a/agentflow/packages/mcp-server/src/ceiling-resolver.ts
+++ b/agentflow/packages/mcp-server/src/ceiling-resolver.ts
@@ -1,0 +1,65 @@
+import type { ResolvedMcpConfig } from "@ageflow/core";
+import type { CliCeilings, EffectiveCeilings } from "./types.js";
+
+type WarnFn = (message: string) => void;
+
+/**
+ * Compose workflow ceilings with CLI overrides.
+ *
+ * Rules:
+ * - Workflow ceiling is the hard upper bound.
+ * - Operator can *lower* via CLI; attempt to raise is clamped with a warning.
+ * - `null` = +Infinity (unlimited).
+ * - CLI `null` (--no-max-X) removes the operator ceiling; workflow ceiling still applies.
+ */
+export function composeCeilings(
+  workflow: ResolvedMcpConfig,
+  cli: CliCeilings,
+  warn: WarnFn = () => {},
+): EffectiveCeilings {
+  return {
+    maxCostUsd: resolveOne(
+      workflow.maxCostUsd,
+      cli.maxCostUsd,
+      "maxCostUsd",
+      warn,
+    ),
+    maxDurationSec: resolveOne(
+      workflow.maxDurationSec,
+      cli.maxDurationSec,
+      "maxDurationSec",
+      warn,
+    ),
+    maxTurns: resolveOne(workflow.maxTurns, cli.maxTurns, "maxTurns", warn),
+  };
+}
+
+function resolveOne(
+  workflowValue: number | null,
+  cliValue: number | null | undefined,
+  fieldName: string,
+  warn: WarnFn,
+): number | null {
+  // CLI not set (undefined) → use workflow value
+  if (cliValue === undefined) return workflowValue;
+
+  // CLI explicitly null (--no-max-X) → remove operator ceiling, workflow wins
+  if (cliValue === null) {
+    if (workflowValue !== null) {
+      warn(
+        `[mcp] --no-${fieldName} ignored: workflow sets ${fieldName}=${workflowValue} as hard ceiling`,
+      );
+    }
+    return workflowValue;
+  }
+
+  // Both numeric → min (with null = +Infinity)
+  if (workflowValue === null) return cliValue;
+  if (cliValue > workflowValue) {
+    warn(
+      `[mcp] CLI ${fieldName}=${cliValue} clamped to workflow ceiling ${workflowValue}`,
+    );
+    return workflowValue;
+  }
+  return cliValue;
+}

--- a/agentflow/packages/mcp-server/src/dag-boundary.ts
+++ b/agentflow/packages/mcp-server/src/dag-boundary.ts
@@ -1,0 +1,77 @@
+import type { TasksMap } from "@ageflow/core";
+
+export interface BoundaryTasks {
+  readonly inputTask: string;
+  readonly outputTask: string;
+}
+
+/**
+ * Identify the task whose input defines the tool's inputSchema (the DAG root)
+ * and the task whose output defines the tool's outputSchema (the DAG leaf).
+ *
+ * If explicit inputTask/outputTask are provided, validate and use them.
+ * Otherwise find the unique root/leaf; throw if ambiguous.
+ */
+export function findBoundaryTasks(
+  tasks: TasksMap,
+  inputTaskOverride: string | undefined,
+  outputTaskOverride: string | undefined,
+): BoundaryTasks {
+  const taskNames = Object.keys(tasks);
+  const allDeps = new Set<string>();
+
+  for (const [, t] of Object.entries(tasks)) {
+    const deps = (t as { dependsOn?: readonly string[] }).dependsOn ?? [];
+    for (const d of deps) allDeps.add(d);
+  }
+
+  // Roots: tasks with no dependsOn
+  const roots = taskNames.filter((n) => {
+    const deps =
+      (tasks[n] as { dependsOn?: readonly string[] }).dependsOn ?? [];
+    return deps.length === 0;
+  });
+
+  // Leaves: tasks not in any dependsOn set
+  const leaves = taskNames.filter((n) => !allDeps.has(n));
+
+  // Resolve input task
+  let inputTask: string;
+  if (inputTaskOverride !== undefined) {
+    if (!taskNames.includes(inputTaskOverride)) {
+      throw new Error(
+        `DAG_INVALID: inputTask "${inputTaskOverride}" not found in workflow tasks`,
+      );
+    }
+    inputTask = inputTaskOverride;
+  } else if (roots.length === 0) {
+    throw new Error("DAG_INVALID: workflow has no root task (cyclic?)");
+  } else if (roots.length > 1) {
+    throw new Error(
+      `DAG_INVALID: workflow has multiple root tasks (${roots.join(", ")}); set workflow.mcp.inputTask to disambiguate`,
+    );
+  } else {
+    inputTask = roots[0] as string;
+  }
+
+  // Resolve output task
+  let outputTask: string;
+  if (outputTaskOverride !== undefined) {
+    if (!taskNames.includes(outputTaskOverride)) {
+      throw new Error(
+        `DAG_INVALID: outputTask "${outputTaskOverride}" not found in workflow tasks`,
+      );
+    }
+    outputTask = outputTaskOverride;
+  } else if (leaves.length === 0) {
+    throw new Error("DAG_INVALID: workflow has no leaf task (cyclic?)");
+  } else if (leaves.length > 1) {
+    throw new Error(
+      `DAG_INVALID: workflow has multiple leaf tasks (${leaves.join(", ")}); set workflow.mcp.outputTask to disambiguate`,
+    );
+  } else {
+    outputTask = leaves[0] as string;
+  }
+
+  return { inputTask, outputTask };
+}

--- a/agentflow/packages/mcp-server/src/errors.ts
+++ b/agentflow/packages/mcp-server/src/errors.ts
@@ -1,0 +1,69 @@
+export const ErrorCode = {
+  INPUT_VALIDATION_FAILED: "INPUT_VALIDATION_FAILED",
+  OUTPUT_VALIDATION_FAILED: "OUTPUT_VALIDATION_FAILED",
+  BUDGET_EXCEEDED: "BUDGET_EXCEEDED",
+  DURATION_EXCEEDED: "DURATION_EXCEEDED",
+  TURNS_EXCEEDED: "TURNS_EXCEEDED",
+  WORKFLOW_FAILED: "WORKFLOW_FAILED",
+  HITL_ELICITATION_UNSUPPORTED: "HITL_ELICITATION_UNSUPPORTED",
+  HITL_DENIED: "HITL_DENIED",
+  HITL_CANCELLED: "HITL_CANCELLED",
+  WORKFLOW_NOT_MCP_EXPOSABLE: "WORKFLOW_NOT_MCP_EXPOSABLE",
+  RUNNER_PREFLIGHT_FAILED: "RUNNER_PREFLIGHT_FAILED",
+  BUSY: "BUSY",
+  SERVER_SHUTDOWN: "SERVER_SHUTDOWN",
+  DAG_INVALID: "DAG_INVALID",
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export class McpServerError extends Error {
+  constructor(
+    public readonly errorCode: ErrorCodeValue,
+    message: string,
+    public readonly context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "McpServerError";
+  }
+}
+
+export interface McpToolErrorResult {
+  readonly content: readonly { type: "text"; text: string }[];
+  readonly structuredContent: {
+    readonly errorCode: ErrorCodeValue;
+    readonly message: string;
+    readonly context?: Record<string, unknown>;
+  };
+  readonly isError: true;
+}
+
+export function formatErrorResult(err: unknown): McpToolErrorResult {
+  if (err instanceof McpServerError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: err.errorCode,
+        message: err.message,
+        context: err.context,
+      },
+      isError: true,
+    };
+  }
+
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : JSON.stringify(err);
+
+  return {
+    content: [{ type: "text", text: message }],
+    structuredContent: {
+      errorCode: ErrorCode.WORKFLOW_FAILED,
+      message,
+    },
+    isError: true,
+  };
+}

--- a/agentflow/packages/mcp-server/src/errors.ts
+++ b/agentflow/packages/mcp-server/src/errors.ts
@@ -45,7 +45,7 @@ export function formatErrorResult(err: unknown): McpToolErrorResult {
       structuredContent: {
         errorCode: err.errorCode,
         message: err.message,
-        context: err.context,
+        ...(err.context !== undefined ? { context: err.context } : {}),
       },
       isError: true,
     };

--- a/agentflow/packages/mcp-server/src/progress-streamer.ts
+++ b/agentflow/packages/mcp-server/src/progress-streamer.ts
@@ -1,0 +1,64 @@
+export interface ProgressPayload {
+  readonly progressToken: string | number;
+  readonly progress: number;
+  readonly total?: number;
+  readonly message?: string;
+  readonly meta: Record<string, unknown>;
+}
+
+export type SendProgress = (payload: ProgressPayload) => void;
+
+/**
+ * Bridges ageflow workflow events to MCP `notifications/progress`.
+ *
+ * If the client did not supply a progressToken (via _meta.progressToken),
+ * all methods become no-ops — clients that didn't ask for progress should not receive it.
+ */
+export class ProgressStreamer {
+  private counter = 0;
+
+  constructor(
+    private readonly send: SendProgress,
+    private readonly progressToken: string | number | undefined,
+  ) {}
+
+  taskStarted(task: string): void {
+    this.emit("task_started", { task });
+  }
+
+  taskCompleted(task: string, metrics: Record<string, unknown>): void {
+    this.emit("task_completed", { task, metrics });
+  }
+
+  taskFailed(task: string, error: string): void {
+    this.emit("task_failed", { task, error });
+  }
+
+  loopIteration(iteration: number): void {
+    this.emit("loop_iteration", { iteration });
+  }
+
+  budgetWarning(spent: number, limit: number): void {
+    this.emit("budget_warning", { spent, limit });
+  }
+
+  awaitingElicitation(task: string, message: string): void {
+    this.emit("awaiting_elicitation", { task, message });
+  }
+
+  unlimitedWarning(axes: readonly string[]): void {
+    this.emit("unlimited_warning", { axes });
+  }
+
+  private emit(phase: string, extra: Record<string, unknown>): void {
+    if (this.progressToken === undefined) return;
+    const progress = this.counter;
+    this.counter += 1;
+    this.send({
+      progressToken: this.progressToken,
+      progress,
+      message: `${phase}: ${JSON.stringify(extra)}`,
+      meta: { phase, ...extra },
+    });
+  }
+}

--- a/agentflow/packages/mcp-server/src/schema-convert.ts
+++ b/agentflow/packages/mcp-server/src/schema-convert.ts
@@ -1,0 +1,36 @@
+import type { ZodType } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export interface McpJsonSchema {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * Convert a Zod schema to a JSON Schema shape suitable for MCP tool registration.
+ *
+ * MCP requires inputSchema/outputSchema to be of type "object" at the top level.
+ * If the Zod root isn't an object, we wrap the result as a single-property object.
+ */
+export function zodToMcpSchema(schema: ZodType): McpJsonSchema {
+  const raw = zodToJsonSchema(schema, { target: "jsonSchema7" }) as Record<
+    string,
+    unknown
+  >;
+
+  // Strip $schema (MCP schemas shouldn't carry JSON-Schema-draft URL)
+  raw.$schema = undefined;
+
+  if (raw.type === "object") {
+    return raw as McpJsonSchema;
+  }
+
+  // Non-object root: wrap so the tool still registers (edge case)
+  return {
+    type: "object",
+    properties: { value: raw },
+    required: ["value"],
+  };
+}

--- a/agentflow/packages/mcp-server/src/types.ts
+++ b/agentflow/packages/mcp-server/src/types.ts
@@ -1,0 +1,13 @@
+export interface CliCeilings {
+  readonly maxCostUsd?: number | null; // null = --no-max-cost flag
+  readonly maxDurationSec?: number | null;
+  readonly maxTurns?: number | null;
+}
+
+export interface EffectiveCeilings {
+  readonly maxCostUsd: number | null;
+  readonly maxDurationSec: number | null;
+  readonly maxTurns: number | null;
+}
+
+export type HitlStrategy = "elicit" | "auto" | "fail";


### PR DESCRIPTION
## Summary

Continuation of MCP server v0.1 plan. Five pure-function modules forming the execution core of the MCP server.

- **Task 4** \`ceiling-resolver.ts\` — compose workflow/CLI ceilings (workflow wins, null = +Infinity, clamp-on-raise with warning)
- **Task 5** \`dag-boundary.ts\` — find unique DAG root/leaf tasks; explicit errors on ambiguity
- **Task 6** \`schema-convert.ts\` — Zod → JSON Schema via \`zod-to-json-schema\`; wraps non-object root
- **Task 7** \`errors.ts\` — \`ErrorCode\` enum (14 codes), \`McpServerError\` class, \`formatErrorResult\` for MCP response shape
- **Task 8** \`progress-streamer.ts\` — maps executor events to MCP \`notifications/progress\`, no-op when no progressToken

Plus one fix commit for \`exactOptionalPropertyTypes\` compat in \`formatErrorResult\`.

## Gates

- **BUILD** ✓ 5 feat commits + 1 fix, all following plan TDD
- **TEST** ✓ 27 new tests pass; typecheck / lint / test all exit 0 monorepo-wide
- **VERIFY** ✓ parallel consolidation
  - code-reviewer: APPROVED (5 Suggestion-severity notes, all optional)
  - reality-checker: APPROVED (scope clean, no regressions, 11 files in diff)

## Deviations from plan (all accepted)

1. \`raw.\$schema = undefined\` instead of \`delete raw.\$schema\` — Biome \`noDelete\` blocks delete. Wire-equivalent since JSON.stringify drops undefined.
2. Task 8 progress counter: capture-before-increment (\`progress: 0, 1, 2...\`) to honor plan's test assertion (\`toEqual({ progress: 0 })\` on first call). Plan had internal contradiction between test and impl; tests win.
3. \`formatErrorResult\` uses conditional spread for \`context\` field due to \`exactOptionalPropertyTypes: true\` in tsconfig.

## Follow-ups

Remaining plan tasks: 9-20 (HITL bridge, watchdog, tool-registry, server, transport, CLI, example, dogfooding, publish). Being executed in subsequent PRs this session.