### PR TITLE
feat(mcp-server): Phase 6-7 — HITL bridge + watchdog + tool-registry + server (Tasks 9-13)

### DIFF
--- a/agentflow/packages/mcp-server/package.json
+++ b/agentflow/packages/mcp-server/package.json
@@ -22,6 +22,7 @@
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
+    "@ageflow/testing": "workspace:*",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"

--- a/agentflow/packages/mcp-server/src/__tests__/dag-boundary.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/dag-boundary.test.ts
@@ -1,6 +1,7 @@
 import type { TasksMap } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { findBoundaryTasks } from "../dag-boundary.js";
+import { ErrorCode, McpServerError } from "../errors.js";
 
 // Minimal TaskDef stubs for testing; actual implementation only reads dependsOn.
 // biome-ignore lint/suspicious/noExplicitAny: narrow test stub
@@ -40,9 +41,15 @@ describe("findBoundaryTasks", () => {
       b: mkTask(),
       c: mkTask(["a", "b"]),
     };
-    expect(() => findBoundaryTasks(tasks, undefined, "c")).toThrow(
-      /multiple root tasks/,
-    );
+    let caught: unknown;
+    try {
+      findBoundaryTasks(tasks, undefined, "c");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(McpServerError);
+    expect((caught as McpServerError).errorCode).toBe(ErrorCode.DAG_INVALID);
+    expect((caught as McpServerError).message).toMatch(/multiple root tasks/);
   });
 
   it("throws if DAG has >1 leaf and no outputTask", () => {
@@ -51,21 +58,43 @@ describe("findBoundaryTasks", () => {
       b: mkTask(["a"]),
       c: mkTask(["a"]),
     };
-    expect(() => findBoundaryTasks(tasks, "a", undefined)).toThrow(
-      /multiple leaf tasks/,
-    );
+    let caught: unknown;
+    try {
+      findBoundaryTasks(tasks, "a", undefined);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(McpServerError);
+    expect((caught as McpServerError).errorCode).toBe(ErrorCode.DAG_INVALID);
+    expect((caught as McpServerError).message).toMatch(/multiple leaf tasks/);
   });
 
   it("throws if inputTask not in tasks", () => {
     const tasks: TasksMap = { a: mkTask() };
-    expect(() => findBoundaryTasks(tasks, "nonexistent", "a")).toThrow(
+    let caught: unknown;
+    try {
+      findBoundaryTasks(tasks, "nonexistent", "a");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(McpServerError);
+    expect((caught as McpServerError).errorCode).toBe(ErrorCode.DAG_INVALID);
+    expect((caught as McpServerError).message).toMatch(
       /inputTask "nonexistent" not found/,
     );
   });
 
   it("throws if outputTask not in tasks", () => {
     const tasks: TasksMap = { a: mkTask() };
-    expect(() => findBoundaryTasks(tasks, "a", "nonexistent")).toThrow(
+    let caught: unknown;
+    try {
+      findBoundaryTasks(tasks, "a", "nonexistent");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(McpServerError);
+    expect((caught as McpServerError).errorCode).toBe(ErrorCode.DAG_INVALID);
+    expect((caught as McpServerError).message).toMatch(
       /outputTask "nonexistent" not found/,
     );
   });

--- a/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
@@ -1,3 +1,5 @@
+import { BudgetExceededError } from "@ageflow/core";
+import { HitlNotInteractiveError } from "@ageflow/executor";
 import { describe, expect, it } from "vitest";
 import { ErrorCode, McpServerError, formatErrorResult } from "../errors.js";
 
@@ -30,5 +32,24 @@ describe("McpServerError + formatErrorResult", () => {
     const result = formatErrorResult("string error" as any);
     expect(result.structuredContent.errorCode).toBe("WORKFLOW_FAILED");
     expect(result.structuredContent.message).toBe("string error");
+  });
+
+  it("maps BudgetExceededError → BUDGET_EXCEEDED", () => {
+    const err = new BudgetExceededError(1.0, 1.23);
+    const result = formatErrorResult(err);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.BUDGET_EXCEEDED);
+    expect(result.structuredContent.context).toEqual({
+      maxCost: 1.0,
+      spent: 1.23,
+    });
+  });
+
+  it("maps HitlNotInteractiveError → HITL_DENIED", () => {
+    const err = new HitlNotInteractiveError("verify");
+    const result = formatErrorResult(err);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.HITL_DENIED);
+    expect(result.structuredContent.context).toEqual({ taskName: "verify" });
   });
 });

--- a/agentflow/packages/mcp-server/src/__tests__/hitl-bridge.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/hitl-bridge.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { ErrorCode, McpServerError } from "../errors.js";
+import { buildMcpHooks } from "../hitl-bridge.js";
+
+const mkConn = (supportsElicit: boolean, elicitResponse?: any) => ({
+  supports: (cap: string) => cap === "elicitation" && supportsElicit,
+  elicit: vi
+    .fn()
+    .mockResolvedValue(
+      elicitResponse ?? { action: "accept", content: { approved: true } },
+    ),
+});
+
+describe("buildMcpHooks", () => {
+  it("hitl=auto always approves", async () => {
+    const hooks = buildMcpHooks(mkConn(false), "auto", () => {}, undefined);
+    const result = await hooks.onCheckpoint?.("verify", "approve?");
+    expect(result).toBe(true);
+  });
+
+  it("hitl=fail always rejects", async () => {
+    const hooks = buildMcpHooks(mkConn(true), "fail", () => {}, undefined);
+    const result = await hooks.onCheckpoint?.("verify", "approve?");
+    expect(result).toBe(false);
+  });
+
+  it("hitl=elicit + supported + accept+approved → true", async () => {
+    const conn = mkConn(true, {
+      action: "accept",
+      content: { approved: true },
+    });
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, undefined);
+    expect(await hooks.onCheckpoint?.("verify", "approve?")).toBe(true);
+    expect(conn.elicit).toHaveBeenCalled();
+  });
+
+  it("hitl=elicit + accept+approved:false → false", async () => {
+    const conn = mkConn(true, {
+      action: "accept",
+      content: { approved: false },
+    });
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, undefined);
+    expect(await hooks.onCheckpoint?.("verify", "approve?")).toBe(false);
+  });
+
+  it("hitl=elicit + decline → false", async () => {
+    const conn = mkConn(true, { action: "decline" });
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, undefined);
+    expect(await hooks.onCheckpoint?.("verify", "approve?")).toBe(false);
+  });
+
+  it("hitl=elicit + cancel → throw HITL_CANCELLED", async () => {
+    const conn = mkConn(true, { action: "cancel" });
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, undefined);
+    await expect(hooks.onCheckpoint?.("verify", "approve?")).rejects.toThrow(
+      /HITL_CANCELLED/,
+    );
+  });
+
+  it("hitl=elicit + unsupported client → throw HITL_ELICITATION_UNSUPPORTED", async () => {
+    const conn = mkConn(false);
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, undefined);
+    await expect(hooks.onCheckpoint?.("verify", "approve?")).rejects.toThrow(
+      /HITL_ELICITATION_UNSUPPORTED/,
+    );
+  });
+
+  it("composes with user-provided onCheckpoint (user truthy short-circuits)", async () => {
+    const conn = mkConn(true);
+    const userHook = vi.fn().mockResolvedValue(true);
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, userHook);
+    expect(await hooks.onCheckpoint?.("verify", "approve?")).toBe(true);
+    expect(userHook).toHaveBeenCalledWith("verify", "approve?");
+    expect(conn.elicit).not.toHaveBeenCalled();
+  });
+
+  it("falls through to elicitation when user hook doesn't approve", async () => {
+    const conn = mkConn(true);
+    const userHook = vi.fn().mockResolvedValue(undefined);
+    const hooks = buildMcpHooks(conn, "elicit", () => {}, userHook);
+    await hooks.onCheckpoint?.("verify", "approve?");
+    expect(conn.elicit).toHaveBeenCalled();
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
@@ -1,7 +1,7 @@
 import { defineAgent, defineWorkflow } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { createMcpServer } from "../../server.js";
+import { type RunWorkflowFn, createMcpServer } from "../../server.js";
 
 describe("createMcpServer (integration)", () => {
   const greetAgent = defineAgent({
@@ -57,5 +57,45 @@ describe("createMcpServer (integration)", () => {
     const result = await server.callTool("greet", { name: "b" });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as any).errorCode).toBe("BUSY");
+  });
+
+  it("runs a workflow end-to-end with mocked runWorkflow injection", async () => {
+    // Uses @ageflow/testing createTestHarness to inject a mock runner.
+    // The real WorkflowExecutor takes the workflow with task inputs pre-set;
+    // for a single-task root workflow, we inject input via a modified workflow.
+    const { createTestHarness } = await import("@ageflow/testing");
+
+    // Wrap harness as RunWorkflowFn: create a harness that knows the workflow,
+    // inject input as the root task's static input, and run.
+    const runWorkflow: RunWorkflowFn = async (args) => {
+      // Build a workflow variant with the MCP input injected as the root task's input.
+      const { defineWorkflow: dw } = await import("@ageflow/core");
+      const wfWithInput = dw({
+        ...args.workflow,
+        tasks: {
+          ...args.workflow.tasks,
+          greet: {
+            ...(args.workflow.tasks as any).greet,
+            input: args.input,
+          },
+        },
+      });
+      const harness = createTestHarness(wfWithInput);
+      harness.mockAgent("greet", { greeting: "hello, Alice!" });
+      const result = await harness.run();
+      // Return the output task's output (boundary task is "greet" for this workflow)
+      return result.outputs.greet;
+    };
+
+    const server = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+      runWorkflow,
+    });
+
+    const result = await server.callTool("greet", { name: "Alice" });
+    expect(result.isError).toBe(false);
+    expect((result.structuredContent as any).greeting).toBe("hello, Alice!");
   });
 });

--- a/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
@@ -59,6 +59,35 @@ describe("createMcpServer (integration)", () => {
     expect((result.structuredContent as any).errorCode).toBe("BUSY");
   });
 
+  it(
+    "returns DURATION_EXCEEDED when workflow exceeds maxDurationSec",
+    async () => {
+      const hangWorkflow = defineWorkflow({
+        name: "hang",
+        mcp: { description: "Hangs forever", maxDurationSec: 0.1 },
+        tasks: {
+          hang: {
+            agent: greetAgent,
+          },
+        },
+      });
+
+      const server = createMcpServer({
+        workflow: hangWorkflow,
+        cliCeilings: {},
+        hitlStrategy: "fail",
+        runWorkflow: async () => new Promise(() => {}), // never resolves
+      });
+
+      const result = await server.callTool("hang", { name: "x" });
+      expect(result.isError).toBe(true);
+      expect((result.structuredContent as any).errorCode).toBe(
+        "DURATION_EXCEEDED",
+      );
+    },
+    { timeout: 2000 },
+  );
+
   it("runs a workflow end-to-end with mocked runWorkflow injection", async () => {
     // Uses @ageflow/testing createTestHarness to inject a mock runner.
     // The real WorkflowExecutor takes the workflow with task inputs pre-set;

--- a/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/server.test.ts
@@ -1,0 +1,61 @@
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createMcpServer } from "../../server.js";
+
+describe("createMcpServer (integration)", () => {
+  const greetAgent = defineAgent({
+    runner: "claude",
+    model: "claude-sonnet-4-6",
+    input: z.object({ name: z.string() }),
+    output: z.object({ greeting: z.string() }),
+    prompt: ({ name }) => `say hi to ${name}`,
+  });
+
+  const workflow = defineWorkflow({
+    name: "greet",
+    mcp: { description: "Greet someone", maxCostUsd: 0.5 },
+    tasks: { greet: { agent: greetAgent } },
+  });
+
+  it("lists the workflow as a single tool", async () => {
+    const server = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+    });
+    const tools = await server.listTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("greet");
+    expect(tools[0]?.description).toBe("Greet someone");
+  });
+
+  it("rejects call with invalid input", async () => {
+    const server = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+    });
+    const result = await server.callTool("greet", { name: 123 });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as any).errorCode).toBe(
+      "INPUT_VALIDATION_FAILED",
+    );
+  });
+
+  it("returns BUSY when a call is already in flight", async () => {
+    const server = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+    });
+    // Mock executor to hang so we can test concurrency
+    const hangPromise = new Promise(() => {});
+    (server as any)._testRunExecutor = () => hangPromise;
+
+    server.callTool("greet", { name: "a" }); // no await
+    const result = await server.callTool("greet", { name: "b" });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as any).errorCode).toBe("BUSY");
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/tool-registry.test.ts
@@ -1,6 +1,7 @@
 import type { WorkflowDef } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { ErrorCode, McpServerError } from "../errors.js";
 import { buildToolDefinition } from "../tool-registry.js";
 
 const mkWorkflow = (mcp?: any): WorkflowDef =>
@@ -47,8 +48,15 @@ describe("buildToolDefinition", () => {
   });
 
   it("throws when workflow.mcp === false", () => {
-    expect(() => buildToolDefinition(mkWorkflow(false))).toThrow(
-      /WORKFLOW_NOT_MCP_EXPOSABLE/,
+    let caught: unknown;
+    try {
+      buildToolDefinition(mkWorkflow(false));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(McpServerError);
+    expect((caught as McpServerError).errorCode).toBe(
+      ErrorCode.WORKFLOW_NOT_MCP_EXPOSABLE,
     );
   });
 });

--- a/agentflow/packages/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/tool-registry.test.ts
@@ -1,0 +1,54 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildToolDefinition } from "../tool-registry.js";
+
+const mkWorkflow = (mcp?: any): WorkflowDef =>
+  ({
+    name: "test-flow",
+    mcp,
+    tasks: {
+      start: {
+        agent: {
+          runner: "claude",
+          model: "claude-sonnet-4-6",
+          input: z.object({ x: z.string() }),
+          output: z.object({ y: z.number() }),
+          prompt: () => "",
+        },
+      } as any,
+    },
+  }) as any;
+
+describe("buildToolDefinition", () => {
+  it("derives tool name from workflow.name", () => {
+    const tool = buildToolDefinition(mkWorkflow());
+    expect(tool.name).toBe("test-flow");
+  });
+
+  it("uses description from mcp.description", () => {
+    const tool = buildToolDefinition(mkWorkflow({ description: "my tool" }));
+    expect(tool.description).toBe("my tool");
+  });
+
+  it("falls back to default description", () => {
+    const tool = buildToolDefinition(mkWorkflow());
+    expect(tool.description).toMatch(/Run ageflow workflow: test-flow/);
+  });
+
+  it("inputSchema derived from input task", () => {
+    const tool = buildToolDefinition(mkWorkflow());
+    expect(tool.inputSchema.properties).toHaveProperty("x");
+  });
+
+  it("outputSchema derived from output task", () => {
+    const tool = buildToolDefinition(mkWorkflow());
+    expect(tool.outputSchema.properties).toHaveProperty("y");
+  });
+
+  it("throws when workflow.mcp === false", () => {
+    expect(() => buildToolDefinition(mkWorkflow(false))).toThrow(
+      /WORKFLOW_NOT_MCP_EXPOSABLE/,
+    );
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/watchdog.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/watchdog.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DurationWatchdog } from "../watchdog.js";
+
+describe("DurationWatchdog", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("fires abort after maxDurationSec elapsed", () => {
+    const onTimeout = vi.fn();
+    const wd = new DurationWatchdog(2, onTimeout);
+    wd.start();
+    vi.advanceTimersByTime(1999);
+    expect(onTimeout).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    expect(onTimeout).toHaveBeenCalledOnce();
+  });
+
+  it("cancel() prevents firing", () => {
+    const onTimeout = vi.fn();
+    const wd = new DurationWatchdog(2, onTimeout);
+    wd.start();
+    wd.cancel();
+    vi.advanceTimersByTime(5000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("no-op when maxDurationSec is null (unlimited)", () => {
+    const onTimeout = vi.fn();
+    const wd = new DurationWatchdog(null, onTimeout);
+    wd.start();
+    vi.advanceTimersByTime(60_000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("abortSignal fires when timer elapses", () => {
+    const wd = new DurationWatchdog(1, () => {});
+    wd.start();
+    let aborted = false;
+    wd.abortSignal.addEventListener("abort", () => {
+      aborted = true;
+    });
+    vi.advanceTimersByTime(1100);
+    expect(aborted).toBe(true);
+  });
+});

--- a/agentflow/packages/mcp-server/src/dag-boundary.ts
+++ b/agentflow/packages/mcp-server/src/dag-boundary.ts
@@ -1,4 +1,5 @@
 import type { TasksMap } from "@ageflow/core";
+import { ErrorCode, McpServerError } from "./errors.js";
 
 export interface BoundaryTasks {
   readonly inputTask: string;
@@ -39,16 +40,23 @@ export function findBoundaryTasks(
   let inputTask: string;
   if (inputTaskOverride !== undefined) {
     if (!taskNames.includes(inputTaskOverride)) {
-      throw new Error(
-        `DAG_INVALID: inputTask "${inputTaskOverride}" not found in workflow tasks`,
+      throw new McpServerError(
+        ErrorCode.DAG_INVALID,
+        `inputTask "${inputTaskOverride}" not found in workflow tasks`,
+        { inputTask: inputTaskOverride },
       );
     }
     inputTask = inputTaskOverride;
   } else if (roots.length === 0) {
-    throw new Error("DAG_INVALID: workflow has no root task (cyclic?)");
+    throw new McpServerError(
+      ErrorCode.DAG_INVALID,
+      "workflow has no root task (cyclic?)",
+    );
   } else if (roots.length > 1) {
-    throw new Error(
-      `DAG_INVALID: workflow has multiple root tasks (${roots.join(", ")}); set workflow.mcp.inputTask to disambiguate`,
+    throw new McpServerError(
+      ErrorCode.DAG_INVALID,
+      `workflow has multiple root tasks (${roots.join(", ")}); set workflow.mcp.inputTask to disambiguate`,
+      { roots },
     );
   } else {
     inputTask = roots[0] as string;
@@ -58,16 +66,23 @@ export function findBoundaryTasks(
   let outputTask: string;
   if (outputTaskOverride !== undefined) {
     if (!taskNames.includes(outputTaskOverride)) {
-      throw new Error(
-        `DAG_INVALID: outputTask "${outputTaskOverride}" not found in workflow tasks`,
+      throw new McpServerError(
+        ErrorCode.DAG_INVALID,
+        `outputTask "${outputTaskOverride}" not found in workflow tasks`,
+        { outputTask: outputTaskOverride },
       );
     }
     outputTask = outputTaskOverride;
   } else if (leaves.length === 0) {
-    throw new Error("DAG_INVALID: workflow has no leaf task (cyclic?)");
+    throw new McpServerError(
+      ErrorCode.DAG_INVALID,
+      "workflow has no leaf task (cyclic?)",
+    );
   } else if (leaves.length > 1) {
-    throw new Error(
-      `DAG_INVALID: workflow has multiple leaf tasks (${leaves.join(", ")}); set workflow.mcp.outputTask to disambiguate`,
+    throw new McpServerError(
+      ErrorCode.DAG_INVALID,
+      `workflow has multiple leaf tasks (${leaves.join(", ")}); set workflow.mcp.outputTask to disambiguate`,
+      { leaves },
     );
   } else {
     outputTask = leaves[0] as string;

--- a/agentflow/packages/mcp-server/src/errors.ts
+++ b/agentflow/packages/mcp-server/src/errors.ts
@@ -1,3 +1,6 @@
+import { BudgetExceededError } from "@ageflow/core";
+import { HitlNotInteractiveError } from "@ageflow/executor";
+
 export const ErrorCode = {
   INPUT_VALIDATION_FAILED: "INPUT_VALIDATION_FAILED",
   OUTPUT_VALIDATION_FAILED: "OUTPUT_VALIDATION_FAILED",
@@ -46,6 +49,30 @@ export function formatErrorResult(err: unknown): McpToolErrorResult {
         errorCode: err.errorCode,
         message: err.message,
         ...(err.context !== undefined ? { context: err.context } : {}),
+      },
+      isError: true,
+    };
+  }
+
+  if (err instanceof BudgetExceededError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: ErrorCode.BUDGET_EXCEEDED,
+        message: err.message,
+        context: { maxCost: err.maxCost, spent: err.actualCost },
+      },
+      isError: true,
+    };
+  }
+
+  if (err instanceof HitlNotInteractiveError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: ErrorCode.HITL_DENIED,
+        message: err.message,
+        context: { taskName: err.taskName },
       },
       isError: true,
     };

--- a/agentflow/packages/mcp-server/src/hitl-bridge.ts
+++ b/agentflow/packages/mcp-server/src/hitl-bridge.ts
@@ -1,0 +1,96 @@
+import type { WorkflowHooks } from "@ageflow/core";
+import { ErrorCode, McpServerError } from "./errors.js";
+import type { HitlStrategy } from "./types.js";
+
+export interface McpConnectionLike {
+  supports(capability: "elicitation" | "progress"): boolean;
+  elicit(req: {
+    message: string;
+    requestedSchema: Record<string, unknown>;
+  }): Promise<ElicitationResponse>;
+}
+
+export interface ElicitationResponse {
+  readonly action: "accept" | "decline" | "cancel";
+  readonly content?: Record<string, unknown>;
+}
+
+type OnAwaitingFn = (task: string, message: string) => void;
+type UserHook = NonNullable<WorkflowHooks["onCheckpoint"]>;
+
+/**
+ * Build a WorkflowHooks object that routes HITL checkpoints to MCP elicitation.
+ *
+ * Strategy semantics:
+ * - "auto": always approve (emits unlimited-style warning upstream if workflow has HITL)
+ * - "fail": always reject → executor raises HitlNotInteractiveError
+ * - "elicit": send elicitation/create to client, map response to approval
+ *
+ * If a user-provided `onCheckpoint` hook exists, call it FIRST. If it returns
+ * truthy, short-circuit approve. Otherwise fall through to the MCP strategy.
+ */
+export function buildMcpHooks(
+  conn: McpConnectionLike,
+  strategy: HitlStrategy,
+  emitAwaiting: OnAwaitingFn,
+  userOnCheckpoint: UserHook | undefined,
+): WorkflowHooks {
+  return {
+    onCheckpoint: async (taskName, message) => {
+      // Compose: user hook first
+      if (userOnCheckpoint !== undefined) {
+        const userResult = await Promise.resolve(
+          userOnCheckpoint(taskName, message) as unknown as Promise<
+            boolean | undefined | undefined
+          >,
+        );
+        if (userResult === true) return true as unknown as undefined;
+      }
+
+      // MCP strategy
+      switch (strategy) {
+        case "auto":
+          return true as unknown as undefined;
+        case "fail":
+          return false as unknown as undefined;
+        case "elicit": {
+          if (!conn.supports("elicitation")) {
+            throw new McpServerError(
+              ErrorCode.HITL_ELICITATION_UNSUPPORTED,
+              `HITL_ELICITATION_UNSUPPORTED: [${taskName}] client does not support elicitation; HITL checkpoint cannot be resolved`,
+              { task: taskName },
+            );
+          }
+          emitAwaiting(taskName, message);
+          const response = await conn.elicit({
+            message: `[${taskName}] ${message}`,
+            requestedSchema: {
+              type: "object",
+              properties: {
+                approved: {
+                  type: "boolean",
+                  description: "Approve to continue",
+                },
+                note: { type: "string", description: "Optional comment" },
+              },
+              required: ["approved"],
+            },
+          });
+
+          if (response.action === "cancel") {
+            throw new McpServerError(
+              ErrorCode.HITL_CANCELLED,
+              `HITL_CANCELLED: [${taskName}] HITL dialog cancelled by client`,
+              { task: taskName },
+            );
+          }
+          if (response.action === "decline") {
+            return false as unknown as undefined;
+          }
+          // action === "accept"
+          return (response.content?.approved === true) as unknown as undefined;
+        }
+      }
+    },
+  };
+}

--- a/agentflow/packages/mcp-server/src/index.ts
+++ b/agentflow/packages/mcp-server/src/index.ts
@@ -1,2 +1,9 @@
-// Public exports — filled in by subsequent tasks.
-export {};
+export { createMcpServer } from "./server.js";
+export type {
+  McpServerOptions,
+  McpServerHandle,
+  McpToolResult,
+  RunWorkflowFn,
+} from "./server.js";
+export type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
+export { ErrorCode, McpServerError } from "./errors.js";

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -1,5 +1,6 @@
-import type { WorkflowDef } from "@ageflow/core";
+import type { WorkflowDef, WorkflowHooks } from "@ageflow/core";
 import { resolveMcpConfig } from "@ageflow/core";
+import { WorkflowExecutor } from "@ageflow/executor";
 import { composeCeilings } from "./ceiling-resolver.js";
 import {
   ErrorCode,
@@ -165,7 +166,7 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
               )
             : undefined;
 
-        // Run executor (delegated; Task 13 wires in the real executor)
+        // Run executor (Task 13: real executor or pluggable injection)
         let rawOutput: unknown;
         if (handle._testRunExecutor !== undefined) {
           rawOutput = await handle._testRunExecutor(
@@ -175,7 +176,9 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
             effective,
           );
         } else {
-          const runner = opts.runWorkflow ?? defaultRunner;
+          const runner =
+            opts.runWorkflow ??
+            makeDefaultRunner(tool.inputTask, tool.outputTask);
           rawOutput = await runner({
             workflow: opts.workflow,
             input: parsedInput,
@@ -244,10 +247,58 @@ function safeParse(
   return result.data;
 }
 
-// Placeholder — real executor integration lands in Task 13.
-async function defaultRunner(): Promise<unknown> {
-  throw new McpServerError(
-    ErrorCode.WORKFLOW_FAILED,
-    "executor not wired (run Task 13 to integrate)",
-  );
+/**
+ * Build the default RunWorkflowFn backed by @ageflow/executor's WorkflowExecutor.
+ *
+ * Real API deviations from plan pseudocode:
+ * - No `runWorkflow` function export — WorkflowExecutor is a class.
+ * - WorkflowExecutor.run() ignores its `_input` argument; input must be injected
+ *   into the workflow's root task definition as a static `input` field.
+ * - Budget is passed via workflow.budget (BudgetConfig), not as a run-time arg.
+ * - HITL hooks are passed via workflow.hooks (merged with existing hooks).
+ * - AbortSignal is not natively supported; the DurationWatchdog's onTimeout
+ *   callback throws into the awaited run(), which propagates as a rejection.
+ */
+function makeDefaultRunner(
+  inputTaskName: string,
+  outputTaskName: string,
+): RunWorkflowFn {
+  return async (args) => {
+    const { workflow, input, hooks, effective } = args;
+
+    // Inject MCP input as the root task's static input field.
+    // biome-ignore lint/suspicious/noExplicitAny: structural injection — task.input must be set at runtime
+    const originalTask = workflow.tasks[inputTaskName] as any;
+    // biome-ignore lint/suspicious/noExplicitAny: structural injection
+    const injectedTasks = {
+      ...workflow.tasks,
+      [inputTaskName]: { ...originalTask, input },
+    } as import("@ageflow/core").TasksMap;
+
+    // Merge HITL hooks with existing workflow hooks.
+    const mcpHooks = hooks as WorkflowHooks | undefined;
+    const mergedHooks: WorkflowHooks = {
+      ...(workflow.hooks ?? {}),
+      ...(mcpHooks !== undefined ? mcpHooks : {}),
+    };
+
+    // Apply budget ceiling from effective config.
+    const budget =
+      effective.maxCostUsd !== null
+        ? { maxCost: effective.maxCostUsd, onExceed: "halt" as const }
+        : undefined;
+
+    const injectedWorkflow: WorkflowDef = {
+      ...workflow,
+      tasks: injectedTasks,
+      hooks: mergedHooks,
+      ...(budget !== undefined ? { budget } : {}),
+    };
+
+    const executor = new WorkflowExecutor(injectedWorkflow);
+    const result = await executor.run();
+
+    // Return the output task's result.
+    return result.outputs[outputTaskName];
+  };
 }

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -145,14 +145,24 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
         if (effective.maxTurns === null) unlimitedAxes.push("turns");
         if (unlimitedAxes.length > 0) streamer.unlimitedWarning(unlimitedAxes);
 
-        // Watchdog
+        // Watchdog — side-effect only; abort is communicated via abortPromise race
         const watchdog = new DurationWatchdog(effective.maxDurationSec, () => {
-          throw new McpServerError(
-            ErrorCode.DURATION_EXCEEDED,
-            `workflow exceeded maxDurationSec=${effective.maxDurationSec}`,
-          );
+          // intentionally empty: AbortController.abort() is called by DurationWatchdog
+          // internally; consumers race against abortPromise below
         });
         watchdog.start();
+
+        const abortPromise = new Promise<never>((_, reject) => {
+          watchdog.abortSignal.addEventListener("abort", () => {
+            reject(
+              new McpServerError(
+                ErrorCode.DURATION_EXCEEDED,
+                `workflow exceeded maxDurationSec=${effective.maxDurationSec}`,
+                { maxDurationSec: effective.maxDurationSec },
+              ),
+            );
+          });
+        });
 
         // HITL bridge (requires MCP connection)
         const mcpHooks =
@@ -169,23 +179,29 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
         // Run executor (Task 13: real executor or pluggable injection)
         let rawOutput: unknown;
         if (handle._testRunExecutor !== undefined) {
-          rawOutput = await handle._testRunExecutor(
-            parsedInput,
-            mcpHooks,
-            watchdog.abortSignal,
-            effective,
-          );
+          rawOutput = await Promise.race([
+            handle._testRunExecutor(
+              parsedInput,
+              mcpHooks,
+              watchdog.abortSignal,
+              effective,
+            ),
+            abortPromise,
+          ]);
         } else {
           const runner =
             opts.runWorkflow ??
             makeDefaultRunner(tool.inputTask, tool.outputTask);
-          rawOutput = await runner({
-            workflow: opts.workflow,
-            input: parsedInput,
-            hooks: mcpHooks,
-            signal: watchdog.abortSignal,
-            effective,
-          });
+          rawOutput = await Promise.race([
+            runner({
+              workflow: opts.workflow,
+              input: parsedInput,
+              hooks: mcpHooks,
+              signal: watchdog.abortSignal,
+              effective,
+            }),
+            abortPromise,
+          ]);
         }
         watchdog.cancel();
 
@@ -269,7 +285,6 @@ function makeDefaultRunner(
     // Inject MCP input as the root task's static input field.
     // biome-ignore lint/suspicious/noExplicitAny: structural injection — task.input must be set at runtime
     const originalTask = workflow.tasks[inputTaskName] as any;
-    // biome-ignore lint/suspicious/noExplicitAny: structural injection
     const injectedTasks = {
       ...workflow.tasks,
       [inputTaskName]: { ...originalTask, input },

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -1,0 +1,253 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { resolveMcpConfig } from "@ageflow/core";
+import { composeCeilings } from "./ceiling-resolver.js";
+import {
+  ErrorCode,
+  McpServerError,
+  type McpToolErrorResult,
+  formatErrorResult,
+} from "./errors.js";
+import { type McpConnectionLike, buildMcpHooks } from "./hitl-bridge.js";
+import { ProgressStreamer, type SendProgress } from "./progress-streamer.js";
+import { type ToolDefinition, buildToolDefinition } from "./tool-registry.js";
+import type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
+import { DurationWatchdog } from "./watchdog.js";
+
+export type RunWorkflowFn = (args: {
+  workflow: WorkflowDef;
+  input: unknown;
+  hooks: unknown;
+  signal: AbortSignal;
+  effective: EffectiveCeilings;
+}) => Promise<unknown>;
+
+export interface McpServerOptions {
+  readonly workflow: WorkflowDef;
+  readonly cliCeilings: CliCeilings;
+  readonly hitlStrategy: HitlStrategy;
+  /** Custom stderr writer (for testing); defaults to process.stderr.write. */
+  readonly stderr?: (line: string) => void;
+  /**
+   * Executor runner. Defaults to calling `@ageflow/executor`'s WorkflowExecutor.
+   * Injected for testing.
+   */
+  readonly runWorkflow?: RunWorkflowFn;
+}
+
+export interface McpToolSuccessResult {
+  readonly content: readonly { type: "text"; text: string }[];
+  readonly structuredContent: Record<string, unknown>;
+  readonly isError: false;
+}
+
+export type McpToolResult = McpToolSuccessResult | McpToolErrorResult;
+
+export interface McpServerHandle {
+  listTools(): Promise<ToolDefinition[]>;
+  callTool(
+    name: string,
+    args: unknown,
+    opts?: {
+      connection?: McpConnectionLike;
+      progressToken?: string | number;
+      sendProgress?: SendProgress;
+    },
+  ): Promise<McpToolResult>;
+  /** Attached by tests only — replaces the real executor invocation. */
+  _testRunExecutor?: (
+    args: unknown,
+    hooks: unknown,
+    signal: AbortSignal,
+    effective: EffectiveCeilings,
+  ) => Promise<unknown>;
+}
+
+/**
+ * Compose an MCP server around a single workflow.
+ *
+ * The returned handle exposes listTools/callTool for wiring into the MCP
+ * transport layer (stdio). A real implementation would forward these to
+ * `@modelcontextprotocol/sdk`'s Server class; this minimal form is testable
+ * directly without the transport.
+ */
+export function createMcpServer(opts: McpServerOptions): McpServerHandle {
+  const resolved = resolveMcpConfig(opts.workflow.mcp);
+  const stderr =
+    opts.stderr ??
+    ((line: string) => {
+      process.stderr.write(line);
+    });
+  const tool = buildToolDefinition(opts.workflow);
+
+  let inflight = false;
+
+  const handle: McpServerHandle = {
+    async listTools() {
+      return [tool];
+    },
+
+    async callTool(name, args, callOpts) {
+      if (name !== tool.name) {
+        return formatErrorResult(
+          new McpServerError(
+            ErrorCode.WORKFLOW_FAILED,
+            `unknown tool: ${name}`,
+            { name },
+          ),
+        );
+      }
+
+      if (inflight) {
+        return formatErrorResult(
+          new McpServerError(
+            ErrorCode.BUSY,
+            "Another workflow run is in progress",
+          ),
+        );
+      }
+      inflight = true;
+
+      try {
+        // Validate input
+        const inputTaskDef = (opts.workflow.tasks as Record<string, unknown>)[
+          tool.inputTask
+        ] as {
+          agent: {
+            input: {
+              safeParse: (v: unknown) => {
+                success: boolean;
+                data?: unknown;
+                error?: unknown;
+              };
+            };
+          };
+        };
+        const parsedInput = safeParse(
+          inputTaskDef.agent.input,
+          args,
+          ErrorCode.INPUT_VALIDATION_FAILED,
+        );
+
+        // Effective ceilings
+        const effective = composeCeilings(resolved, opts.cliCeilings, stderr);
+
+        // Progress streamer
+        const streamer = new ProgressStreamer(
+          callOpts?.sendProgress ?? (() => {}),
+          callOpts?.progressToken,
+        );
+
+        // Emit unlimited warnings
+        const unlimitedAxes: string[] = [];
+        if (effective.maxCostUsd === null) unlimitedAxes.push("cost");
+        if (effective.maxDurationSec === null) unlimitedAxes.push("duration");
+        if (effective.maxTurns === null) unlimitedAxes.push("turns");
+        if (unlimitedAxes.length > 0) streamer.unlimitedWarning(unlimitedAxes);
+
+        // Watchdog
+        const watchdog = new DurationWatchdog(effective.maxDurationSec, () => {
+          throw new McpServerError(
+            ErrorCode.DURATION_EXCEEDED,
+            `workflow exceeded maxDurationSec=${effective.maxDurationSec}`,
+          );
+        });
+        watchdog.start();
+
+        // HITL bridge (requires MCP connection)
+        const mcpHooks =
+          callOpts?.connection !== undefined
+            ? buildMcpHooks(
+                callOpts.connection,
+                opts.hitlStrategy,
+                (taskName, message) =>
+                  streamer.awaitingElicitation(taskName, message),
+                opts.workflow.hooks?.onCheckpoint,
+              )
+            : undefined;
+
+        // Run executor (delegated; Task 13 wires in the real executor)
+        let rawOutput: unknown;
+        if (handle._testRunExecutor !== undefined) {
+          rawOutput = await handle._testRunExecutor(
+            parsedInput,
+            mcpHooks,
+            watchdog.abortSignal,
+            effective,
+          );
+        } else {
+          const runner = opts.runWorkflow ?? defaultRunner;
+          rawOutput = await runner({
+            workflow: opts.workflow,
+            input: parsedInput,
+            hooks: mcpHooks,
+            signal: watchdog.abortSignal,
+            effective,
+          });
+        }
+        watchdog.cancel();
+
+        // Validate output
+        const outputTaskDef = (opts.workflow.tasks as Record<string, unknown>)[
+          tool.outputTask
+        ] as {
+          agent: {
+            output: {
+              safeParse: (v: unknown) => {
+                success: boolean;
+                data?: unknown;
+                error?: unknown;
+              };
+            };
+          };
+        };
+        const parsedOutput = safeParse(
+          outputTaskDef.agent.output,
+          rawOutput,
+          ErrorCode.OUTPUT_VALIDATION_FAILED,
+        );
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(parsedOutput) }],
+          structuredContent: parsedOutput as Record<string, unknown>,
+          isError: false,
+        };
+      } catch (err) {
+        return formatErrorResult(err);
+      } finally {
+        inflight = false;
+      }
+    },
+  };
+
+  return handle;
+}
+
+function safeParse(
+  schema: {
+    safeParse: (v: unknown) => {
+      success: boolean;
+      data?: unknown;
+      error?: unknown;
+    };
+  },
+  value: unknown,
+  errorCode: (typeof ErrorCode)[keyof typeof ErrorCode],
+): unknown {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new McpServerError(
+      errorCode,
+      `schema validation failed: ${String(result.error)}`,
+      { error: result.error },
+    );
+  }
+  return result.data;
+}
+
+// Placeholder — real executor integration lands in Task 13.
+async function defaultRunner(): Promise<unknown> {
+  throw new McpServerError(
+    ErrorCode.WORKFLOW_FAILED,
+    "executor not wired (run Task 13 to integrate)",
+  );
+}

--- a/agentflow/packages/mcp-server/src/tool-registry.ts
+++ b/agentflow/packages/mcp-server/src/tool-registry.ts
@@ -1,6 +1,7 @@
 import type { WorkflowDef } from "@ageflow/core";
 import { resolveMcpConfig } from "@ageflow/core";
 import { findBoundaryTasks } from "./dag-boundary.js";
+import { ErrorCode, McpServerError } from "./errors.js";
 import { type McpJsonSchema, zodToMcpSchema } from "./schema-convert.js";
 
 export interface ToolDefinition {
@@ -20,7 +21,21 @@ export interface ToolDefinition {
  * - outputSchema = Zod → JSON Schema of the output task's `agent.output`
  */
 export function buildToolDefinition(workflow: WorkflowDef): ToolDefinition {
-  const resolved = resolveMcpConfig(workflow.mcp);
+  let resolved: ReturnType<typeof resolveMcpConfig>;
+  try {
+    resolved = resolveMcpConfig(workflow.mcp);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.startsWith("WORKFLOW_NOT_MCP_EXPOSABLE:")
+    ) {
+      throw new McpServerError(
+        ErrorCode.WORKFLOW_NOT_MCP_EXPOSABLE,
+        err.message,
+      );
+    }
+    throw err;
+  }
   const boundary = findBoundaryTasks(
     workflow.tasks,
     resolved.inputTask,

--- a/agentflow/packages/mcp-server/src/tool-registry.ts
+++ b/agentflow/packages/mcp-server/src/tool-registry.ts
@@ -1,0 +1,46 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { resolveMcpConfig } from "@ageflow/core";
+import { findBoundaryTasks } from "./dag-boundary.js";
+import { type McpJsonSchema, zodToMcpSchema } from "./schema-convert.js";
+
+export interface ToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: McpJsonSchema;
+  readonly outputSchema: McpJsonSchema;
+  readonly inputTask: string;
+  readonly outputTask: string;
+}
+
+/**
+ * Build an MCP tool definition from a workflow:
+ * - name = workflow.name
+ * - description = workflow.mcp.description or fallback
+ * - inputSchema = Zod → JSON Schema of the input task's `agent.input`
+ * - outputSchema = Zod → JSON Schema of the output task's `agent.output`
+ */
+export function buildToolDefinition(workflow: WorkflowDef): ToolDefinition {
+  const resolved = resolveMcpConfig(workflow.mcp);
+  const boundary = findBoundaryTasks(
+    workflow.tasks,
+    resolved.inputTask,
+    resolved.outputTask,
+  );
+
+  const inputTask = workflow.tasks[boundary.inputTask] as {
+    agent: { input: import("zod").ZodType; output: import("zod").ZodType };
+  };
+  const outputTask = workflow.tasks[boundary.outputTask] as {
+    agent: { input: import("zod").ZodType; output: import("zod").ZodType };
+  };
+
+  return {
+    name: workflow.name,
+    description:
+      resolved.description ?? `Run ageflow workflow: ${workflow.name}`,
+    inputSchema: zodToMcpSchema(inputTask.agent.input),
+    outputSchema: zodToMcpSchema(outputTask.agent.output),
+    inputTask: boundary.inputTask,
+    outputTask: boundary.outputTask,
+  };
+}

--- a/agentflow/packages/mcp-server/src/watchdog.ts
+++ b/agentflow/packages/mcp-server/src/watchdog.ts
@@ -1,8 +1,12 @@
 /**
- * Fires a callback after `maxDurationSec` elapses and signals abortion via AbortController.
+ * Fires a side-effect callback after `maxDurationSec` elapses and aborts via AbortController.
  *
  * - null maxDurationSec = no watchdog (unlimited).
  * - cancel() stops the timer and releases resources (used on successful completion).
+ * - The `onTimeout` callback must NOT throw — it is called inside a setTimeout callback
+ *   and any exception would become an uncaughtException rather than a promise rejection.
+ *   Consumers should race their main promise against a rejection registered on
+ *   `abortSignal`'s "abort" event to propagate the timeout as a proper rejection.
  */
 export class DurationWatchdog {
   private timer: ReturnType<typeof setTimeout> | null = null;

--- a/agentflow/packages/mcp-server/src/watchdog.ts
+++ b/agentflow/packages/mcp-server/src/watchdog.ts
@@ -1,0 +1,34 @@
+/**
+ * Fires a callback after `maxDurationSec` elapses and signals abortion via AbortController.
+ *
+ * - null maxDurationSec = no watchdog (unlimited).
+ * - cancel() stops the timer and releases resources (used on successful completion).
+ */
+export class DurationWatchdog {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly controller = new AbortController();
+
+  constructor(
+    private readonly maxDurationSec: number | null,
+    private readonly onTimeout: () => void,
+  ) {}
+
+  get abortSignal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  start(): void {
+    if (this.maxDurationSec === null) return;
+    this.timer = setTimeout(() => {
+      this.controller.abort();
+      this.onTimeout();
+    }, this.maxDurationSec * 1000);
+  }
+
+  cancel(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

MCP server core composition — brings the executor integration layer online.

- **Task 9** \`hitl-bridge.ts\` — \`buildMcpHooks\` with elicit/auto/fail strategies; composes with user onCheckpoint
- **Task 10** \`watchdog.ts\` — \`DurationWatchdog\` with AbortController; null = no timer
- **Task 11** \`tool-registry.ts\` — \`buildToolDefinition\` derives MCP tool name/description/schemas from workflow
- **Task 12** \`server.ts\` — \`createMcpServer\` factory with Zod boundary validation, watchdog, progress, HITL, concurrency lock (BUSY on 2nd call), error mapping
- **Task 13** executor integration — adapts real \`WorkflowExecutor\` class API (plan assumed a function export); injects input into root task, merges hooks, applies budget

## Gates

- **BUILD** ✓ 5 feat commits + 1 fix commit, TDD per plan
- **TEST** ✓ 53 tests pass (added 3 for the defect fixes below)
- **VERIFY** ✓ parallel consolidation found 2 critical + 1 important defect — all addressed in fix commit \`d398080\`:
  - **F1** watchdog timeout threw inside setTimeout (uncaughtException); now races runner against AbortSignal-triggered rejection → \`DURATION_EXCEEDED\` propagates cleanly
  - **F2** \`BudgetExceededError\` / \`HitlNotInteractiveError\` collapsed to \`WORKFLOW_FAILED\`; now map to \`BUDGET_EXCEEDED\` / \`HITL_DENIED\` with proper context
  - **F6** DAG validation errors now use \`McpServerError(DAG_INVALID, ...)\`; \`WORKFLOW_NOT_MCP_EXPOSABLE\` wrapped at tool-registry boundary

## Deferred (follow-up issues to file)

From VERIFY code review, non-blocking for Phase 6-7:
- F4 structuredContent may be non-object when Zod root is not object (edge — our workflows use object roots)
- F5 Zod error context could leak input values — scrub before serialization
- F7-F11 cosmetic / test hygiene

## Deviation: real \`@ageflow/executor\` API

Plan pseudocode used \`runWorkflow\` function. Actual API: \`new WorkflowExecutor(workflow, options).run()\`. Adapter in \`defaultRunner\` spreads input as root task's static \`input\`, applies budget via \`workflow.budget\`, merges HITL into \`workflow.hooks\`. \`runWorkflow\` option on \`McpServerOptions\` preserved as pluggable injection point for tests.