### PR TITLE
feat(mcp-server): Phase 8-10 — stdio transport + CLI + example (Tasks 14-17)

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -47,6 +47,7 @@
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
+        "@ageflow/mcp-server": "workspace:*",
         "boxen": "^8.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -92,6 +93,7 @@
         "zod-to-json-schema": "^3.23.0",
       },
       "devDependencies": {
+        "@ageflow/testing": "workspace:*",
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
         "zod": "^3.23.0",

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -38,6 +38,22 @@
         "zod": "^3.23.0",
       },
     },
+    "examples/mcp-server": {
+      "name": "@ageflow/example-mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ageflow/cli": "workspace:*",
+        "@ageflow/core": "workspace:*",
+        "@ageflow/runner-claude": "workspace:*",
+      },
+      "devDependencies": {
+        "@ageflow/mcp-server": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.23.0",
+      },
+    },
     "packages/cli": {
       "name": "@ageflow/cli",
       "version": "0.1.0",
@@ -148,6 +164,8 @@
     "@ageflow/dogfooding": ["@ageflow/dogfooding@workspace:dogfooding"],
 
     "@ageflow/example-bug-fix-pipeline": ["@ageflow/example-bug-fix-pipeline@workspace:examples/bug-fix-pipeline"],
+
+    "@ageflow/example-mcp-server": ["@ageflow/example-mcp-server@workspace:examples/mcp-server"],
 
     "@ageflow/executor": ["@ageflow/executor@workspace:packages/executor"],
 

--- a/agentflow/examples/mcp-server/README.md
+++ b/agentflow/examples/mcp-server/README.md
@@ -1,0 +1,73 @@
+# AgentFlow MCP Server Example
+
+Minimal example of exposing an ageflow workflow as an MCP tool via the stdio transport.
+
+## What it does
+
+Defines a `greet` workflow with a single agent that greets a person by name. The workflow is exposed as an MCP tool:
+
+- **Tool name**: `greet`
+- **Input schema**: `{ name: string }`
+- **Output schema**: `{ greeting: string }`
+
+## Run the MCP server (stdio)
+
+```bash
+# Install dependencies (from monorepo root)
+bun install
+
+# Start the server (reads from stdin, writes to stdout — standard MCP stdio transport)
+bun run serve
+
+# Or with HITL set to auto-approve (no human-in-the-loop prompts)
+bun run serve:auto
+```
+
+## Claude Desktop configuration
+
+Add this snippet to your `claude_desktop_config.json` (usually at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "ageflow-greet": {
+      "command": "bun",
+      "args": [
+        "run",
+        "--cwd",
+        "/absolute/path/to/agentflow/examples/mcp-server",
+        "serve"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/agentflow` with the actual path to this monorepo on your machine.
+
+> **Note:** The `ANTHROPIC_API_KEY` environment variable must be set (or Claude CLI must be authenticated) for the runner to work.
+
+## Integration test
+
+```bash
+bun run test
+```
+
+The test uses `InMemoryTransport` from the MCP SDK to connect a client to the server in-process (no real Claude calls — the runner is mocked).
+
+## Flags
+
+```
+agentwf mcp serve workflow.ts [flags]
+
+  --max-cost <n>       max cost in USD (default: from workflow.mcp.maxCostUsd)
+  --no-max-cost        disable cost ceiling
+  --max-duration <n>   max duration in seconds
+  --no-max-duration    disable duration ceiling
+  --max-turns <n>      max agent turns
+  --no-max-turns       disable turns ceiling
+  --hitl <strategy>    elicit | auto | fail (default: elicit)
+  --name <name>        MCP server name (default: workflow name)
+  --log-file <path>    also write stderr log to a file
+```

--- a/agentflow/examples/mcp-server/__mocks__/claude
+++ b/agentflow/examples/mcp-server/__mocks__/claude
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Mock claude CLI for integration testing without real LLM.
+# Returns a hardcoded JSON greeting response.
+
+RESULT='{"greeting":"Hello, World! Great to meet you!"}'
+
+echo '{"type":"system","subtype":"init","session_id":"mock-session-greet","tools":[],"mcp_servers":[]}'
+echo "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":$(echo "$RESULT" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))'),\"session_id\":\"mock-session-greet\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20}}"

--- a/agentflow/examples/mcp-server/agents/greet.ts
+++ b/agentflow/examples/mcp-server/agents/greet.ts
@@ -1,0 +1,23 @@
+/**
+ * greet.ts — Greeter agent definition.
+ *
+ * Takes a `name` string and returns a friendly `greeting` string.
+ * The prompt is intentionally simple so the example works with any Claude model.
+ */
+
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+export const greetAgent = defineAgent({
+  runner: "claude",
+  model: "claude-haiku-4-5",
+  input: z.object({
+    name: z.string().describe("The name of the person to greet"),
+  }),
+  output: z.object({
+    greeting: z.string().describe("A friendly greeting message"),
+  }),
+  prompt: ({ name }) =>
+    `You are a friendly assistant. Greet the person named "${name}" warmly in one sentence. Reply ONLY with a JSON object matching: { "greeting": "<your message>" }`,
+  sanitizeInput: true,
+});

--- a/agentflow/examples/mcp-server/mcp-client.test.ts
+++ b/agentflow/examples/mcp-server/mcp-client.test.ts
@@ -1,0 +1,104 @@
+/**
+ * mcp-client-test.ts — MCP SDK InMemoryTransport integration test.
+ *
+ * Uses @modelcontextprotocol/sdk's InMemoryTransport + Client to verify:
+ *   1. Client can list the workflow tool via tools/list
+ *   2. Client can call the tool and receive a greeting via tools/call
+ *   3. Invalid input returns isError: true
+ *
+ * No real Claude calls are made — the executor is replaced with a minimal
+ * mock via the runWorkflow injection point on createMcpServer.
+ */
+
+import { createMcpServer } from "@ageflow/mcp-server";
+import type { RunWorkflowFn } from "@ageflow/mcp-server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import workflow from "./workflow.js";
+
+// ─── Mock RunWorkflowFn ───────────────────────────────────────────────────────
+
+/**
+ * Mock executor: returns a greeting without calling Claude.
+ * The input arrives as the validated input object from the boundary task.
+ */
+const mockRunWorkflow: RunWorkflowFn = async (args) => {
+  const input = args.input as { name: string };
+  return { greeting: `Hello, ${input.name}!` };
+};
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("mcp-server example — InMemoryTransport client test", () => {
+  let client: Client;
+  let stderrLines: string[];
+
+  beforeEach(async () => {
+    stderrLines = [];
+
+    const handle = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+      runWorkflow: mockRunWorkflow,
+    });
+
+    // Create linked in-memory transports: one for the server, one for the client.
+    const [serverTransport, clientTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    // Dynamic import so we don't pull in the SDK server at the module level.
+    const { startStdioTransport } = await import("@ageflow/mcp-server");
+
+    await startStdioTransport({
+      serverName: "greet-server",
+      serverVersion: "0.1.0",
+      handle,
+      transport: serverTransport,
+      stderr: (line) => stderrLines.push(line),
+    });
+
+    client = new Client(
+      { name: "test-client", version: "0.0.1" },
+      { capabilities: {} },
+    );
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it("prints startup banner to stderr", () => {
+    expect(stderrLines.join("")).toMatch(/ageflow mcp.*greet-server/);
+  });
+
+  it("lists the greet tool", async () => {
+    const { tools } = await client.listTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("greet");
+    expect(tools[0]?.description).toMatch(/Greet a person/i);
+  });
+
+  it("tools/call returns a greeting", async () => {
+    const result = await client.callTool({
+      name: "greet",
+      arguments: { name: "Alice" },
+    });
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as { type: string; text: string }[])[0]?.text;
+    const parsed = JSON.parse(text ?? "{}") as { greeting: string };
+    expect(parsed.greeting).toBe("Hello, Alice!");
+  });
+
+  it("tools/call with invalid input returns isError: true", async () => {
+    const result = await client.callTool({
+      name: "greet",
+      arguments: { name: 42 }, // name must be string
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as { type: string; text: string }[])[0]?.text;
+    expect(text).toMatch(/schema validation failed/i);
+  });
+});

--- a/agentflow/examples/mcp-server/package.json
+++ b/agentflow/examples/mcp-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ageflow/example-mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "serve": "agentwf mcp serve workflow.ts",
+    "serve:auto": "agentwf mcp serve workflow.ts --hitl auto",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "smoke": "PATH=\"$PWD/__mocks__:$PATH\" agentwf mcp serve workflow.ts --hitl auto"
+  },
+  "dependencies": {
+    "@ageflow/cli": "workspace:*",
+    "@ageflow/core": "workspace:*",
+    "@ageflow/runner-claude": "workspace:*"
+  },
+  "devDependencies": {
+    "@ageflow/mcp-server": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/agentflow/examples/mcp-server/tsconfig.json
+++ b/agentflow/examples/mcp-server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "paths": {}
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/agentflow/examples/mcp-server/workflow.ts
+++ b/agentflow/examples/mcp-server/workflow.ts
@@ -1,0 +1,37 @@
+/**
+ * workflow.ts — Minimal "greet" MCP workflow.
+ *
+ * Exposes a single `greet` tool via the MCP protocol:
+ *   Input:  { name: string }
+ *   Output: { greeting: string }
+ *
+ * Start the server:
+ *   bun run serve               # listens on stdio, HITL = elicit (default)
+ *   bun run serve:auto          # HITL = auto (no human approval needed)
+ *
+ * Or run the integration test:
+ *   bun run test
+ */
+
+import { defineWorkflow, registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+import { greetAgent } from "./agents/greet.js";
+
+// Register the Claude runner so executor can dispatch agent calls.
+// This is a top-level side effect that runs when the file is imported.
+registerRunner("claude", new ClaudeRunner());
+
+export default defineWorkflow({
+  name: "greet",
+  mcp: {
+    description: "Greet a person by name and return a friendly message.",
+    maxCostUsd: 0.1,
+    maxDurationSec: 30,
+    maxTurns: 5,
+  },
+  tasks: {
+    greet: {
+      agent: greetAgent,
+    },
+  },
+});

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ageflow/core": "workspace:*",
     "@ageflow/executor": "workspace:*",
+    "@ageflow/mcp-server": "workspace:*",
     "chalk": "^5.3.0",
     "ora": "^8.0.0",
     "boxen": "^8.0.0",

--- a/agentflow/packages/cli/src/__tests__/mcp-serve.test.ts
+++ b/agentflow/packages/cli/src/__tests__/mcp-serve.test.ts
@@ -1,0 +1,109 @@
+/**
+ * mcp-serve.test.ts
+ *
+ * Unit tests for parseMcpServeArgs — pure argv parsing, no process or I/O.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseMcpServeArgs } from "../commands/mcp-serve.js";
+
+describe("parseMcpServeArgs", () => {
+  it("parses workflow file as first positional", () => {
+    const args = parseMcpServeArgs(["workflow.ts"]);
+    expect(args.workflowFile).toBe("workflow.ts");
+    expect(args.hitlStrategy).toBe("elicit"); // default
+  });
+
+  it("parses --max-cost", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--max-cost", "1.5"]);
+    expect(args.maxCostUsd).toBe(1.5);
+  });
+
+  it("parses --no-max-cost as null", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--no-max-cost"]);
+    expect(args.maxCostUsd).toBeNull();
+  });
+
+  it("parses --max-duration", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--max-duration", "120"]);
+    expect(args.maxDurationSec).toBe(120);
+  });
+
+  it("parses --no-max-duration as null", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--no-max-duration"]);
+    expect(args.maxDurationSec).toBeNull();
+  });
+
+  it("parses --max-turns", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--max-turns", "10"]);
+    expect(args.maxTurns).toBe(10);
+  });
+
+  it("parses --no-max-turns as null", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--no-max-turns"]);
+    expect(args.maxTurns).toBeNull();
+  });
+
+  it("parses --hitl auto", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--hitl", "auto"]);
+    expect(args.hitlStrategy).toBe("auto");
+  });
+
+  it("parses --hitl fail", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--hitl", "fail"]);
+    expect(args.hitlStrategy).toBe("fail");
+  });
+
+  it("parses --name", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--name", "my-server"]);
+    expect(args.serverName).toBe("my-server");
+  });
+
+  it("parses --log-file", () => {
+    const args = parseMcpServeArgs(["wf.ts", "--log-file", "/tmp/mcp.log"]);
+    expect(args.logFile).toBe("/tmp/mcp.log");
+  });
+
+  it("combines multiple flags", () => {
+    const args = parseMcpServeArgs([
+      "workflow.ts",
+      "--max-cost",
+      "2",
+      "--hitl",
+      "auto",
+      "--max-turns",
+      "5",
+      "--name",
+      "greet-server",
+    ]);
+    expect(args.workflowFile).toBe("workflow.ts");
+    expect(args.maxCostUsd).toBe(2);
+    expect(args.hitlStrategy).toBe("auto");
+    expect(args.maxTurns).toBe(5);
+    expect(args.serverName).toBe("greet-server");
+  });
+
+  it("throws when no workflow file provided", () => {
+    expect(() => parseMcpServeArgs([])).toThrow(
+      /Missing required workflow file/,
+    );
+  });
+
+  it("throws on invalid --hitl value", () => {
+    expect(() => parseMcpServeArgs(["wf.ts", "--hitl", "invalid"])).toThrow(
+      /--hitl must be one of/,
+    );
+  });
+
+  it("throws on invalid --max-cost value", () => {
+    expect(() => parseMcpServeArgs(["wf.ts", "--max-cost", "abc"])).toThrow(
+      /--max-cost must be a non-negative number/,
+    );
+  });
+
+  it("throws on unknown flag", () => {
+    expect(() => parseMcpServeArgs(["wf.ts", "--unknown-flag"])).toThrow(
+      /Unknown flag/,
+    );
+  });
+});

--- a/agentflow/packages/cli/src/bin.ts
+++ b/agentflow/packages/cli/src/bin.ts
@@ -2,6 +2,7 @@
 import { program } from "commander";
 import { registerDryRunCommand } from "./commands/dry-run.js";
 import { registerInitCommand } from "./commands/init.js";
+import { registerMcpCommand } from "./commands/mcp-serve.js";
 import { registerRunCommand } from "./commands/run.js";
 import { registerValidateCommand } from "./commands/validate.js";
 
@@ -14,5 +15,6 @@ registerRunCommand(program);
 registerValidateCommand(program);
 registerDryRunCommand(program);
 registerInitCommand(program);
+registerMcpCommand(program);
 
 program.parse();

--- a/agentflow/packages/cli/src/commands/mcp-serve.ts
+++ b/agentflow/packages/cli/src/commands/mcp-serve.ts
@@ -1,0 +1,277 @@
+/**
+ * mcp-serve.ts
+ *
+ * Implements `agentwf mcp serve <workflow>` CLI subcommand.
+ *
+ * Flags:
+ *   --max-cost <n>        maximum cost in USD (overrides workflow.mcp.maxCostUsd)
+ *   --no-max-cost         disable cost ceiling (null)
+ *   --max-duration <n>    maximum duration in seconds
+ *   --no-max-duration     disable duration ceiling
+ *   --max-turns <n>       maximum agent turns
+ *   --no-max-turns        disable turns ceiling
+ *   --hitl <strategy>     HITL strategy: elicit | auto | fail (default: elicit)
+ *   --name <name>         MCP server name (default: workflow name)
+ *   --log-file <path>     write stderr log to a file
+ *
+ * Uses raw argv parsing so the unit test can import parseMcpServeArgs directly.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { WorkflowDef } from "@ageflow/core";
+import type { CliCeilings, HitlStrategy } from "@ageflow/mcp-server";
+import { createMcpServer, startStdioTransport } from "@ageflow/mcp-server";
+import type { Command } from "commander";
+
+// ─── Args model ──────────────────────────────────────────────────────────────
+
+export interface McpServeArgs {
+  readonly workflowFile: string;
+  readonly maxCostUsd?: number | null;
+  readonly maxDurationSec?: number | null;
+  readonly maxTurns?: number | null;
+  readonly hitlStrategy: HitlStrategy;
+  readonly serverName?: string;
+  readonly logFile?: string;
+}
+
+// ─── Raw argv parser ─────────────────────────────────────────────────────────
+
+/**
+ * Parse raw argv array into McpServeArgs.
+ *
+ * Expected argv: the slice AFTER `agentwf mcp serve`, e.g.
+ *   ["workflow.ts", "--max-cost", "1.5", "--hitl", "auto"]
+ *
+ * The workflowFile is the first positional argument.
+ */
+export function parseMcpServeArgs(argv: readonly string[]): McpServeArgs {
+  const args = [...argv];
+
+  // Extract workflow file (first non-flag argument)
+  const workflowIdx = args.findIndex((a) => !a.startsWith("-"));
+  if (workflowIdx === -1) {
+    throw new Error(
+      "Usage: agentwf mcp serve <workflow.ts> [flags]\n  Missing required workflow file argument.",
+    );
+  }
+  const workflowFile = args[workflowIdx] as string;
+  args.splice(workflowIdx, 1);
+
+  let maxCostUsd: number | null | undefined = undefined;
+  let maxDurationSec: number | null | undefined = undefined;
+  let maxTurns: number | null | undefined = undefined;
+  let hitlStrategy: HitlStrategy = "elicit";
+  let serverName: string | undefined = undefined;
+  let logFile: string | undefined = undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const flag = args[i];
+    switch (flag) {
+      case "--max-cost": {
+        const val = args[++i];
+        if (val === undefined || val.startsWith("-")) {
+          throw new Error("--max-cost requires a numeric argument");
+        }
+        const n = Number(val);
+        if (!Number.isFinite(n) || n < 0) {
+          throw new Error(
+            `--max-cost must be a non-negative number, got: ${val}`,
+          );
+        }
+        maxCostUsd = n;
+        break;
+      }
+      case "--no-max-cost":
+        maxCostUsd = null;
+        break;
+
+      case "--max-duration": {
+        const val = args[++i];
+        if (val === undefined || val.startsWith("-")) {
+          throw new Error("--max-duration requires a numeric argument");
+        }
+        const n = Number(val);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new Error(
+            `--max-duration must be a positive number, got: ${val}`,
+          );
+        }
+        maxDurationSec = n;
+        break;
+      }
+      case "--no-max-duration":
+        maxDurationSec = null;
+        break;
+
+      case "--max-turns": {
+        const val = args[++i];
+        if (val === undefined || val.startsWith("-")) {
+          throw new Error("--max-turns requires a numeric argument");
+        }
+        const n = Number(val);
+        if (!Number.isInteger(n) || n <= 0) {
+          throw new Error(
+            `--max-turns must be a positive integer, got: ${val}`,
+          );
+        }
+        maxTurns = n;
+        break;
+      }
+      case "--no-max-turns":
+        maxTurns = null;
+        break;
+
+      case "--hitl": {
+        const val = args[++i];
+        if (val !== "elicit" && val !== "auto" && val !== "fail") {
+          throw new Error(
+            `--hitl must be one of: elicit | auto | fail, got: ${val}`,
+          );
+        }
+        hitlStrategy = val;
+        break;
+      }
+
+      case "--name": {
+        const val = args[++i];
+        if (val === undefined || val.startsWith("-")) {
+          throw new Error("--name requires a string argument");
+        }
+        serverName = val;
+        break;
+      }
+
+      case "--log-file": {
+        const val = args[++i];
+        if (val === undefined || val.startsWith("-")) {
+          throw new Error("--log-file requires a path argument");
+        }
+        logFile = val;
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return {
+    workflowFile,
+    hitlStrategy,
+    ...(maxCostUsd !== undefined ? { maxCostUsd } : {}),
+    ...(maxDurationSec !== undefined ? { maxDurationSec } : {}),
+    ...(maxTurns !== undefined ? { maxTurns } : {}),
+    ...(serverName !== undefined ? { serverName } : {}),
+    ...(logFile !== undefined ? { logFile } : {}),
+  };
+}
+
+// ─── Run action ───────────────────────────────────────────────────────────────
+
+async function runMcpServe(rawArgv: string[]): Promise<void> {
+  let parsed: McpServeArgs;
+  try {
+    parsed = parseMcpServeArgs(rawArgv);
+  } catch (err) {
+    process.stderr.write(
+      `agentwf mcp serve: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  // Load workflow file
+  const resolvedPath = path.resolve(parsed.workflowFile);
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(resolvedPath)) as Record<string, unknown>;
+  } catch (importErr) {
+    process.stderr.write(
+      `Cannot import workflow file "${parsed.workflowFile}": ${
+        importErr instanceof Error ? importErr.message : String(importErr)
+      }\n`,
+    );
+    process.exit(1);
+  }
+
+  const workflow = (mod.default ?? mod.workflow) as WorkflowDef | undefined;
+
+  if (workflow === undefined || !("tasks" in workflow)) {
+    process.stderr.write(
+      `Invalid workflow file: must export a default WorkflowDef (found: ${typeof (mod.default ?? mod.workflow)})\n`,
+    );
+    process.exit(1);
+  }
+
+  // Build ceilings
+  const cliCeilings: CliCeilings = {
+    ...(parsed.maxCostUsd !== undefined
+      ? { maxCostUsd: parsed.maxCostUsd }
+      : {}),
+    ...(parsed.maxDurationSec !== undefined
+      ? { maxDurationSec: parsed.maxDurationSec }
+      : {}),
+    ...(parsed.maxTurns !== undefined ? { maxTurns: parsed.maxTurns } : {}),
+  };
+
+  // Determine server name
+  const serverName = parsed.serverName ?? workflow.name;
+
+  // Set up stderr writer (optionally tee to a log file)
+  let logStream: fs.WriteStream | undefined = undefined;
+  if (parsed.logFile !== undefined) {
+    logStream = fs.createWriteStream(parsed.logFile, { flags: "a" });
+  }
+
+  const stderr = (line: string): void => {
+    process.stderr.write(line);
+    logStream?.write(line);
+  };
+
+  // Create MCP server handle
+  const handle = createMcpServer({
+    workflow,
+    cliCeilings,
+    hitlStrategy: parsed.hitlStrategy,
+    stderr,
+  });
+
+  // Start stdio transport
+  await startStdioTransport({
+    serverName,
+    serverVersion: "0.1.0",
+    handle,
+    stderr,
+  });
+}
+
+// ─── Commander registration ───────────────────────────────────────────────────
+
+export function registerMcpCommand(program: Command): void {
+  const mcp = program
+    .command("mcp")
+    .description("MCP server integration commands");
+
+  mcp
+    .command("serve <workflow> [args...]")
+    .description(
+      "Expose a workflow as an MCP tool via stdio transport\n\n" +
+        "Flags (passed after the workflow file):\n" +
+        "  --max-cost <n>       max cost in USD\n" +
+        "  --no-max-cost        disable cost ceiling\n" +
+        "  --max-duration <n>   max duration in seconds\n" +
+        "  --no-max-duration    disable duration ceiling\n" +
+        "  --max-turns <n>      max agent turns\n" +
+        "  --no-max-turns       disable turns ceiling\n" +
+        "  --hitl <strategy>    elicit | auto | fail (default: elicit)\n" +
+        "  --name <name>        MCP server name\n" +
+        "  --log-file <path>    log stderr to file",
+    )
+    .allowUnknownOption(true) // raw flags parsed manually
+    .action(async (workflowFile: string, extraArgs: string[]) => {
+      // Reconstruct argv for the raw parser
+      const argv = [workflowFile, ...extraArgs];
+      await runMcpServe(argv);
+    });
+}

--- a/agentflow/packages/mcp-server/src/__tests__/stdio-transport.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/stdio-transport.test.ts
@@ -1,0 +1,121 @@
+/**
+ * stdio-transport.test.ts
+ *
+ * Verifies that startStdioTransport wires the SDK Server correctly by using
+ * InMemoryTransport + Client (no real stdio involved).
+ */
+
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { RunWorkflowFn } from "../server.js";
+import { createMcpServer } from "../server.js";
+import { startStdioTransport } from "../stdio-transport.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const greetAgent = defineAgent({
+  runner: "claude",
+  model: "claude-sonnet-4-6",
+  input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
+  prompt: ({ name }) => `say hi to ${name}`,
+});
+
+const workflow = defineWorkflow({
+  name: "greet",
+  mcp: { description: "Greet someone", maxCostUsd: 0.5 },
+  tasks: { greet: { agent: greetAgent } },
+});
+
+/** Minimal runWorkflow that immediately returns a greeting. */
+const mockRunWorkflow: RunWorkflowFn = async (args) => {
+  const input = args.input as { name: string };
+  return { greeting: `hello, ${input.name}!` };
+};
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("startStdioTransport (InMemoryTransport)", () => {
+  let client: Client;
+  let stderrLines: string[];
+
+  beforeEach(async () => {
+    stderrLines = [];
+
+    const handle = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+      runWorkflow: mockRunWorkflow,
+    });
+
+    const [serverTransport, clientTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    // Start transport (server side)
+    await startStdioTransport({
+      serverName: "test-server",
+      serverVersion: "0.0.1",
+      handle,
+      transport: serverTransport,
+      stderr: (line) => {
+        stderrLines.push(line);
+      },
+    });
+
+    // Connect client side
+    client = new Client(
+      { name: "test-client", version: "0.0.1" },
+      { capabilities: {} },
+    );
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it("emits startup banner to stderr", () => {
+    expect(stderrLines.join("")).toMatch(/ageflow mcp.*test-server.*0\.0\.1/);
+  });
+
+  it("tools/list returns the workflow tool", async () => {
+    const { tools } = await client.listTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("greet");
+    expect(tools[0]?.description).toBe("Greet someone");
+  });
+
+  it("tools/call returns the greeting", async () => {
+    const result = await client.callTool({
+      name: "greet",
+      arguments: { name: "World" },
+    });
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as { type: string; text: string }[])[0]?.text;
+    const parsed = JSON.parse(text ?? "{}") as { greeting: string };
+    expect(parsed.greeting).toBe("hello, World!");
+  });
+
+  it("tools/call with invalid input returns isError: true", async () => {
+    const result = await client.callTool({
+      name: "greet",
+      arguments: { name: 123 }, // invalid — name must be string
+    });
+    expect(result.isError).toBe(true);
+    // The error message in content text references the validation failure
+    const text = (result.content as { type: string; text: string }[])[0]?.text;
+    expect(text).toMatch(/schema validation failed/i);
+  });
+
+  it("tools/call unknown tool returns isError: true", async () => {
+    const result = await client.callTool({
+      name: "nonexistent",
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/agentflow/packages/mcp-server/src/index.ts
+++ b/agentflow/packages/mcp-server/src/index.ts
@@ -5,5 +5,9 @@ export type {
   McpToolResult,
   RunWorkflowFn,
 } from "./server.js";
+export {
+  startStdioTransport,
+} from "./stdio-transport.js";
+export type { StdioTransportOptions } from "./stdio-transport.js";
 export type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
 export { ErrorCode, McpServerError } from "./errors.js";

--- a/agentflow/packages/mcp-server/src/index.ts
+++ b/agentflow/packages/mcp-server/src/index.ts
@@ -5,9 +5,7 @@ export type {
   McpToolResult,
   RunWorkflowFn,
 } from "./server.js";
-export {
-  startStdioTransport,
-} from "./stdio-transport.js";
+export { startStdioTransport } from "./stdio-transport.js";
 export type { StdioTransportOptions } from "./stdio-transport.js";
 export type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
 export { ErrorCode, McpServerError } from "./errors.js";

--- a/agentflow/packages/mcp-server/src/stdio-transport.ts
+++ b/agentflow/packages/mcp-server/src/stdio-transport.ts
@@ -62,7 +62,7 @@ function makeProgressSender(
 
 function makeConnection(
   sdkServer: Server,
-  sendNotification: (n: {
+  _sendNotification: (n: {
     method: string;
     params: Record<string, unknown>;
   }) => Promise<void>,
@@ -79,21 +79,26 @@ function makeConnection(
       message: string;
       requestedSchema: Record<string, unknown>;
     }): Promise<ElicitationResponse> {
+      // biome-ignore lint/suspicious/noExplicitAny: ElicitRequestFormParams.requestedSchema.properties is a complex union type; cast via any is necessary
+      const properties = req.requestedSchema.properties as any;
+      const required = (req.requestedSchema.required ?? []) as string[];
+
       const result = await sdkServer.elicitInput({
         message: req.message,
         requestedSchema: {
           type: "object" as const,
-          properties: req.requestedSchema.properties as Record<
-            string,
-            { type: string; description?: string }
-          >,
-          required: (req.requestedSchema.required ?? []) as string[],
+          properties,
+          required,
         },
       });
-      return {
+
+      const response: ElicitationResponse = {
         action: result.action,
-        content: result.content as Record<string, unknown> | undefined,
+        ...(result.content !== undefined
+          ? { content: result.content as Record<string, unknown> }
+          : {}),
       };
+      return response;
     },
   };
 }
@@ -143,11 +148,13 @@ export async function startStdioTransport(
     const connection = makeConnection(sdkServer, extra.sendNotification);
     const sendProgress = makeProgressSender(extra.sendNotification);
 
-    const result = await handle.callTool(toolName, args, {
-      connection,
-      progressToken: progressToken ?? undefined,
-      sendProgress: progressToken !== undefined ? sendProgress : undefined,
-    });
+    // exactOptionalPropertyTypes: only pass progressToken/sendProgress when defined
+    const callOpts =
+      progressToken !== undefined
+        ? { connection, progressToken, sendProgress }
+        : { connection };
+
+    const result = await handle.callTool(toolName, args, callOpts);
 
     return {
       content: result.content as { type: "text"; text: string }[],

--- a/agentflow/packages/mcp-server/src/stdio-transport.ts
+++ b/agentflow/packages/mcp-server/src/stdio-transport.ts
@@ -1,0 +1,166 @@
+/**
+ * stdio-transport.ts
+ *
+ * Wires @modelcontextprotocol/sdk's Server around the createMcpServer handle,
+ * then connects to a transport (StdioServerTransport in production,
+ * InMemoryTransport in tests).
+ *
+ * Handles:
+ *   - tools/list  → handle.listTools()
+ *   - tools/call  → handle.callTool() with progress streaming + elicitation bridge
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { ElicitationResponse, McpConnectionLike } from "./hitl-bridge.js";
+import type { ProgressPayload, SendProgress } from "./progress-streamer.js";
+import type { McpServerHandle } from "./server.js";
+
+// ─── Public options ──────────────────────────────────────────────────────────
+
+export interface StdioTransportOptions {
+  /** Human-readable server name (advertised during initialization). */
+  readonly serverName: string;
+  /** Server version string. */
+  readonly serverVersion: string;
+  /** The workflow server handle from createMcpServer(). */
+  readonly handle: McpServerHandle;
+  /** Optional stderr writer override (for testing). */
+  readonly stderr?: (line: string) => void;
+  /**
+   * Transport override for testing.  When omitted a StdioServerTransport is
+   * created automatically.
+   */
+  readonly transport?: Transport;
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+function makeProgressSender(
+  sendNotification: (n: {
+    method: string;
+    params: Record<string, unknown>;
+  }) => Promise<void>,
+): SendProgress {
+  return (payload: ProgressPayload): void => {
+    void sendNotification({
+      method: "notifications/progress",
+      params: {
+        progressToken: payload.progressToken,
+        progress: payload.progress,
+        ...(payload.total !== undefined ? { total: payload.total } : {}),
+        ...(payload.message !== undefined ? { message: payload.message } : {}),
+      },
+    });
+  };
+}
+
+function makeConnection(
+  sdkServer: Server,
+  sendNotification: (n: {
+    method: string;
+    params: Record<string, unknown>;
+  }) => Promise<void>,
+): McpConnectionLike {
+  return {
+    supports(capability: "elicitation" | "progress"): boolean {
+      if (capability === "elicitation") {
+        return sdkServer.getClientCapabilities()?.elicitation !== undefined;
+      }
+      return true;
+    },
+
+    async elicit(req: {
+      message: string;
+      requestedSchema: Record<string, unknown>;
+    }): Promise<ElicitationResponse> {
+      const result = await sdkServer.elicitInput({
+        message: req.message,
+        requestedSchema: {
+          type: "object" as const,
+          properties: req.requestedSchema.properties as Record<
+            string,
+            { type: string; description?: string }
+          >,
+          required: (req.requestedSchema.required ?? []) as string[],
+        },
+      });
+      return {
+        action: result.action,
+        content: result.content as Record<string, unknown> | undefined,
+      };
+    },
+  };
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Register tools/list and tools/call handlers on a freshly-created SDK Server
+ * and connect it to the given transport (or stdio when none provided).
+ *
+ * Returns the connected Server so callers can close it in tests.
+ */
+export async function startStdioTransport(
+  opts: StdioTransportOptions,
+): Promise<Server> {
+  const { serverName, serverVersion, handle, transport } = opts;
+
+  const writeStderr =
+    opts.stderr ??
+    ((line: string) => {
+      process.stderr.write(line);
+    });
+
+  const sdkServer = new Server(
+    { name: serverName, version: serverVersion },
+    { capabilities: { tools: {} } },
+  );
+
+  // ── tools/list ────────────────────────────────────────────────────────────
+  sdkServer.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = await handle.listTools();
+    return {
+      tools: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    };
+  });
+
+  // ── tools/call ────────────────────────────────────────────────────────────
+  sdkServer.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    const toolName = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const progressToken = request.params._meta?.progressToken;
+
+    const connection = makeConnection(sdkServer, extra.sendNotification);
+    const sendProgress = makeProgressSender(extra.sendNotification);
+
+    const result = await handle.callTool(toolName, args, {
+      connection,
+      progressToken: progressToken ?? undefined,
+      sendProgress: progressToken !== undefined ? sendProgress : undefined,
+    });
+
+    return {
+      content: result.content as { type: "text"; text: string }[],
+      isError: result.isError,
+    };
+  });
+
+  const actualTransport = transport ?? new StdioServerTransport();
+
+  writeStderr(
+    `[ageflow mcp] ${serverName}@${serverVersion} listening on ${transport !== undefined ? "transport" : "stdio"}\n`,
+  );
+
+  await sdkServer.connect(actualTransport);
+  return sdkServer;
+}


### PR DESCRIPTION
## Summary

Transport layer + CLI + working example — the MCP server is now usable end-to-end.

- **Task 14** \`stdio-transport.ts\` — wires SDK \`Server\` (\`@modelcontextprotocol/sdk@1.29.0\`) with tools/list, tools/call handlers; progress via \`notifications/progress\`; HITL via \`server.elicitInput()\`
- **Task 15** \`agentwf mcp serve\` — CLI subcommand with full flag set (\`--max-cost\`, \`--no-max-*\`, \`--hitl elicit|auto|fail\`, \`--name\`, \`--log-file\`); 16 argv tests
- **Task 16** \`examples/mcp-server/\` — micro-workflow (greet agent), README with Claude Desktop config snippet
- **Task 17** integration test — InMemoryTransport + MCP Client end-to-end (list + call greet tool)

## Gates

- BUILD ✓ 4 feat commits + 1 lint fix, TDD per plan
- TEST ✓ 58 mcp-server tests + 40 CLI tests + 4 example tests = 102 total
- VERIFY ✓ parallel:
  - code-reviewer: APPROVED (1 Important: missing SIGTERM handlers → logged as #27)
  - reality-checker: APPROVED (1 lint nit, fixed in 42543d8)

## SDK deviation from plan

Plan pseudocode used \`server.request({method: "elicitation/create", ...})\`. Real SDK 1.29.0 exposes \`server.elicitInput(params)\` directly — used real API.

## Follow-up: #27 — graceful shutdown (SIGTERM/SIGINT + stdin close handling)