### PR TITLE
feat(dogfooding): enable MCP exposure for dev-pipeline

### DIFF
--- a/agentflow/dogfooding/README.md
+++ b/agentflow/dogfooding/README.md
@@ -64,6 +64,23 @@ agentwf validate workflow.ts
 agentwf run workflow.ts
 ```
 
+## Expose to Claude Desktop via MCP
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ageflow-dev-pipeline": {
+      "command": "agentwf",
+      "args": ["mcp", "serve", "/absolute/path/to/agentflow/dogfooding/workflow.ts"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The tool `dev-pipeline` becomes available with progress streaming and HITL elicitation at the verify checkpoint.
+
 ## Difference from real orchestrator
 
 The real orchestrator in `/orchestrator` is a meta-agent that dynamically selects

--- a/agentflow/dogfooding/package.json
+++ b/agentflow/dogfooding/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "run": "agentwf run workflow.ts",
     "dry-run": "agentwf dry-run workflow.ts",
-    "validate": "agentwf validate workflow.ts"
+    "validate": "agentwf validate workflow.ts",
+    "serve": "agentwf mcp serve workflow.ts"
   },
   "dependencies": {
     "@ageflow/core": "workspace:*",

--- a/agentflow/dogfooding/workflow.ts
+++ b/agentflow/dogfooding/workflow.ts
@@ -155,6 +155,15 @@ type WorkflowTasks = {
 export default defineWorkflow({
   name: "dev-pipeline",
 
+  mcp: {
+    description: "Run the full ageflow dev pipeline: plan → build → test → verify → ship.",
+    maxCostUsd: 10,
+    maxDurationSec: 1800,
+    maxTurns: 100,
+    inputTask: "plan",
+    outputTask: "ship",
+  },
+
   // CEO approval gate: if plan flags requiresCeoApproval, pause before SHIP
   hooks: {
     onCheckpoint: async (taskName: string) => {


### PR DESCRIPTION
Adds \`mcp:\` block to dogfooding workflow with safe ceilings ($10, 30min, 100 turns).
Adds \`serve\` script + Claude Desktop config snippet in README.
Validates + dry-runs clean.