### PR TITLE
fix(cli): graceful shutdown for agentwf mcp serve — closes #27

### DIFF
--- a/agentflow/packages/cli/src/__tests__/mcp-serve.test.ts
+++ b/agentflow/packages/cli/src/__tests__/mcp-serve.test.ts
@@ -2,10 +2,84 @@
  * mcp-serve.test.ts
  *
  * Unit tests for parseMcpServeArgs — pure argv parsing, no process or I/O.
+ * Also includes a subprocess test for graceful SIGTERM shutdown.
  */
 
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parseMcpServeArgs } from "../commands/mcp-serve.js";
+
+// ─── Graceful shutdown test ───────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+/** Absolute path to the agentflow monorepo root (4 levels up from __tests__). */
+const MONOREPO_ROOT = path.resolve(__dirname, "../../../../");
+const CLI_BIN = path.join(MONOREPO_ROOT, "packages/cli/src/bin.ts");
+const WORKFLOW = path.join(MONOREPO_ROOT, "examples/mcp-server/workflow.ts");
+
+describe("mcp serve graceful shutdown", () => {
+  it(
+    "exits with code 0 after SIGTERM",
+    async () => {
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(
+          "bun",
+          ["run", CLI_BIN, "mcp", "serve", WORKFLOW, "--hitl", "auto"],
+          { stdio: ["pipe", "pipe", "pipe"] },
+        );
+
+        let stderrBuf = "";
+        let settled = false;
+
+        const done = (err?: Error) => {
+          if (settled) return;
+          settled = true;
+          if (err) reject(err);
+          else resolve();
+        };
+
+        // Emit SIGTERM after seeing the startup banner on stderr.
+        // A short delay ensures the signal handlers are registered before
+        // the signal arrives (handlers are registered after connect resolves).
+        child.stderr.on("data", (chunk: Buffer) => {
+          stderrBuf += chunk.toString();
+          if (stderrBuf.includes("listening on stdio") && !settled) {
+            setTimeout(() => child.kill("SIGTERM"), 100);
+          }
+        });
+
+        child.on("exit", (code, signal) => {
+          if (code === 0) {
+            done();
+          } else {
+            done(
+              new Error(
+                `Expected exit code 0 but got code=${code} signal=${signal}`,
+              ),
+            );
+          }
+        });
+
+        child.on("error", done);
+
+        // Hard timeout — if the server never starts or never exits, fail the test.
+        setTimeout(() => {
+          if (!settled) {
+            child.kill("SIGKILL");
+            done(
+              new Error(
+                `Server did not start or did not exit within 5 s. stderr=${stderrBuf}`,
+              ),
+            );
+          }
+        }, 5000);
+      });
+    },
+    { timeout: 8000 },
+  );
+});
 
 describe("parseMcpServeArgs", () => {
   it("parses workflow file as first positional", () => {

--- a/agentflow/packages/cli/src/commands/mcp-serve.ts
+++ b/agentflow/packages/cli/src/commands/mcp-serve.ts
@@ -238,12 +238,27 @@ async function runMcpServe(rawArgv: string[]): Promise<void> {
   });
 
   // Start stdio transport
-  await startStdioTransport({
+  const server = await startStdioTransport({
     serverName,
     serverVersion: "0.1.0",
     handle,
     stderr,
   });
+
+  // Graceful shutdown: close SDK server, flush log file, exit cleanly.
+  const shutdown = async (): Promise<void> => {
+    try {
+      await server.close();
+    } catch {
+      // ignore close errors — we're shutting down anyway
+    }
+    logStream?.end();
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+  process.stdin.on("end", shutdown);
 }
 
 // ─── Commander registration ───────────────────────────────────────────────────


### PR DESCRIPTION
Adds SIGTERM/SIGINT/stdin-end handlers: server.close() + logStream flush + process.exit(0). Subprocess test verifies clean exit.