### PR TITLE
fix(executor): inject systemPrompt with output JSON schema — closes #6

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -92,6 +92,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
+        "zod-to-json-schema": "^3.23.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -19,7 +19,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*"
+    "@ageflow/core": "workspace:*",
+    "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agentflow/packages/executor/src/__tests__/node-runner.test.ts
+++ b/agentflow/packages/executor/src/__tests__/node-runner.test.ts
@@ -350,4 +350,67 @@ describe("runNode", () => {
     const inputUsed = promptSpy.mock.calls[0]?.[0] as { text: string };
     expect(inputUsed.text).toContain("\n---\n");
   });
+
+  it("passes a systemPrompt to the runner containing the output JSON schema", async () => {
+    let capturedSystemPrompt: string | undefined;
+
+    const runner: import("@ageflow/core").Runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn(
+        async (args: import("@ageflow/core").RunnerSpawnArgs) => {
+          capturedSystemPrompt = args.systemPrompt;
+          return makeSuccessResult({ result: "ok" });
+        },
+      ),
+    };
+
+    const task = { agent: simpleAgent };
+    await Promise.all([
+      runNode(task, { text: "hello" }, runner, "schema-prompt-task"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(capturedSystemPrompt).toBeDefined();
+    expect(capturedSystemPrompt).toContain("You MUST respond with valid JSON");
+    // Output schema has a "result" string field — it should appear in the prompt
+    expect(capturedSystemPrompt).toContain('"result"');
+  });
+
+  it("systemPrompt includes the exact schema keys from the agent output", async () => {
+    const detailedAgent = defineAgent({
+      runner: "mock",
+      input: z.object({ query: z.string() }),
+      output: z.object({
+        title: z.string(),
+        score: z.number(),
+        tags: z.array(z.string()),
+      }),
+      prompt: ({ query }) => `Search: ${query}`,
+    });
+
+    let capturedSystemPrompt: string | undefined;
+    const runner: import("@ageflow/core").Runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn(
+        async (args: import("@ageflow/core").RunnerSpawnArgs) => {
+          capturedSystemPrompt = args.systemPrompt;
+          return makeSuccessResult({ title: "t", score: 1, tags: [] });
+        },
+      ),
+    };
+
+    await Promise.all([
+      runNode(
+        { agent: detailedAgent },
+        { query: "test" },
+        runner,
+        "schema-keys-task",
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(capturedSystemPrompt).toContain('"title"');
+    expect(capturedSystemPrompt).toContain('"score"');
+    expect(capturedSystemPrompt).toContain('"tags"');
+  });
 });

--- a/agentflow/packages/executor/src/__tests__/schema-prompt.test.ts
+++ b/agentflow/packages/executor/src/__tests__/schema-prompt.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildOutputSchemaPrompt } from "../schema-prompt.js";
+
+describe("buildOutputSchemaPrompt", () => {
+  it("includes the JSON schema for a simple object schema", () => {
+    const schema = z.object({
+      result: z.string(),
+      score: z.number(),
+    });
+
+    const prompt = buildOutputSchemaPrompt(schema);
+
+    expect(prompt).toContain("You MUST respond with valid JSON");
+    expect(prompt).toContain('"result"');
+    expect(prompt).toContain('"score"');
+    expect(prompt).toContain('"type": "string"');
+    expect(prompt).toContain('"type": "number"');
+  });
+
+  it("instructs agent not to include text before or after the JSON", () => {
+    const schema = z.object({ value: z.string() });
+    const prompt = buildOutputSchemaPrompt(schema);
+
+    expect(prompt).toContain("Do not include any text");
+  });
+
+  it("wraps schema in a code fence", () => {
+    const schema = z.object({ ok: z.boolean() });
+    const prompt = buildOutputSchemaPrompt(schema);
+
+    expect(prompt).toContain("```json");
+    expect(prompt).toContain("```");
+  });
+
+  it("does not include the $schema meta-field", () => {
+    const schema = z.object({ x: z.string() });
+    const prompt = buildOutputSchemaPrompt(schema);
+
+    expect(prompt).not.toContain('"$schema"');
+    expect(prompt).not.toContain("json-schema.org");
+  });
+
+  it("produces valid JSON inside the fence", () => {
+    const schema = z.object({ items: z.array(z.string()), count: z.number() });
+    const prompt = buildOutputSchemaPrompt(schema);
+
+    const fenceMatch = /```json\s*([\s\S]*?)\s*```/.exec(prompt);
+    expect(fenceMatch).not.toBeNull();
+    const jsonStr = fenceMatch?.[1] ?? "";
+    expect(() => JSON.parse(jsonStr)).not.toThrow();
+  });
+
+  it("handles nested object schemas", () => {
+    const schema = z.object({
+      outer: z.object({
+        inner: z.string(),
+      }),
+    });
+
+    const prompt = buildOutputSchemaPrompt(schema);
+    expect(prompt).toContain('"outer"');
+    expect(prompt).toContain('"inner"');
+  });
+});

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -8,6 +8,7 @@ import type { AgentDef, AttemptRecord, Runner, TaskDef } from "@ageflow/core";
 import type { ZodType } from "zod";
 import { OutputValidationError } from "./errors.js";
 import { parseAgentOutput } from "./output-parser.js";
+import { buildOutputSchemaPrompt } from "./schema-prompt.js";
 
 export interface NodeRunResult<O> {
   output: O;
@@ -123,6 +124,7 @@ export async function runNode<
       const spawnArgs: import("@ageflow/core").RunnerSpawnArgs = {
         prompt,
         taskName,
+        systemPrompt: buildOutputSchemaPrompt(resolvedDef.output),
       };
       if (resolvedDef.model !== undefined) {
         spawnArgs.model = resolvedDef.model;

--- a/agentflow/packages/executor/src/schema-prompt.ts
+++ b/agentflow/packages/executor/src/schema-prompt.ts
@@ -1,0 +1,31 @@
+import type { ZodType } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+/**
+ * Build the system prompt that instructs an agent to respond with structured
+ * JSON conforming to the agent's output Zod schema.
+ *
+ * The generated JSON Schema is embedded verbatim so the agent knows the exact
+ * shape required. `output-parser.ts` enforces this contract on the way back.
+ */
+export function buildOutputSchemaPrompt(outputSchema: ZodType): string {
+  const jsonSchema = zodToJsonSchema(outputSchema, {
+    target: "jsonSchema7",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+
+  // Drop the $schema meta-field — not useful inside a system prompt
+  jsonSchema.$schema = undefined;
+
+  const schemaJson = JSON.stringify(jsonSchema, null, 2);
+
+  return [
+    "You MUST respond with valid JSON that matches this schema exactly.",
+    "Do not include any text, markdown, or explanation before or after the JSON object.",
+    "",
+    "Output schema:",
+    "```json",
+    schemaJson,
+    "```",
+  ].join("\n");
+}


### PR DESCRIPTION
node-runner now synthesizes a systemPrompt from agent.output Zod schema via zod-to-json-schema. Agents receive structured-output instruction on every call. 8 new tests.