### PR TITLE
feat: @ageflow/runner-api Phase 3 — SessionStore (#30)

### DIFF
--- a/agentflow/packages/runners/api/src/__tests__/session-store.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/session-store.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../openai-types.js";
+import { InMemorySessionStore } from "../session-store.js";
+
+const msg: ChatMessage = { role: "user", content: "hello" };
+
+describe("InMemorySessionStore", () => {
+  it("returns undefined for unknown handles", async () => {
+    const store = new InMemorySessionStore();
+    expect(await store.get("missing")).toBeUndefined();
+  });
+
+  it("round-trips messages via set/get", async () => {
+    const store = new InMemorySessionStore();
+    await store.set("h1", [msg]);
+    expect(await store.get("h1")).toEqual([msg]);
+  });
+
+  it("isolates keys", async () => {
+    const store = new InMemorySessionStore();
+    await store.set("a", [msg]);
+    await store.set("b", [{ role: "user", content: "other" }]);
+    expect((await store.get("a"))?.[0]?.content).toBe("hello");
+    expect((await store.get("b"))?.[0]?.content).toBe("other");
+  });
+
+  it("delete removes the handle", async () => {
+    const store = new InMemorySessionStore();
+    await store.set("gone", [msg]);
+    await store.delete("gone");
+    expect(await store.get("gone")).toBeUndefined();
+  });
+
+  it("stored snapshots are independent of the caller's array mutation", async () => {
+    const store = new InMemorySessionStore();
+    const live: ChatMessage[] = [msg];
+    await store.set("h", live);
+    live.push({ role: "user", content: "added after" });
+    const got = await store.get("h");
+    expect(got?.length).toBe(1);
+  });
+});

--- a/agentflow/packages/runners/api/src/openai-types.ts
+++ b/agentflow/packages/runners/api/src/openai-types.ts
@@ -1,0 +1,11 @@
+export type ChatMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string | null; tool_calls?: ToolCall[] }
+  | { role: "tool"; tool_call_id: string; content: string };
+
+export interface ToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}

--- a/agentflow/packages/runners/api/src/session-store.ts
+++ b/agentflow/packages/runners/api/src/session-store.ts
@@ -1,0 +1,28 @@
+import type { ChatMessage } from "./openai-types.js";
+
+export interface SessionStore {
+  get(handle: string): Promise<ChatMessage[] | undefined>;
+  set(handle: string, messages: ChatMessage[]): Promise<void>;
+  delete(handle: string): Promise<void>;
+}
+
+/**
+ * Default session store. Map<handle, ChatMessage[]>, process-local.
+ * Stores copies so external mutation cannot change recorded history.
+ */
+export class InMemorySessionStore implements SessionStore {
+  private readonly data = new Map<string, ChatMessage[]>();
+
+  async get(handle: string): Promise<ChatMessage[] | undefined> {
+    const got = this.data.get(handle);
+    return got ? [...got] : undefined;
+  }
+
+  async set(handle: string, messages: ChatMessage[]): Promise<void> {
+    this.data.set(handle, [...messages]);
+  }
+
+  async delete(handle: string): Promise<void> {
+    this.data.delete(handle);
+  }
+}


### PR DESCRIPTION
SessionStore interface + InMemorySessionStore implementation with defensive copies. Plus initial openai-types.ts (ChatMessage union, ToolCall). 5 tests.