### PR TITLE
feat: @ageflow/runner-api Phase 6-7 — validate() + backward-compat tests (#30)

### DIFF
--- a/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
@@ -119,3 +119,71 @@ describe("ApiRunner.spawn", () => {
     expect(body.messages[0]).toEqual({ role: "system", content: "be concise" });
   });
 });
+
+describe("ApiRunner.validate", () => {
+  it("returns ok + version from the first model id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: "gpt-4o" }, { id: "gpt-4o-mini" }] }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(true);
+    expect(res.version).toBe("gpt-4o");
+  });
+
+  it("returns { ok: false } on 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "bad",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("401");
+  });
+
+  it("returns { ok: false } when fetch throws", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const runner = new ApiRunner({
+      baseUrl: "http://localhost:1",
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("ECONNREFUSED");
+  });
+
+  it("trailing slash on baseUrl is normalized", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: "m" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1/",
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await runner.validate();
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toBe("https://example.test/v1/models");
+  });
+});

--- a/agentflow/packages/runners/api/src/__tests__/integration.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/integration.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { ApiRunner } from "../api-runner.js";
+
+const url = process.env.AGENTFLOW_TEST_API_URL;
+const key = process.env.AGENTFLOW_TEST_API_KEY;
+const model = process.env.AGENTFLOW_TEST_API_MODEL ?? "gpt-4o-mini";
+
+const maybe = url && key ? describe : describe.skip;
+
+maybe("ApiRunner (live)", () => {
+  it("completes a trivial prompt", async () => {
+    const runner = new ApiRunner({
+      baseUrl: url as string,
+      apiKey: key as string,
+      defaultModel: model,
+    });
+    const res = await runner.spawn({
+      prompt: "Reply with the single word: pong",
+    });
+    expect(res.stdout.toLowerCase()).toContain("pong");
+    expect(res.tokensIn).toBeGreaterThan(0);
+    expect(res.tokensOut).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -32,8 +32,27 @@ export class ApiRunner implements Runner {
   }
 
   async validate(): Promise<{ ok: boolean; version?: string; error?: string }> {
-    // Stub — real implementation is Phase 6
-    return { ok: true };
+    try {
+      const res = await this.fetch(`${this.baseUrl}/models`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          ...this.headers,
+        },
+      });
+      if (!res.ok) {
+        return {
+          ok: false,
+          error: `HTTP ${res.status} ${res.statusText}`.trim(),
+        };
+      }
+      const body = (await res.json()) as { data?: Array<{ id: string }> };
+      const version = body.data?.[0]?.id;
+      return { ok: true, ...(version !== undefined ? { version } : {}) };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
   }
 
   async spawn(args: RunnerSpawnArgs): Promise<RunnerSpawnResult> {

--- a/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
+++ b/agentflow/packages/runners/claude/src/__tests__/claude-runner.test.ts
@@ -397,4 +397,12 @@ describe("ClaudeRunner.spawn()", () => {
     expect(callArgs).toContain("json");
     expect(callArgs).toContain("--print");
   });
+
+  it("does not set toolCalls on RunnerSpawnResult", async () => {
+    const stdout = makeJsonlOutput("x");
+    const spawn = (): SpawnResult => makeSpawnResult(stdout);
+    const runner = new ClaudeRunner({ spawn });
+    const res = await runner.spawn({ prompt: "p" });
+    expect(res.toolCalls).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Phase 6: real validate() via GET /models with error handling. Phase 7: backward-compat test for claude runner (toolCalls undefined) + env-gated live integration test. 23 tests pass, 1 skipped.