### PR TITLE
feat: @ageflow/runner-api Phase 8-9 — example + docs/publish prep — closes #30

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -24,6 +24,21 @@
         "@types/node": "^22.0.0",
       },
     },
+    "examples/api-runner": {
+      "name": "@ageflow-example/api-runner",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
+        "@ageflow/runner-api": "workspace:*",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@ageflow/testing": "workspace:*",
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "examples/bug-fix-pipeline": {
       "name": "@ageflow/example-bug-fix-pipeline",
       "version": "0.1.0",
@@ -170,6 +185,8 @@
     "zod": "^3.23.0",
   },
   "packages": {
+    "@ageflow-example/api-runner": ["@ageflow-example/api-runner@workspace:examples/api-runner"],
+
     "@ageflow/cli": ["@ageflow/cli@workspace:packages/cli"],
 
     "@ageflow/core": ["@ageflow/core@workspace:packages/core"],

--- a/agentflow/examples/api-runner/README.md
+++ b/agentflow/examples/api-runner/README.md
@@ -1,0 +1,53 @@
+# api-runner example
+
+Minimal workflow showing `@ageflow/runner-api` calling any OpenAI-compatible
+endpoint to summarize a text string.
+
+## Running the demo
+
+### With a real endpoint
+
+```bash
+OPENAI_API_KEY=<your-key> bun run demo
+# or point at a local model:
+OPENAI_BASE_URL=http://localhost:11434/v1 OPENAI_API_KEY=ollama bun run demo
+```
+
+### Offline (mock fetch — no credentials needed)
+
+```bash
+AGENTFLOW_MOCK=1 bun run demo
+```
+
+## Running tests
+
+```bash
+bun run test
+```
+
+Uses `@ageflow/testing` harness — no real API calls.
+
+## Provider table
+
+| Provider     | OPENAI_BASE_URL                                                     |
+|--------------|---------------------------------------------------------------------|
+| OpenAI       | `https://api.openai.com/v1`                                         |
+| Groq         | `https://api.groq.com/openai/v1`                                    |
+| Together AI  | `https://api.together.xyz/v1`                                       |
+| Ollama       | `http://localhost:11434/v1`                                         |
+| vLLM         | `http://localhost:8000/v1`                                          |
+| LM Studio    | `http://localhost:1234/v1`                                          |
+| Azure OpenAI | `https://<resource>.openai.azure.com/openai/deployments/<model>`   |
+
+## Files
+
+```
+examples/api-runner/
+├── agents/
+│   └── summarize.ts       — defineAgent using runner: "api"
+├── __mocks__/
+│   └── fetch-mock.ts      — offline canned response
+├── workflow.ts            — registerRunner + defineWorkflow
+├── workflow.test.ts       — harness test (no real calls)
+└── README.md
+```

--- a/agentflow/examples/api-runner/__mocks__/fetch-mock.ts
+++ b/agentflow/examples/api-runner/__mocks__/fetch-mock.ts
@@ -1,0 +1,40 @@
+/**
+ * fetch-mock.ts — Offline fetch stub for the api-runner example.
+ *
+ * Returns a canned OpenAI-compatible ChatCompletionResponse so the demo
+ * can run without credentials.  Inject via:
+ *
+ *   AGENTFLOW_MOCK=1 bun run demo
+ */
+
+export function mockFetch(
+  _url: string | URL | Request,
+  _init?: RequestInit,
+): Promise<Response> {
+  const body = JSON.stringify({
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: JSON.stringify({
+            summary:
+              "AgentFlow ships an HTTP runner that talks to any OpenAI-compatible endpoint.",
+          }),
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 42,
+      completion_tokens: 18,
+      total_tokens: 60,
+    },
+  });
+
+  return Promise.resolve(
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}

--- a/agentflow/examples/api-runner/agents/summarize.ts
+++ b/agentflow/examples/api-runner/agents/summarize.ts
@@ -1,0 +1,23 @@
+/**
+ * summarize.ts — Summarizer agent definition.
+ *
+ * Takes a `text` string and returns a one-sentence `summary`.
+ * Expects the model to reply with JSON: { "summary": "<one sentence>" }
+ */
+
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+export const summarize = defineAgent({
+  runner: "api",
+  model: "gpt-4o-mini",
+  input: z.object({
+    text: z.string().describe("The text to summarize"),
+  }),
+  output: z.object({
+    summary: z.string().describe("A one-sentence summary"),
+  }),
+  prompt: (i) =>
+    `Summarize the following in one sentence. Reply ONLY with a JSON object matching: { "summary": "<one sentence>" }\n\n${i.text}`,
+  sanitizeInput: true,
+});

--- a/agentflow/examples/api-runner/package.json
+++ b/agentflow/examples/api-runner/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ageflow-example/api-runner",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "bun workflow.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ageflow/core": "workspace:*",
+    "@ageflow/runner-api": "workspace:*",
+    "@ageflow/executor": "workspace:*",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@ageflow/testing": "workspace:*",
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/agentflow/examples/api-runner/tsconfig.json
+++ b/agentflow/examples/api-runner/tsconfig.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "paths": {
-      "@ageflow/core": ["../../packages/core/src/index.ts"],
-      "@ageflow/runner-api": ["../../packages/runners/api/src/index.ts"],
-      "@ageflow/executor": ["../../packages/executor/src/index.ts"],
-      "@ageflow/testing": ["../../packages/testing/src/index.ts"]
-    }
+    "paths": {}
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "node_modules"]

--- a/agentflow/examples/api-runner/tsconfig.json
+++ b/agentflow/examples/api-runner/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "paths": {
+      "@ageflow/core": ["../../packages/core/src/index.ts"],
+      "@ageflow/runner-api": ["../../packages/runners/api/src/index.ts"],
+      "@ageflow/executor": ["../../packages/executor/src/index.ts"],
+      "@ageflow/testing": ["../../packages/testing/src/index.ts"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/agentflow/examples/api-runner/workflow.test.ts
+++ b/agentflow/examples/api-runner/workflow.test.ts
@@ -1,0 +1,31 @@
+/**
+ * workflow.test.ts — Harness-based test for the api-runner example workflow.
+ *
+ * Uses @ageflow/testing to mock the agent — no real API calls made.
+ */
+
+import { createTestHarness } from "@ageflow/testing";
+import { describe, expect, it } from "vitest";
+import { workflow } from "./workflow.js";
+
+describe("api-runner demo workflow", () => {
+  it("produces a summary via mock agent", async () => {
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("summarize", {
+      summary: "AgentFlow ships the api runner.",
+    });
+    const res = await harness.run({});
+    const summary = (res.outputs.summarize as { summary: string }).summary;
+    expect(summary.toLowerCase()).toContain("api runner");
+  });
+
+  it("records call stats for the summarize task", async () => {
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("summarize", { summary: "demo summary for stats" });
+    await harness.run({});
+    const stats = harness.getTask("summarize");
+    expect(stats.callCount).toBe(1);
+    expect(stats.retryCount).toBe(0);
+    expect(stats.outputs).toHaveLength(1);
+  });
+});

--- a/agentflow/examples/api-runner/workflow.ts
+++ b/agentflow/examples/api-runner/workflow.ts
@@ -1,0 +1,54 @@
+/**
+ * workflow.ts — Minimal "summarize" API runner workflow.
+ *
+ * Calls any OpenAI-compatible endpoint to produce a one-sentence summary.
+ *
+ * Run live (requires OPENAI_API_KEY or compatible endpoint):
+ *   bun run demo
+ *
+ * Run with injected mock fetch (no credentials needed):
+ *   AGENTFLOW_MOCK=1 bun run demo
+ *
+ * Run tests (always uses mock):
+ *   bun run test
+ */
+
+import { defineWorkflow, registerRunner } from "@ageflow/core";
+import { ApiRunner } from "@ageflow/runner-api";
+import { summarize } from "./agents/summarize.js";
+
+// In mock mode inject a canned fetch; otherwise use globalThis.fetch.
+const fetchImpl =
+  process.env.AGENTFLOW_MOCK === "1"
+    ? (await import("./__mocks__/fetch-mock.js")).mockFetch
+    : undefined;
+
+registerRunner(
+  "api",
+  new ApiRunner({
+    baseUrl: process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+    apiKey: process.env.OPENAI_API_KEY ?? "mock-key",
+    defaultModel: "gpt-4o-mini",
+    ...(fetchImpl ? { fetch: fetchImpl } : {}),
+  }),
+);
+
+export const workflow = defineWorkflow({
+  name: "api-runner-demo",
+  tasks: {
+    summarize: {
+      agent: summarize,
+      input: {
+        text: "AgentFlow ships the API runner — a zero-dependency OpenAI-compatible HTTP runner for multi-agent TypeScript workflows.",
+      },
+    },
+  },
+});
+
+// When executed directly (bun workflow.ts), run and print the result.
+if (import.meta.main) {
+  const { WorkflowExecutor } = await import("@ageflow/executor");
+  const executor = new WorkflowExecutor(workflow);
+  const result = await executor.run({});
+  console.log(JSON.stringify(result.outputs, null, 2));
+}

--- a/agentflow/packages/runners/api/README.md
+++ b/agentflow/packages/runners/api/README.md
@@ -1,41 +1,251 @@
 # @ageflow/runner-api
 
-OpenAI-compatible HTTP runner for ageflow. Talks to any `/chat/completions` endpoint via `fetch()`. Supports multi-round tool calling internally, pluggable session storage, and returns `ToolCallRecord[]` for observability. Zero external deps.
+[![npm](https://img.shields.io/npm/v/@ageflow/runner-api)](https://www.npmjs.com/package/@ageflow/runner-api)
 
-## Supported providers
+OpenAI-compatible HTTP runner for [ageflow](../../../README.md). Talks to any
+`/chat/completions` endpoint via `fetch()`. Supports multi-round tool calling
+internally, pluggable session storage, and returns `ToolCallRecord[]` for
+observability. Zero external dependencies.
 
-| Provider | Base URL |
-|----------|----------|
-| OpenAI | `https://api.openai.com/v1` |
-| Groq | `https://api.groq.com/openai/v1` |
-| Together | `https://api.together.xyz/v1` |
-| Ollama | `http://localhost:11434/v1` |
-| vLLM | `http://localhost:8000/v1` |
-| LM Studio | `http://localhost:1234/v1` |
-| Azure OpenAI | `https://<resource>.openai.azure.com/openai/deployments/<model>` |
-
-## Usage
-
-```ts
-import { ApiRunner } from "@ageflow/runner-api";
-
-const runner = new ApiRunner({
-  baseUrl: "https://api.openai.com/v1",
-  apiKey: process.env.OPENAI_API_KEY!,
-  defaultModel: "gpt-4o-mini",
-});
-
-const result = await runner.spawn({
-  prompt: "Summarize this document.",
-  model: "gpt-4o",
-});
-
-console.log(result.stdout);
-console.log(result.toolCalls); // ToolCallRecord[] if tools were used
-```
-
-## Installation
+## Install
 
 ```bash
 bun add @ageflow/runner-api
 ```
+
+## Quick start
+
+```ts
+import { registerRunner } from "@ageflow/core";
+import { ApiRunner } from "@ageflow/runner-api";
+
+registerRunner(
+  "api",
+  new ApiRunner({
+    baseUrl: "https://api.openai.com/v1",
+    apiKey: process.env.OPENAI_API_KEY!,
+    defaultModel: "gpt-4o-mini",
+  }),
+);
+```
+
+Then use `runner: "api"` in any `defineAgent` call:
+
+```ts
+import { defineAgent } from "@ageflow/core";
+import { z } from "zod";
+
+const summarize = defineAgent({
+  runner: "api",
+  model: "gpt-4o-mini",
+  input: z.object({ text: z.string() }),
+  output: z.object({ summary: z.string() }),
+  prompt: (i) =>
+    `Summarize in one sentence as JSON {"summary": string}:\n\n${i.text}`,
+});
+```
+
+## Provider compatibility
+
+| Provider      | `baseUrl`                                                              |
+|---------------|------------------------------------------------------------------------|
+| OpenAI        | `https://api.openai.com/v1`                                            |
+| Groq          | `https://api.groq.com/openai/v1`                                       |
+| Together AI   | `https://api.together.xyz/v1`                                          |
+| Ollama        | `http://localhost:11434/v1`                                            |
+| vLLM          | `http://localhost:8000/v1`                                             |
+| LM Studio     | `http://localhost:1234/v1`                                             |
+| Azure OpenAI  | `https://<resource>.openai.azure.com/openai/deployments/<model>`      |
+
+For Azure you must pass the `api-version` query param via the `headers` option
+(see Configuration below).
+
+## Configuration
+
+```ts
+new ApiRunner({
+  // Required
+  baseUrl: "https://api.openai.com/v1",  // trailing slash is stripped automatically
+  apiKey: "sk-...",
+
+  // Optional
+  defaultModel: "gpt-4o-mini",   // used when spawn() args.model is not set
+  tools: {                       // tool registry — see Tool calling below
+    readFile: { description: "...", parameters: { ... }, execute: async (args) => ... },
+  },
+  sessionStore: myStore,         // custom SessionStore — see Session persistence below
+  maxToolRounds: 10,             // max tool-call loops before MaxToolRoundsError (default 10)
+  requestTimeout: 120_000,       // ms before AbortController fires (default 120 000)
+  headers: {                     // extra headers forwarded on every request
+    "api-version": "2024-02-01", // e.g. Azure api-version
+  },
+  fetch: myFetchImpl,            // injectable fetch (default: globalThis.fetch)
+})
+```
+
+## Tool calling
+
+Register tools that the model may invoke. The runner loops internally until
+the model stops requesting tool calls or `maxToolRounds` is reached.
+
+```ts
+import { ApiRunner } from "@ageflow/runner-api";
+import * as fs from "node:fs/promises";
+
+const runner = new ApiRunner({
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: process.env.OPENAI_API_KEY!,
+  tools: {
+    readFile: {
+      description: "Read the contents of a file from disk",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string", description: "Absolute file path" } },
+        required: ["path"],
+      },
+      execute: async ({ path }) => {
+        return await fs.readFile(String(path), "utf-8");
+      },
+    },
+    writeFile: {
+      description: "Write content to a file",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        required: ["path", "content"],
+      },
+      execute: async ({ path, content }) => {
+        await fs.writeFile(String(path), String(content), "utf-8");
+        return "ok";
+      },
+    },
+  },
+});
+
+const result = await runner.spawn({
+  prompt: "Read ./README.md and summarize it in one sentence.",
+  tools: ["readFile"],            // subset of registered tools exposed to model
+});
+
+console.log(result.stdout);      // final model reply
+console.log(result.toolCalls);   // ToolCallRecord[] — every tool invocation
+```
+
+## Session persistence
+
+By default each `spawn()` call gets a fresh UUID session handle and messages
+are stored in an `InMemorySessionStore` (lives for the lifetime of the
+`ApiRunner` instance). Pass a `sessionHandle` to resume a conversation:
+
+```ts
+const first = await runner.spawn({ prompt: "My name is Alice." });
+// first.sessionHandle === "some-uuid"
+
+const second = await runner.spawn({
+  prompt: "What is my name?",
+  sessionHandle: first.sessionHandle,
+});
+// second.stdout === "Your name is Alice."
+```
+
+### Custom `SessionStore` (e.g. Redis)
+
+```ts
+import type { SessionStore } from "@ageflow/runner-api";
+import type { ChatMessage } from "@ageflow/runner-api";
+import { createClient } from "redis";
+
+const redis = createClient();
+await redis.connect();
+
+const redisStore: SessionStore = {
+  async get(handle) {
+    const raw = await redis.get(`session:${handle}`);
+    return raw ? (JSON.parse(raw) as ChatMessage[]) : undefined;
+  },
+  async set(handle, messages) {
+    await redis.set(`session:${handle}`, JSON.stringify(messages), { EX: 3600 });
+  },
+};
+
+const runner = new ApiRunner({
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: process.env.OPENAI_API_KEY!,
+  sessionStore: redisStore,
+});
+```
+
+## Observability
+
+`RunnerSpawnResult.toolCalls` is a `ToolCallRecord[]` containing every tool
+invocation made during the session:
+
+```ts
+const result = await runner.spawn({ prompt: "...", tools: ["readFile"] });
+
+for (const call of result.toolCalls ?? []) {
+  console.log(call.name);       // "readFile"
+  console.log(call.args);       // { path: "./foo.ts" }
+  console.log(call.result);     // "export const ..."
+  console.log(call.durationMs); // 12
+}
+```
+
+The executor passes `toolCalls` through to `TaskMetrics` / `ExecutionTrace`
+when present, enabling end-to-end observability without extra instrumentation.
+
+## Validation
+
+`runner.validate()` hits `GET /models` and returns `{ ok, version?, error? }`.
+Useful for health-checks and pre-flight guards:
+
+```ts
+const { ok, version, error } = await runner.validate();
+if (!ok) throw new Error(`API runner not reachable: ${error}`);
+console.log("First available model:", version);
+```
+
+## Error types
+
+| Error class         | When thrown                                                       |
+|---------------------|-------------------------------------------------------------------|
+| `MaxToolRoundsError` | Tool-call loop exceeded `maxToolRounds`                          |
+| `ApiRequestError`   | HTTP response was non-2xx                                         |
+| `ToolNotFoundError` | Reserved — executor pre-flight; runner itself soft-errors unknown tools |
+
+```ts
+import { MaxToolRoundsError, ApiRequestError } from "@ageflow/runner-api";
+
+try {
+  await runner.spawn({ prompt: "loop forever", tools: ["infiniteTool"] });
+} catch (err) {
+  if (err instanceof MaxToolRoundsError) {
+    console.error("Too many tool rounds:", err.message);
+  }
+}
+```
+
+## API reference
+
+### `new ApiRunner(config: ApiRunnerConfig)`
+
+Creates a new runner instance. All config fields except `baseUrl` and `apiKey`
+are optional.
+
+### `runner.validate(): Promise<{ ok: boolean; version?: string; error?: string }>`
+
+Checks connectivity by calling `GET /models`. Returns `ok: false` on any
+error (network, 4xx, 5xx) — never throws.
+
+### `runner.spawn(args: RunnerSpawnArgs): Promise<RunnerSpawnResult>`
+
+Executes a prompt, optionally resuming a session, and loops until the model
+produces a non-tool-call response. Returns `stdout` (final text), `sessionHandle`,
+`tokensIn`, `tokensOut`, and `toolCalls`.
+
+## License
+
+MIT

--- a/agentflow/packages/runners/api/package.json
+++ b/agentflow/packages/runners/api/package.json
@@ -2,6 +2,7 @@
   "name": "@ageflow/runner-api",
   "version": "0.1.0",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/api",
   "type": "module",
   "private": false,
   "sideEffects": false,
@@ -23,5 +24,22 @@
     "vitest": "^2.1.0",
     "zod": "^3.23.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Neftedollar/ageflow.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "openai",
+    "groq",
+    "ollama",
+    "multi-agent",
+    "api-runner"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
Phase 8: examples/api-runner/ workspace with mocked demo + harness test (2 tests pass).
Phase 9: full README for @ageflow/runner-api + publish metadata (description, homepage, repository, keywords, license).

Completes #30 — OpenAI-compatible API runner with tool loop, SessionStore, and backward-compat ToolCallRecord.