### PR TITLE
feat: @ageflow/server Phase 3-4 — run() as stream() drain + task:retry emission (#26)

### DIFF
--- a/agentflow/packages/executor/src/__tests__/node-runner.retry-event.test.ts
+++ b/agentflow/packages/executor/src/__tests__/node-runner.retry-event.test.ts
@@ -1,0 +1,45 @@
+import { defineAgent } from "@ageflow/core";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { runNode } from "../node-runner.js";
+
+describe("runNode onRetry callback", () => {
+  it("invokes onRetry(attempt, reason) before each retry attempt", async () => {
+    let attempts = 0;
+    const flaky = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new Error("subprocess transient failure");
+        return {
+          stdout: JSON.stringify({ ok: true }),
+          sessionHandle: "s",
+          tokensIn: 0,
+          tokensOut: 0,
+        };
+      },
+    };
+
+    const a = defineAgent({
+      runner: "x",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      prompt: () => "p",
+      retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+    });
+    const onRetry = vi.fn();
+    await runNode(
+      { agent: a, input: {} },
+      {},
+      flaky,
+      "t",
+      undefined,
+      undefined,
+      undefined,
+      onRetry,
+    );
+    expect(onRetry).toHaveBeenCalledTimes(2); // two failures before success
+    expect(onRetry.mock.calls[0]?.[0]).toBe(1); // attempt about to start (1, then 2)
+    expect(String(onRetry.mock.calls[0]?.[1])).toMatch(/subprocess/);
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -104,6 +104,45 @@ describe("WorkflowExecutor.stream (task failure)", () => {
   });
 });
 
+describe("WorkflowExecutor.stream (task retry)", () => {
+  it("emits task:retry between transient failures", async () => {
+    let tries = 0;
+    const runner: Runner = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        tries += 1;
+        if (tries < 2) throw new Error("subprocess flake");
+        return {
+          stdout: JSON.stringify({ x: "ok" }),
+          sessionHandle: "s",
+          tokensIn: 0,
+          tokensOut: 0,
+        };
+      },
+    };
+    registerRunner("flaky", runner);
+    try {
+      const a = defineAgent({
+        runner: "flaky",
+        input: z.object({}),
+        output: z.object({ x: z.string() }),
+        prompt: () => "p",
+        retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+      });
+      const wfy = defineWorkflow({
+        name: "r",
+        tasks: { t: { agent: a, input: {} } },
+      });
+      const ex = new WorkflowExecutor(wfy);
+      const events: WorkflowEvent[] = [];
+      for await (const ev of ex.stream({})) events.push(ev);
+      expect(events.some((e) => e.type === "task:retry")).toBe(true);
+    } finally {
+      unregisterRunner("flaky");
+    }
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -1,4 +1,9 @@
-import { defineAgent, defineWorkflow, registerRunner, unregisterRunner } from "@ageflow/core";
+import {
+  defineAgent,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
 import type { Runner, WorkflowEvent } from "@ageflow/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -96,5 +101,27 @@ describe("WorkflowExecutor.stream (task failure)", () => {
     } finally {
       unregisterRunner("boom");
     }
+  });
+});
+
+describe("run() is a drain over stream()", () => {
+  it("produces the same WorkflowResult as draining stream()", async () => {
+    const executor = new WorkflowExecutor(wf);
+    const runResult = await executor.run({});
+
+    const executor2 = new WorkflowExecutor(wf);
+    const gen = executor2.stream({});
+    let streamResult: IteratorResult<WorkflowEvent, unknown>;
+    do {
+      streamResult = await gen.next();
+    } while (!streamResult.done);
+
+    expect(runResult.outputs).toEqual(
+      (streamResult.value as { outputs: unknown }).outputs,
+    );
+    expect(runResult.metrics.taskCount).toBe(
+      (streamResult.value as { metrics: { taskCount: number } }).metrics
+        .taskCount,
+    );
   });
 });

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -98,6 +98,7 @@ export async function runNode<
   sessionHandle?: string,
   permissions?: Record<string, boolean>,
   filteredTools?: readonly string[],
+  onRetry?: (attempt: number, reason: string) => void,
 ): Promise<
   NodeRunResult<
     import("zod").infer<
@@ -216,6 +217,9 @@ export async function runNode<
           error: errorMessage,
           errorCode,
         });
+
+        // Notify caller about the upcoming retry attempt
+        onRetry?.(attempt + 1, errorMessage);
 
         // Apply backoff before next attempt (not after last attempt)
         if (attempt < maxAttempts - 1) {

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -582,6 +582,17 @@ export class WorkflowExecutor<T extends TasksMap> {
                 sessionHandle,
                 permissions ?? undefined,
                 filteredTools,
+                (attempt, reason) => {
+                  push({
+                    type: "task:retry",
+                    runId,
+                    workflowName,
+                    timestamp: Date.now(),
+                    taskName,
+                    attempt,
+                    reason,
+                  });
+                },
               );
 
               const latencyMs = Date.now() - taskStart;

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -133,62 +133,24 @@ export class WorkflowExecutor<T extends TasksMap> {
     this.loopExecutor = new LoopExecutor(runBatchesBound);
   }
 
-  async run(_input?: unknown): Promise<WorkflowResult<T>> {
-    const { tasks, hooks } = this.workflow;
-    const workflowStart = Date.now();
-
-    // Build initial context
-    const ctx: Record<string, CtxEntry> = {};
-    const outputs: { [K in keyof T]?: unknown } = {};
-
-    // Accumulated metrics
-    let totalTokensIn = 0;
-    let totalTokensOut = 0;
-    let totalEstimatedCost = 0;
-    let taskCount = 0;
-
-    // Run all task batches
-    const results = await this._runBatches(tasks, ctx);
-
-    // Merge results into outputs
-    for (const [taskName, entry] of Object.entries(results)) {
-      outputs[taskName as keyof T] = entry.output;
-      if (entry._source === "agent") {
-        taskCount++;
-      }
-    }
-
-    // Accumulate totals from budget tracker
-    totalEstimatedCost = this.budgetTracker.total;
-
-    // We need to collect token counts from individual task results
-    // The _runBatches aggregates back into ctx — we compute totals from budgetTracker
-    // For token counts, we need to re-examine ctx
-    for (const entry of Object.values(results)) {
-      if (entry._source === "agent") {
-        const tokenEntry = entry as CtxEntry & {
-          _tokensIn?: number;
-          _tokensOut?: number;
-        };
-        totalTokensIn += tokenEntry._tokensIn ?? 0;
-        totalTokensOut += tokenEntry._tokensOut ?? 0;
-      }
-    }
-
-    const totalLatencyMs = Date.now() - workflowStart;
-
-    const metrics: WorkflowMetrics = {
-      totalLatencyMs,
-      totalTokensIn,
-      totalTokensOut,
-      totalEstimatedCost,
-      taskCount,
+  async run(input?: unknown): Promise<WorkflowResult<T>> {
+    const legacyHitlAdapter = async (ev: CheckpointEvent): Promise<boolean> => {
+      // Legacy HITL adapter: defer to HITLManager (hook-or-TTY path).
+      await this.hitlManager.runCheckpoint(
+        ev.taskName,
+        ev.message,
+        this.workflow.hooks,
+      );
+      return true;
     };
-
-    // Fire onWorkflowComplete hook
-    hooks?.onWorkflowComplete?.(outputs, metrics);
-
-    return { outputs, metrics };
+    const gen = this.stream(input, {
+      onCheckpoint: legacyHitlAdapter,
+    });
+    let result: IteratorResult<WorkflowEvent, WorkflowResult<T>>;
+    do {
+      result = await gen.next();
+    } while (!result.done);
+    return result.value;
   }
 
   /**
@@ -228,6 +190,11 @@ export class WorkflowExecutor<T extends TasksMap> {
               ? { onCheckpoint: options.onCheckpoint }
               : {}),
           },
+        );
+        // Fire onWorkflowComplete hook (was fired at end of old run())
+        this.workflow.hooks?.onWorkflowComplete?.(
+          result.outputs,
+          result.metrics,
         );
         queue.push({
           type: "workflow:complete",
@@ -558,7 +525,10 @@ export class WorkflowExecutor<T extends TasksMap> {
                   : `Task "${taskName}" requires approval before proceeding.`;
 
               // Fire onCheckpoint hook
-              hooks?.onCheckpoint?.(taskName as keyof T & string, checkpointMessage);
+              hooks?.onCheckpoint?.(
+                taskName as keyof T & string,
+                checkpointMessage,
+              );
 
               // Emit checkpoint event
               const checkpointEv: CheckpointEvent = {
@@ -697,11 +667,7 @@ export class WorkflowExecutor<T extends TasksMap> {
               const e = err instanceof Error ? err : new Error(String(err));
               // Fire onTaskError hook
               const latencyMs = Date.now() - taskStart;
-              hooks?.onTaskError?.(
-                taskName as keyof T & string,
-                e,
-                latencyMs,
-              );
+              hooks?.onTaskError?.(taskName as keyof T & string, e, latencyMs);
 
               // Emit task:error event (terminal: true — retries exhausted or non-retryable)
               push({


### PR DESCRIPTION
Phase 3: run() reimpl on stream() with legacyHitlAdapter for CLI TTY. Phase 4: task:retry via node-runner onRetry callback. 140 executor tests (+3 new).