### PR TITLE
feat: @ageflow/server Phase 8-9 — async HITL + cancellation (#26)

### DIFF
--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -176,7 +176,14 @@ export class WorkflowExecutor<T extends TasksMap> {
     });
 
     // Run the DAG in the background; push events via queue; close on exit.
-    const driver = (async (): Promise<WorkflowResult<T>> => {
+    // We use a shared error slot instead of a rejected Promise to avoid
+    // unhandled-rejection warnings when the generator is suspended
+    // (e.g. async HITL timeout): the error is already communicated via the
+    // queue as workflow:error and will be re-thrown from `return driverResult`
+    // once the consumer drains the queue.
+    let driverResult: WorkflowResult<T> | undefined;
+    let driverError: Error | undefined;
+    const driverDone = (async (): Promise<void> => {
       try {
         const result = await this._runBatchesEmitting(
           this.workflow.tasks,
@@ -206,8 +213,8 @@ export class WorkflowExecutor<T extends TasksMap> {
             metrics: result.metrics,
           },
         });
+        driverResult = result;
         queue.close();
-        return result;
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));
         queue.push({
@@ -221,10 +228,12 @@ export class WorkflowExecutor<T extends TasksMap> {
             ...(e.stack !== undefined ? { stack: e.stack } : {}),
           },
         });
+        driverError = e;
         queue.close();
-        throw e;
       }
     })();
+    // Suppress the floating promise rejection (the IIFE returns void / never rejects).
+    void driverDone;
 
     while (true) {
       const ev = await queue.next();
@@ -232,8 +241,10 @@ export class WorkflowExecutor<T extends TasksMap> {
       yield ev;
     }
 
-    // Await so we can return the final WorkflowResult.
-    return await driver;
+    // Await the driver to ensure it has fully completed before returning.
+    await driverDone;
+    if (driverError !== undefined) throw driverError;
+    return driverResult as WorkflowResult<T>;
   }
 
   /**

--- a/agentflow/packages/server/src/__tests__/runner.cancel.test.ts
+++ b/agentflow/packages/server/src/__tests__/runner.cancel.test.ts
@@ -1,0 +1,79 @@
+import {
+  defineAgent,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
+import type { Runner as AgentRunner } from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createRunner } from "../runner.js";
+
+// Slow runner — gives us time to cancel mid-flight.
+const slow: AgentRunner = {
+  validate: async () => ({ ok: true }),
+  spawn: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    return {
+      stdout: JSON.stringify({ ok: true }),
+      sessionHandle: "s",
+      tokensIn: 0,
+      tokensOut: 0,
+    };
+  },
+};
+
+const agent = defineAgent({
+  runner: "slow",
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  prompt: () => "p",
+});
+const wf = defineWorkflow({
+  name: "s",
+  tasks: { t: { agent, input: {} } },
+});
+
+beforeEach(() => registerRunner("slow", slow));
+afterEach(() => unregisterRunner("slow"));
+
+describe("cancel", () => {
+  it("cancel(runId) marks state=cancelled and stops emitting events", async () => {
+    const runner = createRunner();
+    const gen = runner.stream(wf, {});
+    const first = await gen.next();
+    if (first.done) throw new Error("no events");
+    const runId = first.value.runId;
+    runner.cancel(runId);
+
+    // Drain whatever remains; no more events expected after cancel.
+    try {
+      let step = await gen.next();
+      while (!step.done) step = await gen.next();
+    } catch {}
+    expect(runner.get(runId)?.state).toBe("cancelled");
+    runner.close();
+  });
+
+  it("options.signal aborts stream() mid-flight", async () => {
+    const runner = createRunner();
+    const ac = new AbortController();
+    const gen = runner.stream(wf, {}, { signal: ac.signal });
+    const first = await gen.next();
+    if (first.done) throw new Error("no events");
+    const runId = first.value.runId;
+    ac.abort();
+    try {
+      let step = await gen.next();
+      while (!step.done) step = await gen.next();
+    } catch {}
+    expect(runner.get(runId)?.state).toBe("cancelled");
+    runner.close();
+  });
+
+  it("cancel(unknown) is idempotent (no throw)", () => {
+    const runner = createRunner();
+    expect(() => runner.cancel("nope")).not.toThrow();
+    runner.close();
+  });
+});

--- a/agentflow/packages/server/src/__tests__/runner.hitl.test.ts
+++ b/agentflow/packages/server/src/__tests__/runner.hitl.test.ts
@@ -1,0 +1,150 @@
+import {
+  defineAgent,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
+import type { Runner as AgentRunner } from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createRunner } from "../runner.js";
+
+const stub: AgentRunner = {
+  validate: async () => ({ ok: true }),
+  spawn: async () => ({
+    stdout: JSON.stringify({ ok: true }),
+    sessionHandle: "s",
+    tokensIn: 0,
+    tokensOut: 0,
+  }),
+};
+const agent = defineAgent({
+  runner: "stub",
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  prompt: () => "p",
+  hitl: { mode: "checkpoint", message: "please approve" },
+});
+const wf = defineWorkflow({
+  name: "gated",
+  tasks: { t: { agent, input: {} } },
+});
+
+beforeEach(() => registerRunner("stub", stub));
+afterEach(() => unregisterRunner("stub"));
+
+describe("async HITL", () => {
+  it("pauses, exposes pendingCheckpoint, resumes on approve=true", async () => {
+    const runner = createRunner();
+    const events = [];
+    const gen = runner.stream(wf, {});
+
+    let runId: string | undefined;
+    let step = await gen.next();
+    while (!step.done && step.value.type !== "checkpoint") {
+      events.push(step.value);
+      runId = step.value.runId;
+      step = await gen.next();
+    }
+    expect(step.done).toBe(false);
+    if (!step.done) {
+      runId = step.value.runId;
+      events.push(step.value);
+    }
+
+    // Handle is in awaiting-checkpoint
+    // biome-ignore lint/style/noNonNullAssertion: runId is set before this point
+    expect(runner.get(runId!)?.state).toBe("awaiting-checkpoint");
+    // biome-ignore lint/style/noNonNullAssertion: runId is set before this point
+    expect(runner.get(runId!)?.pendingCheckpoint).toBeDefined();
+
+    // Resume from another "request"
+    // biome-ignore lint/style/noNonNullAssertion: runId is set before this point
+    runner.resume(runId!, true);
+
+    // Drain rest
+    let next = await gen.next();
+    while (!next.done) {
+      events.push(next.value);
+      next = await gen.next();
+    }
+    expect(events.at(-1)?.type).toBe("workflow:complete");
+    runner.close();
+  });
+
+  it("resume(false) fails with workflow:error", async () => {
+    const runner = createRunner();
+    const events = [];
+    const gen = runner.stream(wf, {});
+    let step = await gen.next();
+    let runId: string | undefined;
+    while (!step.done) {
+      events.push(step.value);
+      runId = step.value.runId;
+      if (step.value.type === "checkpoint") break;
+      step = await gen.next();
+    }
+    // biome-ignore lint/style/noNonNullAssertion: runId is set before this point
+    runner.resume(runId!, false);
+    try {
+      let next = await gen.next();
+      while (!next.done) {
+        events.push(next.value);
+        next = await gen.next();
+      }
+    } catch {
+      // driver throws — acceptable
+    }
+    expect(events.at(-1)?.type).toBe("workflow:error");
+    runner.close();
+  });
+
+  it("auto-rejects after checkpointTtlMs", async () => {
+    vi.useFakeTimers();
+    const runner = createRunner({ checkpointTtlMs: 50, reaperIntervalMs: 10 });
+    const events = [];
+    const gen = runner.stream(wf, {});
+    let step = await gen.next();
+    while (!step.done && step.value.type !== "checkpoint") {
+      events.push(step.value);
+      step = await gen.next();
+    }
+    if (!step.done) events.push(step.value);
+    await vi.advanceTimersByTimeAsync(200);
+    // Driver should have rejected; drain remaining
+    try {
+      let next = await gen.next();
+      while (!next.done) {
+        events.push(next.value);
+        next = await gen.next();
+      }
+    } catch {}
+    expect(events.at(-1)?.type).toBe("workflow:error");
+    runner.close();
+    vi.useRealTimers();
+  });
+
+  it("resume() on unknown runId throws RunNotFoundError", () => {
+    const runner = createRunner();
+    expect(() => runner.resume("does-not-exist", true)).toThrow(/not found/i);
+    runner.close();
+  });
+
+  it("resume() on running run throws InvalidRunStateError", async () => {
+    const runner = createRunner();
+    const plain = defineAgent({
+      runner: "stub",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      prompt: () => "p",
+    });
+    const wfp = defineWorkflow({
+      name: "p",
+      tasks: { t: { agent: plain, input: {} } },
+    });
+    await runner.run(wfp, {});
+    const id = runner.list()[0]?.runId;
+    if (id) expect(() => runner.resume(id, true)).toThrow();
+    runner.close();
+  });
+});


### PR DESCRIPTION
Phase 8: async HITL via deferred promise + checkpoint TTL auto-reject. Phase 9: AbortSignal cancellation via cancel() + options.signal. 15 server tests (+3), 19/19 tasks green.