### PR TITLE
feat: @ageflow/server Phase 11-13 — example + docs + publish prep — closes #26

### DIFF
--- a/agentflow/CLAUDE.md
+++ b/agentflow/CLAUDE.md
@@ -16,6 +16,19 @@ core ← runners/codex
 core ← testing
 executor ← testing
 runners/* ← executor (via RunnerRegistry)
+core ← server
+executor ← server
+
+## Packages (v1)
+- `@ageflow/core` — types, Zod schemas, DSL builders
+- `@ageflow/executor` — DAG executor, loop, session, HITL, budget, pre-flight
+- `@ageflow/runner-claude` — Claude CLI subprocess runner
+- `@ageflow/runner-codex` — Codex CLI subprocess runner
+- `@ageflow/runner-api` — OpenAI-compatible HTTP runner
+- `@ageflow/testing` — test harness (`createTestHarness`)
+- `@ageflow/server` — embeddable execution surface — streaming events, async HITL, cancellation
+- `agentflow` (CLI) — `agentwf run/validate/dry-run/init`
 
 ## Phase 1 complete: @agentflow/core
 ## Phases 2-6: executor, runners, testing, CLI, examples
+## Phase 7+: @ageflow/server (#26)

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -69,6 +69,21 @@
         "zod": "^3.23.0",
       },
     },
+    "examples/server-embed": {
+      "name": "@ageflow-example/server-embed",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
+        "@ageflow/runner-api": "workspace:*",
+        "@ageflow/server": "workspace:*",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "packages/cli": {
       "name": "@ageflow/cli",
       "version": "0.1.0",
@@ -199,6 +214,8 @@
   },
   "packages": {
     "@ageflow-example/api-runner": ["@ageflow-example/api-runner@workspace:examples/api-runner"],
+
+    "@ageflow-example/server-embed": ["@ageflow-example/server-embed@workspace:examples/server-embed"],
 
     "@ageflow/cli": ["@ageflow/cli@workspace:packages/cli"],
 

--- a/agentflow/examples/server-embed/README.md
+++ b/agentflow/examples/server-embed/README.md
@@ -1,0 +1,50 @@
+# server-embed example
+
+Minimal demo: embed `@ageflow/server` in a raw `node:http` server, stream
+workflow events as Server-Sent Events (SSE), and handle a HITL checkpoint
+from a second HTTP request.
+
+## Quick start
+
+```bash
+# Install dependencies (from the monorepo root)
+bun install
+
+# Start the server
+bun server.ts
+# Listening on :3000
+```
+
+Requires `OPENAI_API_KEY` (or set `OPENAI_BASE_URL` to a compatible endpoint).
+
+## Trigger a run
+
+```bash
+# Stream events as SSE — the server pauses at the checkpoint
+curl -N -X POST http://localhost:3000/runs
+# data: {"type":"workflow:start","runId":"<id>", ...}
+# data: {"type":"task:start","taskName":"classify", ...}
+# data: {"type":"checkpoint","runId":"<id>","message":"Approve classification?", ...}
+```
+
+## Resume a checkpoint
+
+```bash
+# Approve (continues the workflow)
+curl -X POST http://localhost:3000/runs/<runId>/resume \
+  -H 'content-type: application/json' \
+  -d '{"approved":true}'
+
+# Reject (workflow fails with HitlRejectedError)
+curl -X POST http://localhost:3000/runs/<runId>/resume \
+  -H 'content-type: application/json' \
+  -d '{"approved":false}'
+```
+
+## Run tests
+
+Tests use a stub runner — no API key needed.
+
+```bash
+bun run test
+```

--- a/agentflow/examples/server-embed/__tests__/sse.test.ts
+++ b/agentflow/examples/server-embed/__tests__/sse.test.ts
@@ -1,0 +1,69 @@
+/**
+ * sse.test.ts — Harness test driving the server-embed runner.
+ *
+ * Replaces the "api" runner with a stub so no real API calls are made.
+ * Verifies that createRunner().stream() correctly streams events and
+ * pauses at the HITL checkpoint until onCheckpoint resolves.
+ */
+
+import { registerRunner, unregisterRunner } from "@ageflow/core";
+import type { Runner as AgentRunner } from "@ageflow/core";
+import { createRunner } from "@ageflow/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { triageWorkflow } from "../workflow.js";
+
+// Stub runner — returns a valid classification without hitting any API.
+const stub: AgentRunner = {
+  validate: async () => ({ ok: true }),
+  spawn: async () => ({
+    stdout: JSON.stringify({ urgent: true, summary: "Server is on fire" }),
+    sessionHandle: "stub",
+    tokensIn: 5,
+    tokensOut: 10,
+  }),
+};
+
+beforeEach(() => registerRunner("api", stub));
+afterEach(() => unregisterRunner("api"));
+
+describe("server-embed demo", () => {
+  it("streams events and supports resume-true via runner", async () => {
+    const runner = createRunner();
+    const gen = runner.stream(
+      triageWorkflow,
+      {},
+      {
+        onCheckpoint: async () => true,
+      },
+    );
+    const types: string[] = [];
+    for await (const ev of gen) {
+      types.push(ev.type);
+    }
+    expect(types[0]).toBe("workflow:start");
+    expect(types).toContain("checkpoint");
+    expect(types[types.length - 1]).toBe("workflow:complete");
+    runner.close();
+  });
+
+  it("streams events and supports resume-false (rejected checkpoint)", async () => {
+    const runner = createRunner();
+    const events: string[] = [];
+    try {
+      for await (const ev of runner.stream(
+        triageWorkflow,
+        {},
+        {
+          onCheckpoint: async () => false,
+        },
+      )) {
+        events.push(ev.type);
+      }
+    } catch {
+      // driver throws on HITL rejection — expected
+    }
+    expect(events).toContain("checkpoint");
+    expect(events[events.length - 1]).toBe("workflow:error");
+    runner.close();
+  });
+});

--- a/agentflow/examples/server-embed/package.json
+++ b/agentflow/examples/server-embed/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ageflow-example/server-embed",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun server.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ageflow/core": "workspace:*",
+    "@ageflow/executor": "workspace:*",
+    "@ageflow/server": "workspace:*",
+    "@ageflow/runner-api": "workspace:*",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/agentflow/examples/server-embed/server.ts
+++ b/agentflow/examples/server-embed/server.ts
@@ -1,0 +1,71 @@
+/**
+ * server.ts — Minimal SSE server using node:http + @ageflow/server.
+ *
+ * Endpoints:
+ *   POST /runs          — start a workflow run, stream events as SSE
+ *   POST /runs/:id/resume — resume a paused HITL checkpoint
+ *
+ * Run:
+ *   bun server.ts
+ *
+ * Then trigger a run:
+ *   curl -N -X POST http://localhost:3000/runs
+ *
+ * And resume a checkpoint:
+ *   curl -X POST http://localhost:3000/runs/<runId>/resume \
+ *     -H 'content-type: application/json' \
+ *     -d '{"approved":true}'
+ */
+
+import { createServer } from "node:http";
+import { createRunner } from "@ageflow/server";
+import { triageWorkflow } from "./workflow.js";
+
+const runner = createRunner();
+
+const server = createServer(async (req, res) => {
+  if (req.url === "/runs" && req.method === "POST") {
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    try {
+      for await (const ev of runner.stream(triageWorkflow, {})) {
+        res.write(`data: ${JSON.stringify(ev)}\n\n`);
+        if (ev.type === "checkpoint") break;
+      }
+      res.end();
+    } catch (err) {
+      res.write(`event: error\ndata: ${String(err)}\n\n`);
+      res.end();
+    }
+    return;
+  }
+
+  if (
+    req.url?.startsWith("/runs/") &&
+    req.url.endsWith("/resume") &&
+    req.method === "POST"
+  ) {
+    const runId = req.url.split("/")[2] ?? "";
+    let body = "";
+    req.on("data", (c: string) => {
+      body += c;
+    });
+    req.on("end", () => {
+      const approved = JSON.parse(body).approved === true;
+      try {
+        runner.resume(runId, approved);
+        res.writeHead(204).end();
+      } catch (err) {
+        res.writeHead(404).end(String(err));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404).end();
+});
+
+server.listen(3000, () => console.log("listening on :3000"));

--- a/agentflow/examples/server-embed/tsconfig.json
+++ b/agentflow/examples/server-embed/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "paths": {}
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/agentflow/examples/server-embed/workflow.ts
+++ b/agentflow/examples/server-embed/workflow.ts
@@ -1,0 +1,42 @@
+/**
+ * workflow.ts — Triage demo workflow with a HITL checkpoint.
+ *
+ * Classifies an incoming message as urgent/non-urgent, then pauses for
+ * human approval before continuing.
+ *
+ * Start the server:
+ *   bun server.ts
+ *
+ * Or run tests (no real API calls):
+ *   bun run test
+ */
+
+import { defineAgent, defineWorkflow, registerRunner } from "@ageflow/core";
+import { ApiRunner } from "@ageflow/runner-api";
+import { z } from "zod";
+
+registerRunner(
+  "api",
+  new ApiRunner({
+    baseUrl: process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+    apiKey: process.env.OPENAI_API_KEY ?? "",
+    defaultModel: "gpt-4o-mini",
+  }),
+);
+
+const classify = defineAgent({
+  runner: "api",
+  model: "gpt-4o-mini",
+  input: z.object({ message: z.string() }),
+  output: z.object({ urgent: z.boolean(), summary: z.string() }),
+  prompt: (i) =>
+    `Classify: ${i.message}. Output JSON {urgent:boolean, summary:string}.`,
+  hitl: { mode: "checkpoint", message: "Approve classification?" },
+});
+
+export const triageWorkflow = defineWorkflow({
+  name: "triage",
+  tasks: {
+    classify: { agent: classify, input: { message: "Server is on fire" } },
+  },
+});

--- a/agentflow/packages/server/README.md
+++ b/agentflow/packages/server/README.md
@@ -1,0 +1,265 @@
+# `@ageflow/server`
+
+Embeddable execution surface for [AgentFlow](https://github.com/Neftedollar/ageflow) workflows.
+
+- **Stream** structured `WorkflowEvent`s — wire to SSE, WebSocket, or JSONL yourself
+- **Async HITL** — pause a run, expose a `pendingCheckpoint`, resume from any request
+- **Fire-and-forget** — background runs with `onEvent` / `onComplete` / `onError` callbacks
+- **Cancellation** — `AbortSignal` + `cancel(runId)` via a built-in run registry
+- **Zero HTTP dependency** — bring your own Express, Hono, Fastify, Next.js, or raw `node:http`
+
+---
+
+## Installation
+
+```bash
+bun add @ageflow/server @ageflow/core @ageflow/executor
+# or
+npm install @ageflow/server @ageflow/core @ageflow/executor
+```
+
+---
+
+## Quick start
+
+### `stream()` — consume events one by one
+
+```ts
+import { createRunner } from "@ageflow/server";
+import { myWorkflow } from "./workflows.js";
+
+const runner = createRunner();
+
+for await (const ev of runner.stream(myWorkflow, { userId: "u1" })) {
+  console.log(ev.type, ev);
+  // workflow:start | task:start | task:complete | checkpoint | workflow:complete …
+}
+```
+
+### `run()` — await the final result
+
+```ts
+const result = await runner.run(myWorkflow, { userId: "u1" });
+console.log(result.outputs); // { taskName: outputObject, … }
+```
+
+> `run()` auto-rejects HITL checkpoints by default (least-privilege). Pass
+> `onCheckpoint` to handle them inline.
+
+### `fire()` — background run, synchronous handle
+
+```ts
+const handle = runner.fire(myWorkflow, { userId: "u1" }, {
+  onEvent: (ev) => console.log("event", ev.type),
+  onComplete: (result) => console.log("done", result.outputs),
+  onError: (err) => console.error("failed", err),
+});
+
+console.log(handle.runId); // available immediately
+```
+
+---
+
+## SSE example (`node:http`)
+
+```ts
+import { createServer } from "node:http";
+import { createRunner } from "@ageflow/server";
+import { triageWorkflow } from "./workflows.js";
+
+const runner = createRunner();
+
+createServer(async (req, res) => {
+  if (req.method === "POST" && req.url === "/runs") {
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+    });
+    for await (const ev of runner.stream(triageWorkflow, {})) {
+      res.write(`data: ${JSON.stringify(ev)}\n\n`);
+      if (ev.type === "checkpoint") break; // pause; client will resume later
+    }
+    res.end();
+  }
+}).listen(3000);
+```
+
+### Hono
+
+```ts
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { createRunner } from "@ageflow/server";
+
+const app = new Hono();
+const runner = createRunner();
+
+app.post("/runs", (c) =>
+  streamSSE(c, async (stream) => {
+    for await (const ev of runner.stream(myWorkflow, {})) {
+      await stream.writeSSE({ data: JSON.stringify(ev) });
+    }
+  }),
+);
+```
+
+### Express
+
+```ts
+import express from "express";
+import { createRunner } from "@ageflow/server";
+
+const app = express();
+const runner = createRunner();
+
+app.post("/runs", async (req, res) => {
+  res.setHeader("content-type", "text/event-stream");
+  for await (const ev of runner.stream(myWorkflow, req.body)) {
+    res.write(`data: ${JSON.stringify(ev)}\n\n`);
+  }
+  res.end();
+});
+```
+
+---
+
+## Async HITL example
+
+Start a run (SSE handler breaks on `checkpoint`):
+
+```bash
+curl -N -X POST http://localhost:3000/runs
+# data: {"type":"checkpoint","runId":"abc123","message":"Approve output?", ...}
+```
+
+Resume from a second request:
+
+```ts
+app.post("/runs/:id/resume", express.json(), (req, res) => {
+  runner.resume(req.params.id, req.body.approved === true);
+  res.sendStatus(204);
+});
+```
+
+```bash
+curl -X POST http://localhost:3000/runs/abc123/resume \
+  -H 'content-type: application/json' \
+  -d '{"approved":true}'
+```
+
+The paused `stream()` generator will unblock and continue emitting events.
+
+---
+
+## Run registry: TTLs, `list()`, `get()`
+
+`createRunner()` maintains an in-memory registry of all active runs.
+
+```ts
+const runner = createRunner({
+  ttlMs: 5 * 60_000,          // terminal runs evicted after 5 min (default)
+  checkpointTtlMs: 60 * 60_000, // awaiting-checkpoint runs auto-rejected after 1 h (default)
+  reaperIntervalMs: 60_000,    // reaper sweep interval (default)
+});
+
+runner.list();                 // readonly RunHandle[]
+runner.get("abc123");          // RunHandle | undefined
+```
+
+`RunHandle` shape:
+
+```ts
+interface RunHandle {
+  runId: string;
+  state: "running" | "awaiting-checkpoint" | "done" | "failed" | "cancelled";
+  workflowName: string;
+  createdAt: number;          // Date.now()
+  lastEventAt: number;
+  pendingCheckpoint?: CheckpointEvent; // only when state === "awaiting-checkpoint"
+  result?: { outputs: Record<string, unknown>; metrics: WorkflowMetrics };
+  error?: { name: string; message: string };
+}
+```
+
+---
+
+## Configuration
+
+```ts
+interface RunnerConfig {
+  /** TTL (ms) before terminal runs are evicted. Default: 300 000 (5 min). */
+  ttlMs?: number;
+  /** TTL (ms) before awaiting-checkpoint runs are auto-rejected. Default: 3 600 000 (1 h). */
+  checkpointTtlMs?: number;
+  /** Reaper sweep interval (ms). Default: 60 000. */
+  reaperIntervalMs?: number;
+  /** Custom runId generator. Default: crypto.randomUUID(). */
+  generateRunId?: () => string;
+}
+```
+
+---
+
+## Cancellation
+
+```ts
+// Via AbortController
+const ac = new AbortController();
+for await (const ev of runner.stream(wf, {}, { signal: ac.signal })) {
+  if (shouldStop) ac.abort();
+}
+
+// Via registry (fire-and-forget, or from a different request)
+runner.cancel(runId); // idempotent — no-op if unknown
+```
+
+---
+
+## `RunOptions` and `FireOptions`
+
+```ts
+interface RunOptions {
+  signal?: AbortSignal;
+  /** Return true to approve, false to reject. If omitted, stream() pauses (async HITL). */
+  onCheckpoint?: (ev: CheckpointEvent) => Promise<boolean> | boolean;
+}
+
+interface FireOptions extends RunOptions {
+  onEvent?: (ev: WorkflowEvent) => void;
+  onError?: (err: Error) => void;
+  onComplete?: (result: WorkflowResult) => void;
+}
+```
+
+---
+
+## Errors
+
+| Class | Code | When |
+|-------|------|------|
+| `HitlRejectedError` | `hitl_rejected` | Checkpoint was rejected (`approved=false`) |
+| `CheckpointTimeoutError` | `checkpoint_timeout` | `checkpointTtlMs` expired |
+| `RunNotFoundError` | `run_not_found` | `resume()` called with unknown `runId` |
+| `InvalidRunStateError` | `invalid_run_state` | `resume()` called on a non-awaiting-checkpoint run |
+
+All errors extend `AgentFlowError` from `@ageflow/core`.
+
+---
+
+## Non-goals
+
+- **No bundled HTTP middleware.** Turning events into SSE / WebSocket / JSONL
+  is the caller's responsibility. A separate `@ageflow/server-http` package may
+  ship in v0.2.
+- **No persistence.** The run registry is in-memory. Pluggable `RunStore`
+  (SQLite / Redis) is planned for v0.2.
+- **No distributed runs.** Single-process only.
+- **No `subscribe(runId)`.** Joining an in-flight run from a second observer
+  is deferred to v0.2.
+
+---
+
+## Roadmap
+
+See the [design spec](../../docs/superpowers/specs/2026-04-16-server-execution-design.md)
+§Roadmap for planned v0.2 and v0.3 features.

--- a/agentflow/packages/server/package.json
+++ b/agentflow/packages/server/package.json
@@ -29,6 +29,22 @@
     "type": "git",
     "url": "https://github.com/Neftedollar/ageflow.git"
   },
-  "keywords": ["ai", "agents", "workflow", "server", "sse", "hitl", "ageflow"],
+  "keywords": [
+    "ai",
+    "agents",
+    "workflow",
+    "llm",
+    "dsl",
+    "typescript",
+    "server",
+    "sse",
+    "streaming",
+    "hitl",
+    "human-in-the-loop",
+    "cancellation",
+    "abortcontroller",
+    "multi-agent",
+    "ageflow"
+  ],
   "license": "MIT"
 }

--- a/agentflow/packages/server/src/__tests__/runner.fire.test.ts
+++ b/agentflow/packages/server/src/__tests__/runner.fire.test.ts
@@ -1,0 +1,95 @@
+import {
+  defineAgent,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
+import type { Runner as AgentRunner } from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createRunner } from "../runner.js";
+
+const stub: AgentRunner = {
+  validate: async () => ({ ok: true }),
+  spawn: async () => ({
+    stdout: JSON.stringify({ ok: true }),
+    sessionHandle: "s",
+    tokensIn: 1,
+    tokensOut: 1,
+  }),
+};
+const agent = defineAgent({
+  runner: "stub2",
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  prompt: () => "p",
+});
+const wf = defineWorkflow({
+  name: "fire-wf",
+  tasks: { t: { agent, input: {} } },
+});
+
+beforeEach(() => registerRunner("stub2", stub));
+afterEach(() => unregisterRunner("stub2"));
+
+describe("fire()", () => {
+  it("invokes onEvent for each event and onComplete at the end", async () => {
+    const runner = createRunner();
+    const events: unknown[] = [];
+    const done = new Promise<void>((resolve) => {
+      runner.fire(
+        wf,
+        {},
+        {
+          onEvent: (ev) => events.push(ev),
+          onComplete: () => resolve(),
+        },
+      );
+    });
+    await done;
+    expect(
+      events.some((e) => (e as { type: string }).type === "workflow:complete"),
+    ).toBe(true);
+    runner.close();
+  });
+
+  it("invokes onError when the workflow fails", async () => {
+    const boomRunner: AgentRunner = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        throw new Error("boom");
+      },
+    };
+    registerRunner("boom2", boomRunner);
+    try {
+      const a = defineAgent({
+        runner: "boom2",
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        prompt: () => "p",
+        retry: { max: 1, on: ["subprocess_error"], backoff: "fixed" },
+      });
+      const wfb = defineWorkflow({
+        name: "b",
+        tasks: { t: { agent: a, input: {} } },
+      });
+      const runner = createRunner();
+      const err = await new Promise<Error>((resolve) => {
+        runner.fire(wfb, {}, { onError: resolve });
+      });
+      expect(err.message).toMatch(/boom/);
+      runner.close();
+    } finally {
+      unregisterRunner("boom2");
+    }
+  });
+
+  it("returns a RunHandle synchronously with state=running", () => {
+    const runner = createRunner();
+    const handle = runner.fire(wf, {});
+    expect(handle.runId).toBeDefined();
+    expect(handle.state).toBe("running");
+    expect(handle.workflowName).toBe("fire-wf");
+    runner.close();
+  });
+});

--- a/agentflow/packages/server/src/__tests__/types.test-d.ts
+++ b/agentflow/packages/server/src/__tests__/types.test-d.ts
@@ -1,0 +1,46 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { describe, expectTypeOf, it } from "vitest";
+import { createRunner } from "../runner.js";
+import type { RunHandle, Runner, WorkflowResult } from "../types.js";
+
+// Use a real but minimal tasks map to avoid the {} ban.
+type EmptyTasks = Record<string, never>;
+
+describe("types", () => {
+  it("stream yields WorkflowEvent, returns WorkflowResult<T>", () => {
+    const r: Runner = createRunner();
+    type WF = WorkflowDef<EmptyTasks>;
+    const gen = r.stream({} as WF);
+    expectTypeOf(gen).toMatchTypeOf<
+      AsyncGenerator<unknown, WorkflowResult<EmptyTasks>, void>
+    >();
+  });
+
+  it("fire returns RunHandle synchronously", () => {
+    const r: Runner = createRunner();
+    type WF = WorkflowDef<EmptyTasks>;
+    expectTypeOf(r.fire({} as WF)).toEqualTypeOf<RunHandle>();
+  });
+
+  it("run returns Promise<WorkflowResult<T>>", () => {
+    const r: Runner = createRunner();
+    type WF = WorkflowDef<EmptyTasks>;
+    expectTypeOf(r.run({} as WF)).toMatchTypeOf<
+      Promise<WorkflowResult<EmptyTasks>>
+    >();
+  });
+
+  it("resume and cancel take correct parameter types", () => {
+    const r: Runner = createRunner();
+    expectTypeOf(r.resume).toMatchTypeOf<
+      (runId: string, approved: boolean) => void
+    >();
+    expectTypeOf(r.cancel).toMatchTypeOf<(runId: string) => void>();
+  });
+
+  it("get returns RunHandle | undefined, list returns readonly RunHandle[]", () => {
+    const r: Runner = createRunner();
+    expectTypeOf(r.get("id")).toEqualTypeOf<RunHandle | undefined>();
+    expectTypeOf(r.list()).toMatchTypeOf<readonly RunHandle[]>();
+  });
+});


### PR DESCRIPTION
Phase 11: fire() callbacks + type surface tests. Phase 12: examples/server-embed/ workspace with SSE demo (2 tests). Phase 13: full README + publish metadata for @ageflow/server. Completes #26.