### PR TITLE
ci: add runner-api + mcp-server + server to npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,22 @@ jobs:
         run: npm publish --access public --provenance
         working-directory: agentflow/packages/runners/codex
 
+      - name: Publish @ageflow/runner-api
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/runners/api
+
       - name: Publish @ageflow/testing
         run: npm publish --access public --provenance
         working-directory: agentflow/packages/testing
 
-      - name: Publish ageflow (CLI)
+      - name: Publish @ageflow/mcp-server
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/mcp-server
+
+      - name: Publish @ageflow/server
+        run: npm publish --access public --provenance
+        working-directory: agentflow/packages/server
+
+      - name: Publish @ageflow/cli
         run: npm publish --access public --provenance
         working-directory: agentflow/packages/cli


### PR DESCRIPTION
Adds 3 missing packages to the npm publish workflow in topological dependency order:

1. @ageflow/runner-api (depends on core)
2. @ageflow/mcp-server (depends on core + executor)
3. @ageflow/server (depends on core + executor)

Also updates CLI step header from 'Publish ageflow (CLI)' to 'Publish @ageflow/cli'.

The workflow now publishes all 9 packages in correct dependency order.