### PR TITLE
chore: bump all packages to v0.2.0

### DIFF
--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/cli",
   "type": "module",

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/core",
   "type": "module",

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/executor",
   "type": "module",

--- a/agentflow/packages/mcp-server/package.json
+++ b/agentflow/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Expose ageflow workflows as MCP tools (stdio transport, progress streaming, HITL via elicitation).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/mcp-server",
   "type": "module",

--- a/agentflow/packages/runners/api/package.json
+++ b/agentflow/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/api",
   "type": "module",

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-claude",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Claude CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/claude",
   "type": "module",

--- a/agentflow/packages/runners/codex/package.json
+++ b/agentflow/packages/runners/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-codex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenAI Codex CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/codex",
   "type": "module",

--- a/agentflow/packages/server/package.json
+++ b/agentflow/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embeddable execution surface for ageflow workflows: stream, fire-and-forget, async HITL, cancellation.",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/server",
   "type": "module",

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/testing",
   "type": "module",


### PR DESCRIPTION
Bump all 9 packages from v0.1.0 to v0.2.0.

## New surface in v0.2.0
- runner-api: OpenAI-compatible HTTP runner
- mcp-server: MCP tool transport for workflows
- server: Embeddable execution surface with streaming events and async HITL
- core: WorkflowEvent + stream() API
- executor: Event streaming and job-based async support