### PR TITLE
docs: implementation plan for MCP job-based async (#18)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-mcp-async.md
+++ b/docs/superpowers/plans/2026-04-16-mcp-async.md
@@ -1,0 +1,1782 @@
+# MCP Job-Based Async Execution — Implementation Plan
+
+**Date:** 2026-04-16
+**Issue:** #18
+**Spec:** `docs/superpowers/specs/2026-04-16-mcp-async-design.md`
+**Status:** Ready to execute
+
+---
+
+## Goal
+
+Add an **opt-in async mode** to `@ageflow/mcp-server` that exposes five
+additional MCP tools (`start_<wf>`, `get_workflow_status`,
+`get_workflow_result`, `resume_workflow`, `cancel_workflow`) alongside
+the existing synchronous streaming tool. Async mode is enabled by an
+`async: true` server option (or `--async` on the CLI) and is
+**off by default** — today's sync streaming behaviour is preserved
+byte-for-byte when the flag is off.
+
+The job machinery is **not** reimplemented: the async path delegates to
+`@ageflow/server`'s `createRunner()` (shipped in #26), which already
+owns `RunHandle`, `RunRegistry`, TTL sweeping, async-HITL via deferred
+resolution, and `AbortController` plumbing.
+
+No new transport, no persistence, no multi-tenant auth.
+
+## Architecture
+
+```
+@ageflow/core (existing)
+  └── RunHandle / RunState / WorkflowEvent already exported (from #26)
+
+@ageflow/server (existing, from #26)
+  └── createRunner() — fire() / resume() / cancel() / get() / list()
+       + in-memory RunRegistry with TTL sweeping
+       + deferred-checkpoint path for async HITL
+
+@ageflow/mcp-server (extended)
+  ├── server.ts           — new `async?: boolean` option; routes to sync or async dispatch
+  ├── types.ts            — McpServerOptions: `async?`, `jobTtlMs?`, `jobCheckpointTtlMs?`
+  ├── errors.ts           — new ErrorCodes: JOB_NOT_FOUND, JOB_CANCELLED,
+  │                          INVALID_RUN_STATE, ASYNC_MODE_DISABLED
+  ├── job-tools.ts        — new: buildJobTools(workflow) → 5 ToolDefinition[]
+  ├── job-event-recorder.ts — new: tracks task:start / task:complete / budget:warning
+  │                            per-runId for status reporting
+  ├── job-dispatch.ts     — new: callTool handlers for the 5 async tools
+  └── index.ts            — public re-exports
+```
+
+Dependency shape after the change: `mcp-server → {core, executor, server}`.
+No cycle (`server → {core, executor}`).
+
+## Tech stack
+
+- Runtime: Bun / Node 20+ (already used by mcp-server)
+- Types: TypeScript strict, extends `tsconfig.base.json`
+- Tests: Vitest (`environment: "node"`, fake timers for TTL tests)
+- Lint: Biome (inherited)
+- **New runtime dep on `@ageflow/server` (workspace:\*)** — see Phase 1
+- No new HTTP or transport libs
+
+## Spec references (resolved decisions)
+
+- **Reuse `@ageflow/server`, do not duplicate.** Async HITL is the hardest
+  piece; `createRunner()` already delivers it (spec §Architecture). No
+  inline `JobRegistry`.
+- **Five job tools, not four.** `resume_workflow` is mandatory — without
+  it, checkpoints always hit `checkpointTtlMs` and auto-reject
+  (spec §6).
+- **Same workflow, two surfaces.** Sync tool stays; job tools are
+  namespaced `start_<workflow>` / generic observer names (spec §4).
+- **Shared `inflight` lock** across the sync tool and `start_*` —
+  observer tools (`get_*`, `cancel_workflow`, `resume_workflow`) do
+  **not** acquire it (spec §5).
+- **Defaults:** `jobTtlMs = 30 min`; `jobCheckpointTtlMs = 1 hour`
+  (spec §5).
+- **`get_workflow_result` is cached, not consumed.** Idempotent reads
+  until TTL (spec §Open questions #3).
+- **Per-workflow `start_*` naming.** `start_<workflow.name>`; revisit
+  only if one server hosts multiple workflows (spec §Open questions #1).
+- **Out of scope:** distributed jobs, persistence, queueing, bulk APIs,
+  auth, webhooks (spec §Non-goals).
+
+## Runner contract consumed from `@ageflow/server`
+
+```ts
+// from packages/server/src/types.ts
+interface Runner {
+  fire(workflow, input?, options?: FireOptions): RunHandle;
+  resume(runId: string, approved: boolean): void;
+  cancel(runId: string): void;
+  get(runId: string): RunHandle | undefined;
+  close(): void;
+  // stream() and run() — not used by mcp-server async path
+}
+
+interface FireOptions extends RunOptions {
+  onEvent?(ev: WorkflowEvent): void;
+  onError?(err: Error): void;
+  onComplete?(result: WorkflowResult): void;
+}
+
+// RunHandle (from @ageflow/core)
+interface RunHandle {
+  runId: string;
+  state: RunState;   // "running" | "awaiting-checkpoint" | "done" | "failed" | "cancelled"
+  workflowName: string;
+  createdAt: number;
+  lastEventAt: number;
+  pendingCheckpoint?: CheckpointEvent;
+  result?: { outputs: Record<string, unknown>; metrics: WorkflowMetrics };
+  error?: { name: string; message: string };
+}
+```
+
+All five async tools are thin wrappers around these methods plus input/output
+Zod validation and an event recorder for progress data not present on
+`RunHandle`.
+
+---
+
+## File structure
+
+### New files
+
+| Path | Purpose |
+|------|---------|
+| `packages/mcp-server/src/job-tools.ts` | `buildJobTools(workflow)` → array of 5 `ToolDefinition`s |
+| `packages/mcp-server/src/job-event-recorder.ts` | `JobEventRecorder` class — `Map<runId, ProgressSnapshot>` fed from `fire({ onEvent })` |
+| `packages/mcp-server/src/job-dispatch.ts` | `dispatchJobTool(name, args, ctx)` — routes to runner + recorder |
+| `packages/mcp-server/src/__tests__/job-tools.test.ts` | Snapshot test on the 5 tool definitions |
+| `packages/mcp-server/src/__tests__/job-event-recorder.test.ts` | Recorder state machine unit tests |
+| `packages/mcp-server/src/__tests__/integration/async-mode.test.ts` | Happy path, cancel, HITL resume, HITL deny, BUSY, validation, TTL |
+| `packages/mcp-server/src/__tests__/async-mode.test-d.ts` | Type-level: `start_<wf>` input type === sync tool input type |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `packages/mcp-server/package.json` | Add `"@ageflow/server": "workspace:*"` to `dependencies` |
+| `packages/mcp-server/tsconfig.json` | Add `{ "path": "../server" }` to `references`; add `@ageflow/server` to `paths` |
+| `packages/mcp-server/src/types.ts` | Nothing (CliCeilings / HitlStrategy unchanged) |
+| `packages/mcp-server/src/errors.ts` | Add `JOB_NOT_FOUND`, `JOB_CANCELLED`, `INVALID_RUN_STATE`, `ASYNC_MODE_DISABLED`; map `RunNotFoundError` / `InvalidRunStateError` / `CheckpointTimeoutError` in `formatErrorResult` |
+| `packages/mcp-server/src/server.ts` | Add `async?: boolean`, `jobTtlMs?`, `jobCheckpointTtlMs?` to `McpServerOptions`; lazy-create Runner on first `start_*`; split callTool into sync vs. async dispatch; share inflight lock; clear lock from `fire({ onComplete, onError })` |
+| `packages/mcp-server/src/index.ts` | Re-export the new error codes |
+| `packages/cli/src/commands/mcp-serve.ts` | Add `--async`, `--job-ttl <ms>`, `--checkpoint-ttl <ms>` flag parsing + thread to `createMcpServer()` |
+| `packages/cli/src/__tests__/mcp-serve.test.ts` | Extend parser tests for new flags |
+| `packages/mcp-server/README.md` | Document async mode: when to use, tool surface, curl / mcp-client snippets |
+| `examples/mcp-server/README.md` | Add "Async mode" section with `agentwf mcp serve workflow.ts --async` |
+| `examples/mcp-server/mcp-client.test.ts` | Add async-mode smoke test that starts, polls, gets result |
+| `agentflow/CLAUDE.md` | Note `@ageflow/mcp-server` now depends on `@ageflow/server` (async mode) |
+
+---
+
+## Phases
+
+Each task = one commit with a fixed message. TDD order: failing test
+first, then implementation, then green. **Sync mode tests must stay
+green after every task** — regressions in the default path are the
+primary failure mode for this change.
+
+### Phase 1 — Wire `@ageflow/server` as a dependency
+
+Zero behaviour change. Make sure async code can import from
+`@ageflow/server` before we write any of it.
+
+#### Task 1.1 — failing build: import `createRunner` from a file that doesn't exist yet
+
+Create `packages/mcp-server/src/job-dispatch.ts` with a single import
+line to force the type/ref failure:
+
+```ts
+import { createRunner } from "@ageflow/server";
+
+// Placeholder to keep the module non-empty. Real impl lands in Phase 4.
+export const _unused = createRunner;
+```
+
+Run `bun run --filter @ageflow/mcp-server typecheck` → fails (no
+workspace reference, module not resolvable).
+
+#### Task 1.2 — add workspace dep + tsconfig reference
+
+1. `packages/mcp-server/package.json`:
+
+```jsonc
+{
+  // ...
+  "dependencies": {
+    "@ageflow/core": "workspace:*",
+    "@ageflow/executor": "workspace:*",
+    "@ageflow/server": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod-to-json-schema": "^3.23.0"
+  }
+}
+```
+
+2. `packages/mcp-server/tsconfig.json`:
+
+```jsonc
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@ageflow/core": ["../core/src/index.ts"],
+      "@ageflow/executor": ["../executor/src/index.ts"],
+      "@ageflow/server": ["../server/src/index.ts"]
+    }
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../executor" },
+    { "path": "../server" }
+  ],
+  // ...
+}
+```
+
+3. `bun install` at repo root to re-link workspaces.
+
+4. Verify: `bun run --filter @ageflow/mcp-server typecheck` → green.
+   `bun run --filter @ageflow/mcp-server test` → existing suite still
+   green (no behaviour change — the `_unused` const is never referenced
+   at runtime).
+
+**Commit:** `feat(mcp-server): add @ageflow/server dependency for async mode (#18)`
+
+---
+
+### Phase 2 — `JobEventRecorder`
+
+Pure in-memory state. No runner, no MCP, no async logic yet. Exists so
+`get_workflow_status.currentTask` / `.progress` have a data source —
+`RunHandle` alone doesn't carry them (spec §5 "Event recorder").
+
+#### Task 2.1 — failing test: recorder state machine
+
+Create `packages/mcp-server/src/__tests__/job-event-recorder.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { JobEventRecorder } from "../job-event-recorder.js";
+import type {
+  BudgetWarningEvent,
+  TaskCompleteEvent,
+  TaskStartEvent,
+} from "@ageflow/core";
+
+const baseEv = {
+  runId: "r1",
+  workflowName: "wf",
+  timestamp: 0,
+};
+
+describe("JobEventRecorder", () => {
+  it("tracks lastTaskStart, tasksCompleted, lastBudgetWarning per runId", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    expect(rec.snapshot("r1")).toMatchObject({
+      tasksCompleted: 0,
+      lastTaskStart: { taskName: "a" },
+    });
+
+    rec.record({
+      ...baseEv,
+      type: "task:complete",
+      taskName: "a",
+      output: {},
+      metrics: { latencyMs: 0, tokensIn: 0, tokensOut: 0, estimatedCost: 0 },
+    } as TaskCompleteEvent);
+    expect(rec.snapshot("r1")?.tasksCompleted).toBe(1);
+
+    rec.record({
+      ...baseEv,
+      type: "budget:warning",
+      spentUsd: 0.5,
+      limitUsd: 1.0,
+    } as BudgetWarningEvent);
+    expect(rec.snapshot("r1")?.lastBudgetWarning).toEqual({
+      spentUsd: 0.5,
+      limitUsd: 1.0,
+    });
+  });
+
+  it("isolates state between runIds", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, runId: "a", type: "task:start", taskName: "x" } as TaskStartEvent);
+    rec.record({ ...baseEv, runId: "b", type: "task:start", taskName: "y" } as TaskStartEvent);
+    expect(rec.snapshot("a")?.lastTaskStart?.taskName).toBe("x");
+    expect(rec.snapshot("b")?.lastTaskStart?.taskName).toBe("y");
+  });
+
+  it("returns undefined for unknown runId", () => {
+    const rec = new JobEventRecorder();
+    expect(rec.snapshot("ghost")).toBeUndefined();
+  });
+
+  it("drops state on forget(runId)", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    expect(rec.snapshot("r1")).toBeDefined();
+    rec.forget("r1");
+    expect(rec.snapshot("r1")).toBeUndefined();
+  });
+});
+```
+
+Run → fails (module doesn't exist).
+
+#### Task 2.2 — implement the recorder
+
+Create `packages/mcp-server/src/job-event-recorder.ts`:
+
+```ts
+import type { WorkflowEvent } from "@ageflow/core";
+
+export interface ProgressSnapshot {
+  readonly lastTaskStart?: { readonly taskName: string; readonly at: number };
+  readonly tasksCompleted: number;
+  readonly lastBudgetWarning?: {
+    readonly spentUsd: number;
+    readonly limitUsd: number;
+    readonly at: number;
+  };
+}
+
+/**
+ * Per-run progress accumulator. Fed by the executor's event stream via
+ * `fire({ onEvent })` inside the job dispatcher.
+ *
+ * Lifetime: entries are created on the first event for a runId and cleared
+ * explicitly via `forget(runId)` when the corresponding RunHandle leaves
+ * the RunRegistry (TTL eviction or terminal state + cleanup pass).
+ */
+export class JobEventRecorder {
+  private readonly map = new Map<string, ProgressSnapshotMutable>();
+
+  record(ev: WorkflowEvent): void {
+    const snap = this.ensure(ev.runId);
+    switch (ev.type) {
+      case "task:start":
+        snap.lastTaskStart = { taskName: ev.taskName, at: ev.timestamp };
+        return;
+      case "task:complete":
+        snap.tasksCompleted += 1;
+        return;
+      case "budget:warning":
+        snap.lastBudgetWarning = {
+          spentUsd: ev.spentUsd,
+          limitUsd: ev.limitUsd,
+          at: ev.timestamp,
+        };
+        return;
+      default:
+        return;
+    }
+  }
+
+  snapshot(runId: string): ProgressSnapshot | undefined {
+    return this.map.get(runId);
+  }
+
+  forget(runId: string): void {
+    this.map.delete(runId);
+  }
+
+  private ensure(runId: string): ProgressSnapshotMutable {
+    let s = this.map.get(runId);
+    if (!s) {
+      s = { tasksCompleted: 0 };
+      this.map.set(runId, s);
+    }
+    return s;
+  }
+}
+
+interface ProgressSnapshotMutable {
+  lastTaskStart?: { taskName: string; at: number };
+  tasksCompleted: number;
+  lastBudgetWarning?: { spentUsd: number; limitUsd: number; at: number };
+}
+```
+
+Run tests → green.
+
+**Commit:** `feat(mcp-server): JobEventRecorder tracks progress per runId (#18)`
+
+---
+
+### Phase 3 — New error codes + server-error mapping
+
+Pure additive changes to `errors.ts`. `formatErrorResult` is extended to
+map thrown errors from `@ageflow/server` onto MCP error codes.
+
+#### Task 3.1 — failing test: async error codes exist and map correctly
+
+Append to `packages/mcp-server/src/__tests__/errors.test.ts`:
+
+```ts
+import { ErrorCode, formatErrorResult } from "../errors.js";
+import { RunNotFoundError, InvalidRunStateError, CheckpointTimeoutError } from "@ageflow/server";
+
+describe("async-mode error mapping (#18)", () => {
+  it("includes new codes in ErrorCode enum", () => {
+    expect(ErrorCode.JOB_NOT_FOUND).toBe("JOB_NOT_FOUND");
+    expect(ErrorCode.JOB_CANCELLED).toBe("JOB_CANCELLED");
+    expect(ErrorCode.INVALID_RUN_STATE).toBe("INVALID_RUN_STATE");
+    expect(ErrorCode.ASYNC_MODE_DISABLED).toBe("ASYNC_MODE_DISABLED");
+  });
+
+  it("maps RunNotFoundError → JOB_NOT_FOUND", () => {
+    const result = formatErrorResult(new RunNotFoundError("abc"));
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.JOB_NOT_FOUND);
+  });
+
+  it("maps InvalidRunStateError → INVALID_RUN_STATE", () => {
+    const result = formatErrorResult(new InvalidRunStateError("abc", "done"));
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.INVALID_RUN_STATE);
+    expect(result.structuredContent.context).toMatchObject({ runId: "abc", state: "done" });
+  });
+
+  it("maps CheckpointTimeoutError → HITL_CANCELLED (existing code, reused)", () => {
+    const result = formatErrorResult(new CheckpointTimeoutError("approve"));
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.HITL_CANCELLED);
+  });
+});
+```
+
+Run → fails (codes missing; `formatErrorResult` has no mapping).
+
+#### Task 3.2 — extend `ErrorCode` + `formatErrorResult`
+
+Edit `packages/mcp-server/src/errors.ts`:
+
+```ts
+export const ErrorCode = {
+  // ...existing...
+  JOB_NOT_FOUND: "JOB_NOT_FOUND",
+  JOB_CANCELLED: "JOB_CANCELLED",
+  INVALID_RUN_STATE: "INVALID_RUN_STATE",
+  ASYNC_MODE_DISABLED: "ASYNC_MODE_DISABLED",
+} as const;
+```
+
+And in `formatErrorResult`, insert mapping branches **before** the
+generic fallback:
+
+```ts
+import {
+  CheckpointTimeoutError,
+  InvalidRunStateError,
+  RunNotFoundError,
+} from "@ageflow/server";
+
+// ...inside formatErrorResult:
+if (err instanceof RunNotFoundError) {
+  return {
+    content: [{ type: "text", text: err.message }],
+    structuredContent: {
+      errorCode: ErrorCode.JOB_NOT_FOUND,
+      message: err.message,
+      context: { runId: err.runId },
+    },
+    isError: true,
+  };
+}
+if (err instanceof InvalidRunStateError) {
+  return {
+    content: [{ type: "text", text: err.message }],
+    structuredContent: {
+      errorCode: ErrorCode.INVALID_RUN_STATE,
+      message: err.message,
+      context: { runId: err.runId, state: err.state },
+    },
+    isError: true,
+  };
+}
+if (err instanceof CheckpointTimeoutError) {
+  return {
+    content: [{ type: "text", text: err.message }],
+    structuredContent: {
+      errorCode: ErrorCode.HITL_CANCELLED,
+      message: err.message,
+      context: { taskName: err.taskName },
+    },
+    isError: true,
+  };
+}
+```
+
+Re-export from `packages/mcp-server/src/index.ts`:
+
+```ts
+export { ErrorCode, McpServerError } from "./errors.js";
+// (ErrorCode now carries the new values)
+```
+
+Run → green. Existing error tests still pass.
+
+**Commit:** `feat(mcp-server): async error codes + @ageflow/server error mapping (#18)`
+
+---
+
+### Phase 4 — `buildJobTools(workflow)` — the 5 tool definitions
+
+Pure function: `WorkflowDef → ToolDefinition[]` of length 5. No runtime
+state, no executor coupling. Input schema of `start_<wf>` **must**
+equal the sync tool's input schema (structural equality, enforced in
+tests).
+
+#### Task 4.1 — failing test: 5 tool definitions with exact names + schemas
+
+Create `packages/mcp-server/src/__tests__/job-tools.test.ts`:
+
+```ts
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildJobTools } from "../job-tools.js";
+import { buildToolDefinition } from "../tool-registry.js";
+
+const agent = defineAgent({
+  runner: "fake",
+  input: z.object({ q: z.string() }),
+  output: z.object({ a: z.string() }),
+  prompt: () => "p",
+});
+
+const workflow = defineWorkflow({
+  name: "ask",
+  tasks: { t: { agent, input: { q: "hi" } } },
+});
+
+describe("buildJobTools", () => {
+  it("returns exactly 5 tools with canonical names", () => {
+    const tools = buildJobTools(workflow);
+    expect(tools.map((t) => t.name)).toEqual([
+      "start_ask",
+      "get_workflow_status",
+      "get_workflow_result",
+      "resume_workflow",
+      "cancel_workflow",
+    ]);
+  });
+
+  it("start_<wf> input schema mirrors the sync tool's input schema", () => {
+    const sync = buildToolDefinition(workflow);
+    const [startTool] = buildJobTools(workflow);
+    expect(startTool?.inputSchema).toEqual(sync.inputSchema);
+  });
+
+  it("start_<wf> output schema is { jobId: string }", () => {
+    const [startTool] = buildJobTools(workflow);
+    expect(startTool?.outputSchema).toMatchObject({
+      type: "object",
+      required: ["jobId"],
+      properties: { jobId: { type: "string" } },
+    });
+  });
+
+  it("observer tools share the { jobId } input schema", () => {
+    const tools = buildJobTools(workflow);
+    for (const name of ["get_workflow_status", "get_workflow_result", "cancel_workflow"]) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool?.inputSchema).toMatchObject({
+        type: "object",
+        required: ["jobId"],
+        properties: { jobId: { type: "string" } },
+      });
+    }
+  });
+
+  it("resume_workflow input is { jobId, approved }", () => {
+    const tools = buildJobTools(workflow);
+    const resume = tools.find((t) => t.name === "resume_workflow");
+    expect(resume?.inputSchema).toMatchObject({
+      type: "object",
+      required: ["jobId", "approved"],
+      properties: {
+        jobId: { type: "string" },
+        approved: { type: "boolean" },
+      },
+    });
+  });
+
+  it("get_workflow_status output schema covers state + currentTask + progress", () => {
+    const tools = buildJobTools(workflow);
+    const status = tools.find((t) => t.name === "get_workflow_status");
+    const props = (status?.outputSchema as { properties: Record<string, unknown> }).properties;
+    expect(props).toHaveProperty("state");
+    expect(props).toHaveProperty("currentTask");
+    expect(props).toHaveProperty("progress");
+    expect(props).toHaveProperty("createdAt");
+    expect(props).toHaveProperty("lastEventAt");
+  });
+});
+```
+
+Run → fails (module missing).
+
+#### Task 4.2 — implement `buildJobTools`
+
+Create `packages/mcp-server/src/job-tools.ts`:
+
+```ts
+import type { WorkflowDef } from "@ageflow/core";
+import { type ToolDefinition, buildToolDefinition } from "./tool-registry.js";
+
+const JOB_ID_SCHEMA = {
+  type: "object",
+  required: ["jobId"],
+  properties: { jobId: { type: "string", description: "Job identifier (UUID)" } },
+  additionalProperties: false,
+} as const;
+
+const RESUME_SCHEMA = {
+  type: "object",
+  required: ["jobId", "approved"],
+  properties: {
+    jobId: { type: "string", description: "Job identifier (UUID)" },
+    approved: { type: "boolean", description: "true to approve checkpoint, false to reject" },
+  },
+  additionalProperties: false,
+} as const;
+
+const STATUS_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["state", "createdAt", "lastEventAt"],
+  properties: {
+    state: {
+      type: "string",
+      enum: ["running", "awaiting-checkpoint", "done", "failed", "cancelled"],
+    },
+    currentTask: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        kind: { type: "string", enum: ["task", "checkpoint"] },
+        message: { type: "string" },
+      },
+    },
+    progress: {
+      type: "object",
+      properties: {
+        tasksCompleted: { type: "number" },
+        tasksTotal: { type: "number" },
+        spentUsd: { type: "number" },
+        limitUsd: { type: "number" },
+      },
+    },
+    createdAt: { type: "number" },
+    lastEventAt: { type: "number" },
+  },
+} as const;
+
+const RESULT_OUTPUT_SCHEMA = {
+  type: "object",
+  // Either { pending: true } OR { state: "done", output: ..., metrics: ... }
+  properties: {
+    pending: { type: "boolean" },
+    state: { type: "string" },
+    output: {},
+    metrics: { type: "object" },
+  },
+} as const;
+
+const CANCEL_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["cancelled", "priorState"],
+  properties: {
+    cancelled: { type: "boolean" },
+    priorState: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const RESUME_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["resumed"],
+  properties: { resumed: { type: "boolean" } },
+  additionalProperties: false,
+} as const;
+
+/**
+ * Build the 5 MCP tool definitions exposed in async mode:
+ *
+ *   start_<workflow.name>   — fire-and-forget; returns { jobId }
+ *   get_workflow_status     — poll state + progress
+ *   get_workflow_result     — fetch validated output (or { pending: true })
+ *   resume_workflow         — approve/reject a checkpoint
+ *   cancel_workflow         — best-effort cancel
+ *
+ * Named after the workflow so clients get per-workflow input typing
+ * (spec §Open questions #1). Observer tools are generic because any
+ * call references a runId that a `start_*` produced.
+ */
+export function buildJobTools(workflow: WorkflowDef): readonly ToolDefinition[] {
+  const sync = buildToolDefinition(workflow);
+  const wf = workflow.name;
+  return [
+    {
+      name: `start_${wf}`,
+      description: `Start workflow "${wf}" asynchronously. Returns a jobId for polling.`,
+      inputSchema: sync.inputSchema,
+      outputSchema: {
+        type: "object",
+        required: ["jobId"],
+        properties: { jobId: { type: "string", description: "UUID for polling" } },
+        additionalProperties: false,
+      },
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "get_workflow_status",
+      description: "Poll the current state of an async workflow job.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: STATUS_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "get_workflow_result",
+      description:
+        "Fetch the validated output of a completed async workflow job. Returns { pending: true } while still running.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: RESULT_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "resume_workflow",
+      description:
+        "Resolve an awaiting-checkpoint job. Pass approved=true to continue, false to reject.",
+      inputSchema: RESUME_SCHEMA,
+      outputSchema: RESUME_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "cancel_workflow",
+      description:
+        "Cancel an async workflow job. Idempotent: returns cancelled=false if the job is already terminal.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: CANCEL_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+  ];
+}
+```
+
+Run tests → green.
+
+**Commit:** `feat(mcp-server): buildJobTools produces 5 async tool definitions (#18)`
+
+---
+
+### Phase 5 — `McpServerOptions.async` + `listTools` routing
+
+No dispatch yet — just the server option, the listTools branch, and the
+TTL overrides. Touching `callTool` with a non-sync name in async mode
+returns a placeholder error until Phase 6.
+
+#### Task 5.1 — failing test: listTools shape depends on `async`
+
+Create `packages/mcp-server/src/__tests__/integration/async-mode.test.ts`
+(the file we'll build up over Phases 5–8):
+
+```ts
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createMcpServer } from "../../server.js";
+
+const agent = defineAgent({
+  runner: "fake",
+  input: z.object({ q: z.string() }),
+  output: z.object({ a: z.string() }),
+  prompt: () => "p",
+});
+
+const workflow = defineWorkflow({
+  name: "ask",
+  tasks: { t: { agent, input: { q: "hi" } } },
+});
+
+describe("async mode: listTools (#18)", () => {
+  it("returns 1 tool when async is omitted (default)", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["ask"]);
+  });
+
+  it("returns 1 tool when async: false", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: false,
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["ask"]);
+  });
+
+  it("returns 6 tools when async: true (sync + 5 job tools)", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      [
+        "ask",
+        "cancel_workflow",
+        "get_workflow_result",
+        "get_workflow_status",
+        "resume_workflow",
+        "start_ask",
+      ].sort(),
+    );
+  });
+});
+```
+
+Run → fails (`async` not a known option; listTools returns only 1).
+
+#### Task 5.2 — add options + wire listTools
+
+Edit `packages/mcp-server/src/server.ts`:
+
+1. Extend `McpServerOptions`:
+
+```ts
+export interface McpServerOptions {
+  readonly workflow: WorkflowDef;
+  readonly cliCeilings: CliCeilings;
+  readonly hitlStrategy: HitlStrategy;
+  /** Opt-in async job mode. Default: false. */
+  readonly async?: boolean;
+  /** Override the default 30-minute job TTL (async mode only). */
+  readonly jobTtlMs?: number;
+  /** Override the default 1-hour checkpoint TTL (async mode only). */
+  readonly jobCheckpointTtlMs?: number;
+  readonly stderr?: (line: string) => void;
+  readonly runWorkflow?: RunWorkflowFn;
+}
+```
+
+2. Inside `createMcpServer`, compute job tools eagerly only when
+   `async === true`:
+
+```ts
+import { buildJobTools } from "./job-tools.js";
+
+const jobTools = opts.async === true ? buildJobTools(opts.workflow) : [];
+```
+
+3. Replace `listTools()`:
+
+```ts
+async listTools() {
+  return opts.async === true ? [tool, ...jobTools] : [tool];
+}
+```
+
+4. In `callTool`, short-circuit unknown-tool handling for any job tool
+   name with a stub that returns `ASYNC_MODE_DISABLED` unless async is
+   on. Actual dispatch comes in Phase 6 — for now throw "not
+   implemented" as an `McpServerError` with code `WORKFLOW_FAILED` to
+   keep other tests running. (This intermediate failure only surfaces if
+   someone calls a job tool in Phase 5; the Phase-5 tests only check
+   `listTools`.)
+
+Run tests → listTools tests green; existing callTool tests unchanged.
+
+**Commit:** `feat(mcp-server): async option + listTools returns job tools when enabled (#18)`
+
+---
+
+### Phase 6 — Job dispatch: `start_<wf>` + observer tools
+
+This is the meat. `callTool` now branches: sync tool → existing path;
+`start_<wf>` → `runner.fire()`; observer tools → registry reads.
+
+#### Task 6.1 — lazy `Runner` + test: start_<wf> returns a jobId
+
+Append to `async-mode.test.ts`:
+
+```ts
+describe("async mode: start_<wf> (#18)", () => {
+  it("returns a jobId and registers a RunHandle in state 'running'", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    // Inject a no-op executor so we can observe the RunHandle without real work.
+    // (_testRunExecutor is replaced by an injected runWorkflow for async mode — see Task 6.2 note.)
+    h._testRunExecutor = async () => ({ a: "done" });
+
+    const res = await h.callTool("start_ask", { q: "hello" });
+    expect(res.isError).toBe(false);
+    if (!res.isError) {
+      expect(res.structuredContent).toMatchObject({
+        jobId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      });
+    }
+  });
+
+  it("rejects invalid input with INPUT_VALIDATION_FAILED", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    const res = await h.callTool("start_ask", { q: 42 });
+    expect(res.isError).toBe(true);
+    if (res.isError) {
+      expect(res.structuredContent.errorCode).toBe("INPUT_VALIDATION_FAILED");
+    }
+  });
+});
+```
+
+Run → fails (dispatch not implemented).
+
+#### Task 6.2 — implement `start_<wf>` dispatch
+
+Create `packages/mcp-server/src/job-dispatch.ts`:
+
+```ts
+import type { WorkflowDef, WorkflowEvent } from "@ageflow/core";
+import { createRunner, type Runner } from "@ageflow/server";
+import { ErrorCode, McpServerError, formatErrorResult } from "./errors.js";
+import { JobEventRecorder } from "./job-event-recorder.js";
+import type { ToolDefinition } from "./tool-registry.js";
+import type { McpToolResult } from "./server.js";
+
+export interface JobDispatchContext {
+  readonly runner: Runner;
+  readonly recorder: JobEventRecorder;
+  readonly workflow: WorkflowDef;
+  readonly tool: ToolDefinition;                 // sync tool (for output validation)
+  readonly jobTools: readonly ToolDefinition[];  // full job-tool array
+  /** Executor injection hook from tests (mirrors sync path's _testRunExecutor). */
+  readonly testRunExecutor?: (input: unknown) => Promise<unknown>;
+  /** Task count in the workflow (for progress.tasksTotal). */
+  readonly taskCount: number;
+  /** Called from fire() onComplete/onError to release the inflight lock. */
+  readonly releaseInflight: () => void;
+}
+
+export async function dispatchStart(
+  toolName: string,
+  args: unknown,
+  ctx: JobDispatchContext,
+): Promise<McpToolResult> {
+  // Validate input via the sync tool's input Zod (shared between sync + async)
+  const inputTaskDef = ctx.workflow.tasks[ctx.tool.inputTask] as {
+    agent: { input: import("zod").ZodType };
+  };
+  const parsed = inputTaskDef.agent.input.safeParse(args);
+  if (!parsed.success) {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.INPUT_VALIDATION_FAILED,
+        `schema validation failed: ${String(parsed.error)}`,
+        { error: parsed.error },
+      ),
+    );
+  }
+
+  const handle = ctx.runner.fire(ctx.workflow, parsed.data, {
+    // onCheckpoint is intentionally OMITTED — triggers server's deferred path
+    // (handle.markAwaitingCheckpoint(ev, resolver)) so resume_workflow can clear it.
+    onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
+    onComplete: () => {
+      ctx.releaseInflight();
+    },
+    onError: () => {
+      ctx.releaseInflight();
+    },
+  });
+
+  return {
+    content: [{ type: "text", text: JSON.stringify({ jobId: handle.runId }) }],
+    structuredContent: { jobId: handle.runId },
+    isError: false,
+  };
+}
+
+export function dispatchGetStatus(args: unknown, ctx: JobDispatchContext): McpToolResult {
+  const jobId = assertJobId(args);
+  const handle = ctx.runner.get(jobId);
+  if (!handle) return formatErrorResult(new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, { jobId }));
+  const snap = ctx.recorder.snapshot(jobId);
+  const currentTask =
+    handle.state === "awaiting-checkpoint" && handle.pendingCheckpoint
+      ? {
+          name: handle.pendingCheckpoint.taskName,
+          kind: "checkpoint" as const,
+          message: handle.pendingCheckpoint.message,
+        }
+      : snap?.lastTaskStart
+        ? { name: snap.lastTaskStart.taskName, kind: "task" as const }
+        : undefined;
+  const progress = snap
+    ? {
+        tasksCompleted: snap.tasksCompleted,
+        tasksTotal: ctx.taskCount,
+        ...(snap.lastBudgetWarning !== undefined
+          ? {
+              spentUsd: snap.lastBudgetWarning.spentUsd,
+              limitUsd: snap.lastBudgetWarning.limitUsd,
+            }
+          : {}),
+      }
+    : undefined;
+
+  const structured = {
+    state: handle.state,
+    createdAt: handle.createdAt,
+    lastEventAt: handle.lastEventAt,
+    ...(currentTask !== undefined ? { currentTask } : {}),
+    ...(progress !== undefined ? { progress } : {}),
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(structured) }],
+    structuredContent: structured,
+    isError: false,
+  };
+}
+
+export function dispatchGetResult(args: unknown, ctx: JobDispatchContext): McpToolResult {
+  const jobId = assertJobId(args);
+  const handle = ctx.runner.get(jobId);
+  if (!handle) return formatErrorResult(new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, { jobId }));
+
+  if (handle.state === "running" || handle.state === "awaiting-checkpoint") {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ pending: true }) }],
+      structuredContent: { pending: true },
+      isError: false,
+    };
+  }
+  if (handle.state === "cancelled") {
+    return formatErrorResult(
+      new McpServerError(ErrorCode.JOB_CANCELLED, `job ${jobId} was cancelled`, { jobId }),
+    );
+  }
+  if (handle.state === "failed") {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.WORKFLOW_FAILED,
+        handle.error?.message ?? "workflow failed",
+        { jobId, error: handle.error },
+      ),
+    );
+  }
+  // done — re-validate the output task's result through the output Zod schema.
+  const raw = handle.result?.outputs[ctx.tool.outputTask];
+  const outputTaskDef = ctx.workflow.tasks[ctx.tool.outputTask] as {
+    agent: { output: import("zod").ZodType };
+  };
+  const parsed = outputTaskDef.agent.output.safeParse(raw);
+  if (!parsed.success) {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.OUTPUT_VALIDATION_FAILED,
+        `schema validation failed: ${String(parsed.error)}`,
+        { error: parsed.error },
+      ),
+    );
+  }
+  const structured = {
+    state: "done" as const,
+    output: parsed.data,
+    metrics: handle.result?.metrics,
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(structured) }],
+    structuredContent: structured as Record<string, unknown>,
+    isError: false,
+  };
+}
+
+export function dispatchCancel(args: unknown, ctx: JobDispatchContext): McpToolResult {
+  const jobId = assertJobId(args);
+  const handle = ctx.runner.get(jobId);
+  if (!handle) return formatErrorResult(new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, { jobId }));
+  if (handle.state !== "running" && handle.state !== "awaiting-checkpoint") {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ cancelled: false, priorState: handle.state }) }],
+      structuredContent: { cancelled: false, priorState: handle.state },
+      isError: false,
+    };
+  }
+  const priorState = handle.state;
+  ctx.runner.cancel(jobId);
+  return {
+    content: [{ type: "text", text: JSON.stringify({ cancelled: true, priorState }) }],
+    structuredContent: { cancelled: true, priorState },
+    isError: false,
+  };
+}
+
+export function dispatchResume(args: unknown, ctx: JobDispatchContext): McpToolResult {
+  const parsed = assertResumeArgs(args);
+  try {
+    ctx.runner.resume(parsed.jobId, parsed.approved);
+  } catch (err) {
+    return formatErrorResult(err);
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify({ resumed: true }) }],
+    structuredContent: { resumed: true },
+    isError: false,
+  };
+}
+
+function assertJobId(args: unknown): string {
+  if (typeof args !== "object" || args === null || typeof (args as { jobId?: unknown }).jobId !== "string") {
+    throw new McpServerError(ErrorCode.INPUT_VALIDATION_FAILED, "missing jobId", { args });
+  }
+  return (args as { jobId: string }).jobId;
+}
+
+function assertResumeArgs(args: unknown): { jobId: string; approved: boolean } {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    typeof (args as { jobId?: unknown }).jobId !== "string" ||
+    typeof (args as { approved?: unknown }).approved !== "boolean"
+  ) {
+    throw new McpServerError(ErrorCode.INPUT_VALIDATION_FAILED, "missing jobId or approved", { args });
+  }
+  return args as { jobId: string; approved: boolean };
+}
+
+/** Factory used by server.ts to build the per-server dispatch context. */
+export function createJobDispatchContext(args: {
+  workflow: WorkflowDef;
+  tool: ToolDefinition;
+  jobTools: readonly ToolDefinition[];
+  jobTtlMs?: number;
+  jobCheckpointTtlMs?: number;
+  releaseInflight: () => void;
+}): JobDispatchContext {
+  const runner = createRunner({
+    ttlMs: args.jobTtlMs ?? 30 * 60_000,
+    checkpointTtlMs: args.jobCheckpointTtlMs ?? 60 * 60_000,
+  });
+  return {
+    runner,
+    recorder: new JobEventRecorder(),
+    workflow: args.workflow,
+    tool: args.tool,
+    jobTools: args.jobTools,
+    taskCount: Object.keys(args.workflow.tasks).length,
+    releaseInflight: args.releaseInflight,
+  };
+}
+```
+
+#### Task 6.3 — wire dispatch into `server.ts`
+
+Replace `createMcpServer`'s `callTool` body with the shared-inflight
+router described in spec §5:
+
+```ts
+let inflight = false;
+let dispatchCtx: JobDispatchContext | undefined; // lazy — created on first start_*
+
+const startName = `start_${opts.workflow.name}`;
+const OBSERVER_TOOLS = new Set(["get_workflow_status", "get_workflow_result", "cancel_workflow", "resume_workflow"]);
+
+async callTool(name, args, callOpts) {
+  const isSync = name === tool.name;
+  const isStart = opts.async === true && name === startName;
+  const isObserver = opts.async === true && OBSERVER_TOOLS.has(name);
+
+  if (!isSync && !isStart && !isObserver) {
+    if (opts.async !== true && (name === startName || OBSERVER_TOOLS.has(name))) {
+      return formatErrorResult(
+        new McpServerError(ErrorCode.ASYNC_MODE_DISABLED, `async mode is disabled; tool "${name}" is unavailable`, { name }),
+      );
+    }
+    return formatErrorResult(
+      new McpServerError(ErrorCode.WORKFLOW_FAILED, `unknown tool: ${name}`, { name }),
+    );
+  }
+
+  // Observer tools: no lock.
+  if (isObserver) {
+    const ctx = ensureDispatchCtx();
+    switch (name) {
+      case "get_workflow_status":  return dispatchGetStatus(args, ctx);
+      case "get_workflow_result":  return dispatchGetResult(args, ctx);
+      case "cancel_workflow":      return dispatchCancel(args, ctx);
+      case "resume_workflow":      return dispatchResume(args, ctx);
+    }
+  }
+
+  // Sync + start_*: share the inflight lock.
+  if (inflight) {
+    return formatErrorResult(new McpServerError(ErrorCode.BUSY, "Another workflow run is in progress"));
+  }
+  inflight = true;
+
+  if (isStart) {
+    const ctx = ensureDispatchCtx();
+    // releaseInflight was passed into ctx at creation — it flips `inflight = false`
+    // from onComplete/onError. Return the jobId immediately.
+    return await dispatchStart(name, args, ctx);
+  }
+
+  // Sync path (existing body) — unchanged, with inflight cleared in finally.
+  try { /* ...existing sync body... */ } finally { inflight = false; }
+
+  function ensureDispatchCtx(): JobDispatchContext {
+    if (!dispatchCtx) {
+      dispatchCtx = createJobDispatchContext({
+        workflow: opts.workflow,
+        tool,
+        jobTools,
+        ...(opts.jobTtlMs !== undefined ? { jobTtlMs: opts.jobTtlMs } : {}),
+        ...(opts.jobCheckpointTtlMs !== undefined ? { jobCheckpointTtlMs: opts.jobCheckpointTtlMs } : {}),
+        releaseInflight: () => { inflight = false; },
+      });
+    }
+    return dispatchCtx;
+  }
+},
+```
+
+**Close path:** add a `dispose()` method on the handle that calls
+`dispatchCtx?.runner.close()` so tests can stop the TTL reaper. Wire
+it into the handle's public type:
+
+```ts
+export interface McpServerHandle {
+  // ...existing...
+  dispose?(): void;
+}
+```
+
+Run → Task 6.1 tests green; sync tests unchanged.
+
+**Commit:** `feat(mcp-server): start_<wf> + observer tool dispatch backed by @ageflow/server (#18)`
+
+---
+
+### Phase 7 — Shared BUSY lock behaviour + resume_workflow
+
+Spec §5 calls this out explicitly; we already wired it in Phase 6.3 but
+only now do we assert the behaviour in tests.
+
+#### Task 7.1 — failing test: shared lock, observers never blocked
+
+Append to `async-mode.test.ts`:
+
+```ts
+describe("async mode: inflight lock (#18)", () => {
+  it("two concurrent start_* calls: second returns BUSY", async () => {
+    // Executor stubbed to block until released; see Task 6.1 note.
+    const h = createMcpServer({ workflow, cliCeilings: {}, hitlStrategy: "auto", async: true });
+    let release!: () => void;
+    h._testRunExecutor = () => new Promise((res) => { release = () => res({ a: "ok" }); });
+
+    const first = h.callTool("start_ask", { q: "1" });
+    const second = await h.callTool("start_ask", { q: "2" });
+    expect(second.isError).toBe(true);
+    if (second.isError) expect(second.structuredContent.errorCode).toBe("BUSY");
+
+    release();
+    await first;
+
+    const third = await h.callTool("start_ask", { q: "3" });
+    expect(third.isError).toBe(false);
+    h.dispose?.();
+  });
+
+  it("get_workflow_status is callable while a job is running", async () => {
+    const h = createMcpServer({ workflow, cliCeilings: {}, hitlStrategy: "auto", async: true });
+    let release!: () => void;
+    h._testRunExecutor = () => new Promise((res) => { release = () => res({ a: "ok" }); });
+
+    const startRes = await h.callTool("start_ask", { q: "q" });
+    if (startRes.isError) throw new Error("start failed");
+    const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+    // While inflight — observer must not be blocked.
+    const status = await h.callTool("get_workflow_status", { jobId });
+    expect(status.isError).toBe(false);
+    if (!status.isError) {
+      expect(status.structuredContent.state).toBe("running");
+    }
+
+    release();
+    h.dispose?.();
+  });
+});
+```
+
+Run → both tests should pass given Phase 6 implementation. Include as
+regression guards.
+
+**Commit:** `test(mcp-server): BUSY lock shared between sync + async, observers exempt (#18)`
+
+#### Task 7.2 — HITL resume flow (end-to-end)
+
+Append to `async-mode.test.ts`:
+
+```ts
+describe("async mode: HITL via poll + resume (#18)", () => {
+  it("workflow emits checkpoint → status shows awaiting-checkpoint → resume(true) unblocks", async () => {
+    // Define a workflow with a hitl-checkpoint task. Use the test harness's
+    // fake runner; inject a real executor so the executor's stream() fires
+    // the checkpoint event.
+    const gatedAgent = defineAgent({
+      runner: "fake",
+      input: z.object({ q: z.string() }),
+      output: z.object({ a: z.string() }),
+      prompt: () => "p",
+      hitl: { mode: "checkpoint", message: "approve?" },
+    });
+    const gatedWf = defineWorkflow({
+      name: "gated",
+      tasks: { t: { agent: gatedAgent, input: { q: "hi" } } },
+    });
+
+    // Register a test Runner that returns { a: "ok" }.
+    // ...registerRunner("fake", fakeRunner) setup...
+
+    const h = createMcpServer({
+      workflow: gatedWf,
+      cliCeilings: {},
+      hitlStrategy: "auto", // irrelevant — async path bypasses hitl-bridge
+      async: true,
+    });
+
+    const startRes = await h.callTool("start_gated", { q: "hi" });
+    if (startRes.isError) throw new Error("start failed");
+    const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+    // Poll until awaiting-checkpoint.
+    let status: McpToolResult;
+    for (let i = 0; i < 50; i++) {
+      status = await h.callTool("get_workflow_status", { jobId });
+      if (!status.isError && status.structuredContent.state === "awaiting-checkpoint") break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(status!.isError).toBe(false);
+    if (!status!.isError) {
+      expect(status!.structuredContent.state).toBe("awaiting-checkpoint");
+      expect(status!.structuredContent.currentTask).toMatchObject({ kind: "checkpoint" });
+    }
+
+    // Resume with approved=true.
+    const resume = await h.callTool("resume_workflow", { jobId, approved: true });
+    expect(resume.isError).toBe(false);
+
+    // Poll until done.
+    for (let i = 0; i < 50; i++) {
+      status = await h.callTool("get_workflow_status", { jobId });
+      if (!status.isError && status.structuredContent.state === "done") break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    // Fetch result.
+    const result = await h.callTool("get_workflow_result", { jobId });
+    expect(result.isError).toBe(false);
+    if (!result.isError) {
+      expect(result.structuredContent).toMatchObject({ state: "done", output: { a: "ok" } });
+    }
+
+    h.dispose?.();
+  });
+
+  it("resume_workflow(false) → run fails with HITL_DENIED", async () => {
+    // Same setup, but approved=false ⇒ runner throws HitlRejectedError ⇒
+    // handle.state === "failed" ⇒ get_workflow_result yields HITL_DENIED.
+    // ...see spec §7 mapping table.
+  });
+
+  it("resume_workflow when state !== awaiting-checkpoint → INVALID_RUN_STATE", async () => {
+    // start_* → before the workflow reaches a checkpoint, call resume →
+    // InvalidRunStateError → mapped to ErrorCode.INVALID_RUN_STATE.
+  });
+});
+```
+
+The dispatcher already routes `resume_workflow` to `runner.resume()`
+which throws `InvalidRunStateError` on wrong state (caught by
+`formatErrorResult`). No additional code needed — these are regression
+guards on the Phase 6 implementation.
+
+Run → green.
+
+**Commit:** `test(mcp-server): HITL resume / deny / invalid-state flows (#18)`
+
+---
+
+### Phase 8 — TTL + cancellation coverage
+
+#### Task 8.1 — failing test: cancellation end-to-end
+
+Append:
+
+```ts
+describe("async mode: cancel_workflow (#18)", () => {
+  it("start → cancel → status=cancelled → get_workflow_result yields JOB_CANCELLED", async () => {
+    const h = createMcpServer({ workflow, cliCeilings: {}, hitlStrategy: "auto", async: true });
+    let release!: () => void;
+    h._testRunExecutor = () => new Promise((res) => { release = () => res({ a: "ok" }); });
+
+    const startRes = await h.callTool("start_ask", { q: "q" });
+    if (startRes.isError) throw new Error("start failed");
+    const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+    const cancelRes = await h.callTool("cancel_workflow", { jobId });
+    expect(cancelRes.isError).toBe(false);
+    if (!cancelRes.isError) {
+      expect(cancelRes.structuredContent).toMatchObject({ cancelled: true, priorState: "running" });
+    }
+
+    const status = await h.callTool("get_workflow_status", { jobId });
+    if (!status.isError) expect(status.structuredContent.state).toBe("cancelled");
+
+    const result = await h.callTool("get_workflow_result", { jobId });
+    expect(result.isError).toBe(true);
+    if (result.isError) expect(result.structuredContent.errorCode).toBe("JOB_CANCELLED");
+
+    // Idempotent second cancel.
+    const cancel2 = await h.callTool("cancel_workflow", { jobId });
+    if (!cancel2.isError) {
+      expect(cancel2.structuredContent).toMatchObject({ cancelled: false, priorState: "cancelled" });
+    }
+
+    release();
+    h.dispose?.();
+  });
+});
+```
+
+#### Task 8.2 — failing test: checkpoint TTL auto-reject
+
+```ts
+import { vi } from "vitest";
+
+describe("async mode: checkpoint TTL (#18)", () => {
+  it("awaiting-checkpoint job auto-rejects after checkpointTtlMs", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createMcpServer({
+        workflow: /* gated workflow from Phase 7 */,
+        cliCeilings: {},
+        hitlStrategy: "auto",
+        async: true,
+        jobCheckpointTtlMs: 1000,
+        // reaperIntervalMs on RunRegistry is internal; default 60s still fires via fake timers
+      });
+
+      const startRes = await h.callTool("start_gated", { q: "hi" });
+      if (startRes.isError) throw new Error("start failed");
+      const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+      // ... wait until awaiting-checkpoint ...
+
+      vi.advanceTimersByTime(2 * 60_000); // > ttl + reaper interval
+      await Promise.resolve();
+
+      const status = await h.callTool("get_workflow_status", { jobId });
+      if (!status.isError) {
+        expect(status.structuredContent.state).toBe("failed");
+      }
+
+      h.dispose?.();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+The TTL logic is owned by `@ageflow/server`'s `RunRegistry` — we only
+thread `jobCheckpointTtlMs` into `createRunner()`. This test asserts the
+wiring works end-to-end.
+
+#### Task 8.3 — failing test: missing jobId paths
+
+```ts
+describe("async mode: JOB_NOT_FOUND (#18)", () => {
+  it.each(["get_workflow_status", "get_workflow_result", "cancel_workflow", "resume_workflow"])(
+    "%s with unknown jobId → JOB_NOT_FOUND or INVALID_RUN_STATE",
+    async (toolName) => {
+      const h = createMcpServer({ workflow, cliCeilings: {}, hitlStrategy: "auto", async: true });
+      const res = await h.callTool(toolName, { jobId: "nope", approved: true });
+      expect(res.isError).toBe(true);
+      if (res.isError) {
+        expect(["JOB_NOT_FOUND", "INVALID_RUN_STATE"]).toContain(res.structuredContent.errorCode);
+      }
+      h.dispose?.();
+    },
+  );
+});
+```
+
+All green after Phase 6 wiring.
+
+**Commit:** `test(mcp-server): cancellation, checkpoint TTL, JOB_NOT_FOUND coverage (#18)`
+
+---
+
+### Phase 9 — Type-level schema-drift guard
+
+Spec §8 "Type-level": asserts that the input type of `start_<wf>` is
+structurally identical to the sync tool's input type.
+
+#### Task 9.1 — `.test-d.ts` assertion
+
+Create `packages/mcp-server/src/__tests__/async-mode.test-d.ts`:
+
+```ts
+import { describe, expectTypeOf, it } from "vitest";
+import { buildToolDefinition } from "../tool-registry.js";
+import { buildJobTools } from "../job-tools.js";
+import type { WorkflowDef } from "@ageflow/core";
+
+declare const wf: WorkflowDef;
+
+describe("async-mode type guards", () => {
+  it("start_<wf> inputSchema type matches sync tool's inputSchema type", () => {
+    const sync = buildToolDefinition(wf);
+    const [start] = buildJobTools(wf);
+    expectTypeOf(start!.inputSchema).toEqualTypeOf<typeof sync.inputSchema>();
+  });
+});
+```
+
+Enable typecheck in `packages/mcp-server/vitest.config.ts` if not
+already (`typecheck: { enabled: true, include: ["src/**/*.test-d.ts"] }`).
+
+**Commit:** `test(mcp-server): type-level schema-drift guard for async input schema (#18)`
+
+---
+
+### Phase 10 — CLI flags `--async`, `--job-ttl`, `--checkpoint-ttl`
+
+Thread through `packages/cli/src/commands/mcp-serve.ts`.
+
+#### Task 10.1 — failing test: parser accepts new flags
+
+Append to `packages/cli/src/__tests__/mcp-serve.test.ts`:
+
+```ts
+import { parseMcpServeArgs } from "../commands/mcp-serve.js";
+
+describe("parseMcpServeArgs: async mode flags (#18)", () => {
+  it("parses --async without a value", () => {
+    const parsed = parseMcpServeArgs(["wf.ts", "--async"]);
+    expect(parsed.async).toBe(true);
+  });
+
+  it("defaults async to undefined (off)", () => {
+    const parsed = parseMcpServeArgs(["wf.ts"]);
+    expect(parsed.async).toBeUndefined();
+  });
+
+  it("parses --job-ttl <ms>", () => {
+    const parsed = parseMcpServeArgs(["wf.ts", "--async", "--job-ttl", "1800000"]);
+    expect(parsed.jobTtlMs).toBe(1_800_000);
+  });
+
+  it("parses --checkpoint-ttl <ms>", () => {
+    const parsed = parseMcpServeArgs(["wf.ts", "--async", "--checkpoint-ttl", "900000"]);
+    expect(parsed.jobCheckpointTtlMs).toBe(900_000);
+  });
+
+  it("rejects --job-ttl with no value", () => {
+    expect(() => parseMcpServeArgs(["wf.ts", "--async", "--job-ttl"])).toThrow(/requires/);
+  });
+
+  it("rejects --job-ttl with non-positive value", () => {
+    expect(() => parseMcpServeArgs(["wf.ts", "--async", "--job-ttl", "0"])).toThrow(/positive/);
+  });
+
+  it("rejects TTL flags without --async (warns user of no-op)", () => {
+    // Design decision: TTL flags without --async are a user error;
+    // surface a clear message.
+    expect(() => parseMcpServeArgs(["wf.ts", "--job-ttl", "1000"])).toThrow(/requires --async/);
+  });
+});
+```
+
+Run → fails.
+
+#### Task 10.2 — implement parser + threading
+
+Extend `McpServeArgs`:
+
+```ts
+export interface McpServeArgs {
+  // ...existing...
+  readonly async?: boolean;
+  readonly jobTtlMs?: number;
+  readonly jobCheckpointTtlMs?: number;
+}
+```
+
+Add parsing branches in the `for` loop:
+
+```ts
+case "--async":
+  asyncMode = true;
+  break;
+
+case "--job-ttl": {
+  const val = args[++i];
+  if (val === undefined || val.startsWith("-")) {
+    throw new Error("--job-ttl requires a numeric argument (ms)");
+  }
+  const n = Number(val);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`--job-ttl must be a positive integer in ms, got: ${val}`);
+  }
+  jobTtlMs = n;
+  break;
+}
+
+case "--checkpoint-ttl": {
+  const val = args[++i];
+  if (val === undefined || val.startsWith("-")) {
+    throw new Error("--checkpoint-ttl requires a numeric argument (ms)");
+  }
+  const n = Number(val);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`--checkpoint-ttl must be a positive integer in ms, got: ${val}`);
+  }
+  jobCheckpointTtlMs = n;
+  break;
+}
+```
+
+After the loop, validate TTL flags require async:
+
+```ts
+if (asyncMode !== true && (jobTtlMs !== undefined || jobCheckpointTtlMs !== undefined)) {
+  throw new Error("--job-ttl / --checkpoint-ttl requires --async");
+}
+```
+
+Thread into `createMcpServer(...)`:
+
+```ts
+const handle = createMcpServer({
+  workflow,
+  cliCeilings,
+  hitlStrategy: parsed.hitlStrategy,
+  stderr,
+  ...(parsed.async === true ? { async: true } : {}),
+  ...(parsed.jobTtlMs !== undefined ? { jobTtlMs: parsed.jobTtlMs } : {}),
+  ...(parsed.jobCheckpointTtlMs !== undefined ? { jobCheckpointTtlMs: parsed.jobCheckpointTtlMs } : {}),
+});
+```
+
+Update commander description with the new flags.
+
+Run tests → green.
+
+**Commit:** `feat(cli): --async / --job-ttl / --checkpoint-ttl flags for mcp serve (#18)`
+
+---
+
+### Phase 11 — Example workspace update
+
+#### Task 11.1 — async smoke test
+
+Extend `examples/mcp-server/mcp-client.test.ts` with an async-mode
+scenario: start `agentwf mcp serve workflow.ts --async --hitl auto` via
+the existing `@modelcontextprotocol/sdk` client, list tools (expect 6),
+call `start_example` → get `jobId`, poll `get_workflow_status` until
+`done`, call `get_workflow_result`, assert structured output.
+
+Uses the same `__mocks__` PATH trick as the existing smoke test so no
+real runner is invoked.
+
+#### Task 11.2 — README updates
+
+1. `examples/mcp-server/README.md`: add "Async mode" section with the
+   `--async` command, the 5 extra tool names, and a short polling
+   snippet.
+2. `packages/mcp-server/README.md`: new "Async job mode" chapter:
+   - When to use (long-running workflows, clients without progress,
+     reconnect semantics)
+   - Tool surface (table of 5 tools + input/output)
+   - Error codes (`JOB_NOT_FOUND`, `JOB_CANCELLED`,
+     `INVALID_RUN_STATE`)
+   - Known limitations (no persistence, single-instance, single
+     `BUSY` lock)
+3. `agentflow/CLAUDE.md`: note `@ageflow/mcp-server` depends on
+   `@ageflow/server` as of this change.
+
+Run `bun run --filter @ageflow/example-mcp-server test` → green.
+
+**Commit:** `docs(mcp-server): async mode example + README chapter (#18)`
+
+---
+
+### Phase 12 — Publish prep
+
+#### Task 12.1 — root checks
+
+```bash
+bun install
+bun run typecheck
+bun run test
+bun run lint
+```
+
+All green.
+
+#### Task 12.2 — version bump
+
+`packages/mcp-server/package.json`: bump to `0.3.0` (new tools + new
+dep = minor in pre-1.0 terms). Update the package `description` to
+mention async mode.
+
+**Commit:** `chore(mcp-server): v0.3.0 — async job tools (#18)`
+
+---
+
+## Verification checklist
+
+- [ ] `bun run --filter @ageflow/mcp-server typecheck` — green (new
+  workspace ref resolves)
+- [ ] `bun run --filter @ageflow/mcp-server test` — all suites green:
+  existing (`errors`, `tool-registry`, `hitl-bridge`, `progress-streamer`,
+  `dag-boundary`, `schema-convert`, `stdio-transport`, `watchdog`,
+  `ceiling-resolver`) + new (`job-event-recorder`, `job-tools`,
+  `integration/async-mode`)
+- [ ] `bun run --filter @ageflow/mcp-server test -- --typecheck` — new
+  `.test-d.ts` passes (schema-drift guard)
+- [ ] `bun run --filter @ageflow/cli test` — extended `mcp-serve` parser
+  tests green
+- [ ] `bun run --filter @ageflow/example-mcp-server test` — both sync
+  and async client tests green
+- [ ] `bun run typecheck && bun run test && bun run lint` at repo root
+  — everything green
+- [ ] Manual smoke: `bun run --filter @ageflow/example-mcp-server
+  smoke` (sync) and with `--async` appended (async) — server starts,
+  `tools/list` returns 1 or 6 respectively
+
+## Open questions (deferred, not blockers)
+
+- **Should `listTools` differ between clients that do vs. don't support
+  `notifications/progress`?** Spec picks "always show all 6 in async
+  mode"; could adapt based on `initialize` capabilities in v2.
+- **Default `jobTtlMs` of 30 min** (spec §5) — may need downtuning if
+  memory pressure from abandoned completed jobs matters. Adjustable per
+  server; revisit if a real deployment hits it.
+- **`RunStore` persistence hook.** Sketched in spec §5 "Future" block;
+  not implemented here. If a caller ever wants durable jobs, extend
+  `createRunner({ store })` in `@ageflow/server` first, then thread
+  through `McpServerOptions`.
+- **Webhook / push notifications** and **multi-workflow servers**:
+  future work per spec §"Open follow-ups". Keep the per-workflow
+  `start_<wf>` naming decision in mind if multi-workflow ever lands —
+  `cancel_workflow` / `get_workflow_status` are already generic.


### PR DESCRIPTION
1782-line plan, 12 phases, 23 tasks. Reuses @ageflow/server primitives (fire/resume/cancel + deferred HITL + TTL reaper). Shared BUSY lock, JobEventRecorder sidecar, 5 new MCP tools.