### PR TITLE
feat(mcp-server): #18 Phase 1-3 — @ageflow/server dep + JobEventRecorder + error codes

### DIFF
--- a/agentflow/packages/mcp-server/package.json
+++ b/agentflow/packages/mcp-server/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ageflow/core": "workspace:*",
     "@ageflow/executor": "workspace:*",
+    "@ageflow/server": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod-to-json-schema": "^3.23.0"
   },

--- a/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
@@ -1,5 +1,6 @@
 import { BudgetExceededError } from "@ageflow/core";
 import { HitlNotInteractiveError } from "@ageflow/executor";
+import { CheckpointTimeoutError, InvalidRunStateError, RunNotFoundError } from "@ageflow/server";
 import { describe, expect, it } from "vitest";
 import { ErrorCode, McpServerError, formatErrorResult } from "../errors.js";
 
@@ -51,5 +52,31 @@ describe("McpServerError + formatErrorResult", () => {
     expect(result.isError).toBe(true);
     expect(result.structuredContent.errorCode).toBe(ErrorCode.HITL_DENIED);
     expect(result.structuredContent.context).toEqual({ taskName: "verify" });
+  });
+});
+
+describe("async-mode error mapping (#18)", () => {
+  it("includes new codes in ErrorCode enum", () => {
+    expect(ErrorCode.JOB_NOT_FOUND).toBe("JOB_NOT_FOUND");
+    expect(ErrorCode.JOB_CANCELLED).toBe("JOB_CANCELLED");
+    expect(ErrorCode.INVALID_RUN_STATE).toBe("INVALID_RUN_STATE");
+    expect(ErrorCode.ASYNC_MODE_DISABLED).toBe("ASYNC_MODE_DISABLED");
+  });
+
+  it("maps RunNotFoundError → JOB_NOT_FOUND", () => {
+    const result = formatErrorResult(new RunNotFoundError("abc"));
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.JOB_NOT_FOUND);
+  });
+
+  it("maps InvalidRunStateError → INVALID_RUN_STATE", () => {
+    const result = formatErrorResult(new InvalidRunStateError("abc", "done"));
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.INVALID_RUN_STATE);
+    expect(result.structuredContent.context).toMatchObject({ runId: "abc", state: "done" });
+  });
+
+  it("maps CheckpointTimeoutError → HITL_CANCELLED (existing code, reused)", () => {
+    const result = formatErrorResult(new CheckpointTimeoutError("approve"));
+    expect(result.structuredContent.errorCode).toBe(ErrorCode.HITL_CANCELLED);
   });
 });

--- a/agentflow/packages/mcp-server/src/__tests__/job-event-recorder.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/job-event-recorder.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { JobEventRecorder } from "../job-event-recorder.js";
+import type {
+  BudgetWarningEvent,
+  TaskCompleteEvent,
+  TaskStartEvent,
+} from "@ageflow/core";
+
+const baseEv = {
+  runId: "r1",
+  workflowName: "wf",
+  timestamp: 0,
+};
+
+describe("JobEventRecorder", () => {
+  it("tracks lastTaskStart, tasksCompleted, lastBudgetWarning per runId", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    expect(rec.snapshot("r1")).toMatchObject({
+      tasksCompleted: 0,
+      lastTaskStart: { taskName: "a" },
+    });
+
+    rec.record({
+      ...baseEv,
+      type: "task:complete",
+      taskName: "a",
+      output: {},
+      metrics: { latencyMs: 0, tokensIn: 0, tokensOut: 0, estimatedCost: 0 },
+    } as TaskCompleteEvent);
+    expect(rec.snapshot("r1")?.tasksCompleted).toBe(1);
+
+    rec.record({
+      ...baseEv,
+      type: "budget:warning",
+      spentUsd: 0.5,
+      limitUsd: 1.0,
+    } as BudgetWarningEvent);
+    expect(rec.snapshot("r1")?.lastBudgetWarning).toEqual({
+      spentUsd: 0.5,
+      limitUsd: 1.0,
+      at: 0,
+    });
+  });
+
+  it("isolates state between runIds", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, runId: "a", type: "task:start", taskName: "x" } as TaskStartEvent);
+    rec.record({ ...baseEv, runId: "b", type: "task:start", taskName: "y" } as TaskStartEvent);
+    expect(rec.snapshot("a")?.lastTaskStart?.taskName).toBe("x");
+    expect(rec.snapshot("b")?.lastTaskStart?.taskName).toBe("y");
+  });
+
+  it("returns undefined for unknown runId", () => {
+    const rec = new JobEventRecorder();
+    expect(rec.snapshot("ghost")).toBeUndefined();
+  });
+
+  it("drops state on forget(runId)", () => {
+    const rec = new JobEventRecorder();
+    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    expect(rec.snapshot("r1")).toBeDefined();
+    rec.forget("r1");
+    expect(rec.snapshot("r1")).toBeUndefined();
+  });
+});

--- a/agentflow/packages/mcp-server/src/errors.ts
+++ b/agentflow/packages/mcp-server/src/errors.ts
@@ -1,5 +1,10 @@
 import { BudgetExceededError } from "@ageflow/core";
 import { HitlNotInteractiveError } from "@ageflow/executor";
+import {
+  CheckpointTimeoutError,
+  InvalidRunStateError,
+  RunNotFoundError,
+} from "@ageflow/server";
 
 export const ErrorCode = {
   INPUT_VALIDATION_FAILED: "INPUT_VALIDATION_FAILED",
@@ -16,6 +21,10 @@ export const ErrorCode = {
   BUSY: "BUSY",
   SERVER_SHUTDOWN: "SERVER_SHUTDOWN",
   DAG_INVALID: "DAG_INVALID",
+  JOB_NOT_FOUND: "JOB_NOT_FOUND",
+  JOB_CANCELLED: "JOB_CANCELLED",
+  INVALID_RUN_STATE: "INVALID_RUN_STATE",
+  ASYNC_MODE_DISABLED: "ASYNC_MODE_DISABLED",
 } as const;
 
 export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -71,6 +80,42 @@ export function formatErrorResult(err: unknown): McpToolErrorResult {
       content: [{ type: "text", text: err.message }],
       structuredContent: {
         errorCode: ErrorCode.HITL_DENIED,
+        message: err.message,
+        context: { taskName: err.taskName },
+      },
+      isError: true,
+    };
+  }
+
+  if (err instanceof RunNotFoundError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: ErrorCode.JOB_NOT_FOUND,
+        message: err.message,
+        context: { runId: err.runId },
+      },
+      isError: true,
+    };
+  }
+
+  if (err instanceof InvalidRunStateError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: ErrorCode.INVALID_RUN_STATE,
+        message: err.message,
+        context: { runId: err.runId, state: err.state },
+      },
+      isError: true,
+    };
+  }
+
+  if (err instanceof CheckpointTimeoutError) {
+    return {
+      content: [{ type: "text", text: err.message }],
+      structuredContent: {
+        errorCode: ErrorCode.HITL_CANCELLED,
         message: err.message,
         context: { taskName: err.taskName },
       },

--- a/agentflow/packages/mcp-server/src/job-dispatch.ts
+++ b/agentflow/packages/mcp-server/src/job-dispatch.ts
@@ -1,0 +1,4 @@
+import { createRunner } from "@ageflow/server";
+
+// Placeholder to keep the module non-empty. Real impl lands in Phase 4.
+export const _unused = createRunner;

--- a/agentflow/packages/mcp-server/src/job-event-recorder.ts
+++ b/agentflow/packages/mcp-server/src/job-event-recorder.ts
@@ -1,0 +1,67 @@
+import type { WorkflowEvent } from "@ageflow/core";
+
+export interface ProgressSnapshot {
+  readonly lastTaskStart?: { readonly taskName: string; readonly at: number };
+  readonly tasksCompleted: number;
+  readonly lastBudgetWarning?: {
+    readonly spentUsd: number;
+    readonly limitUsd: number;
+    readonly at: number;
+  };
+}
+
+/**
+ * Per-run progress accumulator. Fed by the executor's event stream via
+ * `fire({ onEvent })` inside the job dispatcher.
+ *
+ * Lifetime: entries are created on the first event for a runId and cleared
+ * explicitly via `forget(runId)` when the corresponding RunHandle leaves
+ * the RunRegistry (TTL eviction or terminal state + cleanup pass).
+ */
+export class JobEventRecorder {
+  private readonly map = new Map<string, ProgressSnapshotMutable>();
+
+  record(ev: WorkflowEvent): void {
+    const snap = this.ensure(ev.runId);
+    switch (ev.type) {
+      case "task:start":
+        snap.lastTaskStart = { taskName: ev.taskName, at: ev.timestamp };
+        return;
+      case "task:complete":
+        snap.tasksCompleted += 1;
+        return;
+      case "budget:warning":
+        snap.lastBudgetWarning = {
+          spentUsd: ev.spentUsd,
+          limitUsd: ev.limitUsd,
+          at: ev.timestamp,
+        };
+        return;
+      default:
+        return;
+    }
+  }
+
+  snapshot(runId: string): ProgressSnapshot | undefined {
+    return this.map.get(runId);
+  }
+
+  forget(runId: string): void {
+    this.map.delete(runId);
+  }
+
+  private ensure(runId: string): ProgressSnapshotMutable {
+    let s = this.map.get(runId);
+    if (!s) {
+      s = { tasksCompleted: 0 };
+      this.map.set(runId, s);
+    }
+    return s;
+  }
+}
+
+interface ProgressSnapshotMutable {
+  lastTaskStart?: { taskName: string; at: number };
+  tasksCompleted: number;
+  lastBudgetWarning?: { spentUsd: number; limitUsd: number; at: number };
+}

--- a/agentflow/packages/mcp-server/tsconfig.json
+++ b/agentflow/packages/mcp-server/tsconfig.json
@@ -3,8 +3,18 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true
+    "composite": true,
+    "paths": {
+      "@ageflow/core": ["../core/src/index.ts"],
+      "@ageflow/executor": ["../executor/src/index.ts"],
+      "@ageflow/server": ["../server/src/index.ts"]
+    }
   },
+  "references": [
+    { "path": "../core" },
+    { "path": "../executor" },
+    { "path": "../server" }
+  ],
   "include": ["src/**/*"],
   "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "dist"]
 }


### PR DESCRIPTION
Phase 1: @ageflow/server workspace dep. Phase 2: JobEventRecorder sidecar tracks currentTask/tasksCompleted/spentUsd from WorkflowEvent stream. Phase 3: 4 new error codes + mapping for RunNotFoundError/InvalidRunStateError/CheckpointTimeoutError. 66 tests (+8), 21/21 green.