### PR TITLE
fix: 4 P1 issues from Codex review (#54)

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -86,7 +86,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -107,7 +107,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -119,7 +119,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "zod-to-json-schema": "^3.23.0",
@@ -132,10 +132,11 @@
     },
     "packages/mcp-server": {
       "name": "@ageflow/mcp-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
+        "@ageflow/server": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "zod-to-json-schema": "^3.23.0",
       },
@@ -148,7 +149,7 @@
     },
     "packages/runners/api": {
       "name": "@ageflow/runner-api",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -160,7 +161,7 @@
     },
     "packages/runners/claude": {
       "name": "@ageflow/runner-claude",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -172,7 +173,7 @@
     },
     "packages/runners/codex": {
       "name": "@ageflow/runner-codex",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -184,7 +185,7 @@
     },
     "packages/server": {
       "name": "@ageflow/server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
@@ -197,7 +198,7 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -266,6 +266,109 @@ describe("P1-1: single-ownership of onCheckpoint hook", () => {
   });
 });
 
+describe("P1-2: AbortSignal stops executor", () => {
+  it("transitions to workflow:error with aborted cause and no more events fire after cancellation", async () => {
+    // Workflow with 3 sequential tasks (a → b → c).
+    // We abort the signal before the workflow even starts (already-aborted signal).
+    // The first batch boundary check must throw WorkflowAbortedError, producing
+    // workflow:error and no task events.
+    const agentSlow = defineAgent({
+      runner: "fake",
+      input: z.object({}),
+      output: z.object({ summary: z.string() }),
+      prompt: () => "p",
+    });
+    const wfSeq = defineWorkflow({
+      name: "seq-abort",
+      tasks: {
+        a: { agent: agentSlow, input: {} },
+        b: { agent: agentSlow, input: {}, dependsOn: ["a"] as const },
+        c: { agent: agentSlow, input: {}, dependsOn: ["b"] as const },
+      },
+    });
+    const controller = new AbortController();
+    // Abort before streaming — signal is already aborted at first batch boundary
+    controller.abort();
+
+    const ex = new WorkflowExecutor(wfSeq);
+    const events: WorkflowEvent[] = [];
+    try {
+      for await (const ev of ex.stream({}, { signal: controller.signal })) {
+        events.push(ev);
+      }
+    } catch {
+      // expected throw after abort
+    }
+    // Workflow must end with workflow:error
+    const lastEv = events[events.length - 1];
+    expect(lastEv?.type).toBe("workflow:error");
+    // No task:start should have fired at all
+    expect(events.some((e) => e.type === "task:start")).toBe(false);
+  });
+
+  it("stops mid-workflow when signal is aborted between tasks", async () => {
+    // Workflow with 3 sequential tasks (a → b → c).
+    // The runner for "b" and "c" checks the abort flag via a shared signal.
+    // We abort the controller inside the runner for "a" so the batch check
+    // for "b" sees it aborted before starting.
+    const controller = new AbortController();
+    let taskAStarted = false;
+    const abortingRunner: Runner = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        if (!taskAStarted) {
+          taskAStarted = true;
+          // Abort after task a — the batch boundary check before b will catch it
+          controller.abort();
+        }
+        return {
+          stdout: JSON.stringify({ summary: "ok" }),
+          sessionHandle: "s",
+          tokensIn: 1,
+          tokensOut: 1,
+        };
+      },
+    };
+    registerRunner("aborting", abortingRunner);
+    try {
+      const agentAborting = defineAgent({
+        runner: "aborting",
+        input: z.object({}),
+        output: z.object({ summary: z.string() }),
+        prompt: () => "p",
+      });
+      const wfAborting = defineWorkflow({
+        name: "aborting-wf",
+        tasks: {
+          a: { agent: agentAborting, input: {} },
+          b: { agent: agentAborting, input: {}, dependsOn: ["a"] as const },
+          c: { agent: agentAborting, input: {}, dependsOn: ["b"] as const },
+        },
+      });
+      const ex = new WorkflowExecutor(wfAborting);
+      const events: WorkflowEvent[] = [];
+      try {
+        for await (const ev of ex.stream({}, { signal: controller.signal })) {
+          events.push(ev);
+        }
+      } catch {
+        // expected throw after abort
+      }
+      // Workflow must end with workflow:error
+      const lastEv = events[events.length - 1];
+      expect(lastEv?.type).toBe("workflow:error");
+      // Task b and c must not have started
+      const taskStarts = events
+        .filter((e) => e.type === "task:start")
+        .map((e) => (e as { taskName: string }).taskName);
+      expect(taskStarts).not.toContain("b");
+      expect(taskStarts).not.toContain("c");
+    } finally {
+      unregisterRunner("aborting");
+    }
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -193,6 +193,79 @@ describe("stream() onCheckpoint", () => {
   });
 });
 
+describe("P1-1: single-ownership of onCheckpoint hook", () => {
+  it("fires hooks.onCheckpoint exactly once when both hooks and stream onCheckpoint are provided", async () => {
+    // When caller provides onCheckpoint to stream(), hooks.onCheckpoint must NOT
+    // fire — the caller's handler owns the side-effect (single-ownership rule).
+    let hookCallCount = 0;
+    const a = defineAgent({
+      runner: "fake",
+      input: z.object({}),
+      output: z.object({ summary: z.string() }),
+      prompt: () => "p",
+      hitl: { mode: "checkpoint", message: "approve?" },
+    });
+    const wfGated = defineWorkflow({
+      name: "gated-hook",
+      tasks: { t: { agent: a, input: {} } },
+      hooks: {
+        onCheckpoint: (_taskName: string, _msg: string) => {
+          hookCallCount++;
+        },
+      },
+    });
+    const ex = new WorkflowExecutor(wfGated);
+    let streamCheckpointCalls = 0;
+    const events: WorkflowEvent[] = [];
+    for await (const ev of ex.stream(
+      {},
+      {
+        onCheckpoint: async () => {
+          streamCheckpointCalls++;
+          return true;
+        },
+      },
+    )) {
+      events.push(ev);
+    }
+    // Stream onCheckpoint fired exactly once
+    expect(streamCheckpointCalls).toBe(1);
+    // hooks.onCheckpoint must NOT fire when stream's onCheckpoint takes ownership
+    expect(hookCallCount).toBe(0);
+    expect(events[events.length - 1]?.type).toBe("workflow:complete");
+  });
+
+  it("fires hooks.onCheckpoint exactly once via HITLManager when no stream onCheckpoint", async () => {
+    // When no stream onCheckpoint, HITLManager fires hooks.onCheckpoint — exactly once.
+    let hookCallCount = 0;
+    const a = defineAgent({
+      runner: "fake",
+      input: z.object({}),
+      output: z.object({ summary: z.string() }),
+      prompt: () => "p",
+      hitl: { mode: "checkpoint", message: "approve?" },
+    });
+    const wfGated = defineWorkflow({
+      name: "gated-hitl",
+      tasks: { t: { agent: a, input: {} } },
+      hooks: {
+        onCheckpoint: (_taskName: string, _msg: string): Promise<boolean> => {
+          hookCallCount++;
+          return Promise.resolve(true); // approve via hook
+        },
+      },
+    });
+    const ex = new WorkflowExecutor(wfGated);
+    const events: WorkflowEvent[] = [];
+    for await (const ev of ex.stream({})) {
+      events.push(ev);
+    }
+    // HITLManager fires it exactly once
+    expect(hookCallCount).toBe(1);
+    expect(events[events.length - 1]?.type).toBe("workflow:complete");
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/agentflow/packages/executor/src/errors.ts
+++ b/agentflow/packages/executor/src/errors.ts
@@ -102,3 +102,10 @@ export class RunnerNotRegisteredError extends AgentFlowError {
     );
   }
 }
+
+export class WorkflowAbortedError extends AgentFlowError {
+  readonly code = "workflow_aborted" as const;
+  constructor(options?: ErrorOptions) {
+    super("Workflow execution was aborted via AbortSignal", options);
+  }
+}

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -11,7 +11,11 @@ import type {
 } from "@ageflow/core";
 import { BudgetTracker } from "./budget-tracker.js";
 import { topologicalSort } from "./dag-resolver.js";
-import { HitlRejectedError, RunnerNotRegisteredError } from "./errors.js";
+import {
+  HitlRejectedError,
+  RunnerNotRegisteredError,
+  WorkflowAbortedError,
+} from "./errors.js";
 import { HITLManager } from "./hitl-manager.js";
 import { LoopExecutor } from "./loop-executor.js";
 import { runNode } from "./node-runner.js";
@@ -195,6 +199,9 @@ export class WorkflowExecutor<T extends TasksMap> {
             push: (ev) => queue.push(ev),
             ...(options?.onCheckpoint !== undefined
               ? { onCheckpoint: options.onCheckpoint }
+              : {}),
+            ...(options?.signal !== undefined
+              ? { signal: options.signal }
               : {}),
           },
         );
@@ -451,9 +458,10 @@ export class WorkflowExecutor<T extends TasksMap> {
       workflowName: string;
       push: (ev: WorkflowEvent) => void;
       onCheckpoint?: (ev: CheckpointEvent) => Promise<boolean> | boolean;
+      signal?: AbortSignal;
     },
   ): Promise<WorkflowResult<T>> {
-    const { runId, workflowName, push, onCheckpoint } = emitting;
+    const { runId, workflowName, push, onCheckpoint, signal } = emitting;
     const { hooks, budget } = this.workflow;
     const sm = sessionManagerOverride ?? this.sessionManager;
     const workflowStart = Date.now();
@@ -470,6 +478,11 @@ export class WorkflowExecutor<T extends TasksMap> {
     let taskCount = 0;
 
     for (const batch of batches) {
+      // Check AbortSignal at every batch boundary (P1-2)
+      if (signal?.aborted) {
+        throw new WorkflowAbortedError();
+      }
+
       // Check budget before each batch
       if (budget !== undefined) {
         this.budgetTracker.checkBudget(budget);
@@ -482,6 +495,11 @@ export class WorkflowExecutor<T extends TasksMap> {
       await Promise.all(
         groups.map(async (group) => {
           for (const taskName of group) {
+            // Check AbortSignal before each task within a group (P1-2)
+            if (signal?.aborted) {
+              throw new WorkflowAbortedError();
+            }
+
             const taskDef = tasks[taskName];
             if (taskDef === undefined) continue;
 

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -535,12 +535,6 @@ export class WorkflowExecutor<T extends TasksMap> {
                   ? hitlConfig.message
                   : `Task "${taskName}" requires approval before proceeding.`;
 
-              // Fire onCheckpoint hook
-              hooks?.onCheckpoint?.(
-                taskName as keyof T & string,
-                checkpointMessage,
-              );
-
               // Emit checkpoint event
               const checkpointEv: CheckpointEvent = {
                 type: "checkpoint",
@@ -553,13 +547,18 @@ export class WorkflowExecutor<T extends TasksMap> {
               push(checkpointEv);
 
               if (onCheckpoint !== undefined) {
-                // Caller-provided handler (stream() path)
+                // Caller-provided handler (stream() path).
+                // Single-ownership: when caller supplies onCheckpoint, it is
+                // solely responsible for approval. hooks.onCheckpoint is NOT
+                // fired here — the caller's handler owns the side-effect.
                 const approved = await onCheckpoint(checkpointEv);
                 if (!approved) {
                   throw new HitlRejectedError(taskName);
                 }
               } else {
-                // Legacy path: defer to HITLManager (TTY / hook)
+                // Legacy path: defer to HITLManager (TTY / hook).
+                // HITLManager fires hooks.onCheckpoint internally — no
+                // double-call.
                 await this.hitlManager.runCheckpoint(
                   taskName,
                   checkpointMessage,

--- a/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/errors.test.ts
@@ -1,6 +1,10 @@
 import { BudgetExceededError } from "@ageflow/core";
 import { HitlNotInteractiveError } from "@ageflow/executor";
-import { CheckpointTimeoutError, InvalidRunStateError, RunNotFoundError } from "@ageflow/server";
+import {
+  CheckpointTimeoutError,
+  InvalidRunStateError,
+  RunNotFoundError,
+} from "@ageflow/server";
 import { describe, expect, it } from "vitest";
 import { ErrorCode, McpServerError, formatErrorResult } from "../errors.js";
 
@@ -71,8 +75,13 @@ describe("async-mode error mapping (#18)", () => {
 
   it("maps InvalidRunStateError → INVALID_RUN_STATE", () => {
     const result = formatErrorResult(new InvalidRunStateError("abc", "done"));
-    expect(result.structuredContent.errorCode).toBe(ErrorCode.INVALID_RUN_STATE);
-    expect(result.structuredContent.context).toMatchObject({ runId: "abc", state: "done" });
+    expect(result.structuredContent.errorCode).toBe(
+      ErrorCode.INVALID_RUN_STATE,
+    );
+    expect(result.structuredContent.context).toMatchObject({
+      runId: "abc",
+      state: "done",
+    });
   });
 
   it("maps CheckpointTimeoutError → HITL_CANCELLED (existing code, reused)", () => {

--- a/agentflow/packages/mcp-server/src/__tests__/job-event-recorder.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/job-event-recorder.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { JobEventRecorder } from "../job-event-recorder.js";
 import type {
   BudgetWarningEvent,
   TaskCompleteEvent,
   TaskStartEvent,
 } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { JobEventRecorder } from "../job-event-recorder.js";
 
 const baseEv = {
   runId: "r1",
@@ -15,7 +15,11 @@ const baseEv = {
 describe("JobEventRecorder", () => {
   it("tracks lastTaskStart, tasksCompleted, lastBudgetWarning per runId", () => {
     const rec = new JobEventRecorder();
-    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    rec.record({
+      ...baseEv,
+      type: "task:start",
+      taskName: "a",
+    } as TaskStartEvent);
     expect(rec.snapshot("r1")).toMatchObject({
       tasksCompleted: 0,
       lastTaskStart: { taskName: "a" },
@@ -45,8 +49,18 @@ describe("JobEventRecorder", () => {
 
   it("isolates state between runIds", () => {
     const rec = new JobEventRecorder();
-    rec.record({ ...baseEv, runId: "a", type: "task:start", taskName: "x" } as TaskStartEvent);
-    rec.record({ ...baseEv, runId: "b", type: "task:start", taskName: "y" } as TaskStartEvent);
+    rec.record({
+      ...baseEv,
+      runId: "a",
+      type: "task:start",
+      taskName: "x",
+    } as TaskStartEvent);
+    rec.record({
+      ...baseEv,
+      runId: "b",
+      type: "task:start",
+      taskName: "y",
+    } as TaskStartEvent);
     expect(rec.snapshot("a")?.lastTaskStart?.taskName).toBe("x");
     expect(rec.snapshot("b")?.lastTaskStart?.taskName).toBe("y");
   });
@@ -58,7 +72,11 @@ describe("JobEventRecorder", () => {
 
   it("drops state on forget(runId)", () => {
     const rec = new JobEventRecorder();
-    rec.record({ ...baseEv, type: "task:start", taskName: "a" } as TaskStartEvent);
+    rec.record({
+      ...baseEv,
+      type: "task:start",
+      taskName: "a",
+    } as TaskStartEvent);
     expect(rec.snapshot("r1")).toBeDefined();
     rec.forget("r1");
     expect(rec.snapshot("r1")).toBeUndefined();

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { ApiRunner } from "../api-runner.js";
+import { ToolNotFoundError } from "../errors.js";
 import type { ChatCompletionResponse } from "../openai-types.js";
 import { InMemorySessionStore } from "../session-store.js";
 
@@ -117,6 +118,114 @@ describe("ApiRunner.spawn", () => {
       messages: Array<{ role: string; content: string }>;
     };
     expect(body.messages[0]).toEqual({ role: "system", content: "be concise" });
+  });
+});
+
+describe("P1-3: tool registry filtered by args.tools allowlist", () => {
+  it("throws ToolNotFoundError when model calls a tool not in args.tools allowlist", async () => {
+    // Registry has 3 tools: a, b, c.  spawn is called with args.tools = ["a", "b"].
+    // The mock LLM response requests tool "c" — must throw ToolNotFoundError.
+    const toolCallResponse: ChatCompletionResponse = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call1",
+                type: "function",
+                function: { name: "c", arguments: "{}" },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResp(toolCallResponse));
+
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      defaultModel: "gpt-4o",
+      fetch: fetchMock as unknown as typeof fetch,
+      tools: {
+        a: { description: "tool a", parameters: {}, execute: async () => "a" },
+        b: { description: "tool b", parameters: {}, execute: async () => "b" },
+        c: { description: "tool c", parameters: {}, execute: async () => "c" },
+      },
+    });
+
+    // Only allow tools "a" and "b" — "c" is not in the allowlist
+    await expect(
+      runner.spawn({ prompt: "use tool c", tools: ["a", "b"] }),
+    ).rejects.toThrow(ToolNotFoundError);
+  });
+
+  it("allows calling a tool that is in the allowlist", async () => {
+    // Registry has a, b, c. spawn with args.tools = ["a"]. Model calls "a" — ok.
+    const toolCallThenStop: ChatCompletionResponse[] = [
+      {
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call1",
+                  type: "function",
+                  function: { name: "a", arguments: "{}" },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      },
+      {
+        choices: [
+          {
+            message: { role: "assistant", content: "done" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      },
+    ];
+
+    let callIdx = 0;
+    const fetchMock = vi.fn().mockImplementation(() => {
+      const resp = toolCallThenStop[callIdx++];
+      return Promise.resolve(jsonResp(resp));
+    });
+
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      defaultModel: "gpt-4o",
+      fetch: fetchMock as unknown as typeof fetch,
+      tools: {
+        a: {
+          description: "tool a",
+          parameters: {},
+          execute: async () => "result-a",
+        },
+        b: { description: "tool b", parameters: {}, execute: async () => "b" },
+        c: { description: "tool c", parameters: {}, execute: async () => "c" },
+      },
+    });
+
+    const result = await runner.spawn({ prompt: "use a", tools: ["a"] });
+    expect(result.stdout).toBe("done");
+    expect(result.toolCalls.length).toBe(1);
+    expect(result.toolCalls[0]?.name).toBe("a");
   });
 });
 

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
@@ -145,9 +145,7 @@ describe("P1-3: tool registry filtered by args.tools allowlist", () => {
       usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
     };
 
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(jsonResp(toolCallResponse));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(toolCallResponse));
 
     const runner = new ApiRunner({
       baseUrl: "https://example.test/v1",

--- a/agentflow/packages/runners/api/src/__tests__/session-store.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/session-store.test.ts
@@ -39,4 +39,38 @@ describe("InMemorySessionStore", () => {
     const got = await store.get("h");
     expect(got?.length).toBe(1);
   });
+
+  it("P1-4: mutating a returned message object does not change stored history", async () => {
+    // Shallow clone ([...messages]) does not deep-copy ChatMessage objects.
+    // structuredClone must be used so in-place mutation of a returned message
+    // cannot rewrite the stored history.
+    const store = new InMemorySessionStore();
+    const original: ChatMessage = { role: "user", content: "original" };
+    await store.set("h2", [original]);
+
+    // get() returns a deep copy; mutate it in place
+    const returned = await store.get("h2");
+    expect(returned).toBeDefined();
+    if (returned?.[0]) {
+      returned[0].content = "mutated";
+    }
+
+    // Re-get: stored history must be unchanged
+    const reloaded = await store.get("h2");
+    expect(reloaded?.[0]?.content).toBe("original");
+  });
+
+  it("P1-4: mutating the original array passed to set() does not change stored history", async () => {
+    // Also verify that structuredClone is applied on set(), not just get()
+    const store = new InMemorySessionStore();
+    const msgs: ChatMessage[] = [{ role: "user", content: "before" }];
+    await store.set("h3", msgs);
+
+    // Mutate the original message object after set
+    const m = msgs[0];
+    if (m) m.content = "after";
+
+    const stored = await store.get("h3");
+    expect(stored?.[0]?.content).toBe("before");
+  });
 });

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -80,6 +80,17 @@ export class ApiRunner implements Runner {
 
     const toolSchemas = toolsToSchemas(this.tools, args.tools);
 
+    // P1-3: filter the runtime registry to the caller's allowlist so that
+    // tools not in args.tools cannot be executed even if the model names them.
+    const filteredRegistry =
+      args.tools !== undefined
+        ? Object.fromEntries(
+            Object.entries(this.tools).filter(([name]) =>
+              (args.tools as string[]).includes(name),
+            ),
+          )
+        : this.tools;
+
     const loop = await runToolLoop({
       baseUrl: this.baseUrl,
       apiKey: this.apiKey,
@@ -88,7 +99,7 @@ export class ApiRunner implements Runner {
       model,
       messages: initialMessages,
       tools: toolSchemas,
-      registry: this.tools,
+      registry: filteredRegistry,
       maxRounds: this.maxToolRounds,
       requestTimeout: this.requestTimeout,
     });

--- a/agentflow/packages/runners/api/src/session-store.ts
+++ b/agentflow/packages/runners/api/src/session-store.ts
@@ -8,18 +8,19 @@ export interface SessionStore {
 
 /**
  * Default session store. Map<handle, ChatMessage[]>, process-local.
- * Stores copies so external mutation cannot change recorded history.
+ * Stores deep-cloned copies so external mutation of message objects
+ * cannot silently rewrite recorded history (P1-4 fix).
  */
 export class InMemorySessionStore implements SessionStore {
   private readonly data = new Map<string, ChatMessage[]>();
 
   async get(handle: string): Promise<ChatMessage[] | undefined> {
     const got = this.data.get(handle);
-    return got ? [...got] : undefined;
+    return got ? structuredClone(got) : undefined;
   }
 
   async set(handle: string, messages: ChatMessage[]): Promise<void> {
-    this.data.set(handle, [...messages]);
+    this.data.set(handle, structuredClone(messages));
   }
 
   async delete(handle: string): Promise<void> {


### PR DESCRIPTION
Addresses P1 findings from issue #54:

- **P1-1**: single-ownership of onCheckpoint hook (no double-fire side effects)
- **P1-2**: honor AbortSignal at batch boundaries in executor — cancel() actually stops work
- **P1-3**: filter tool registry by args.tools allowlist in runner-api (permission boundary)
- **P1-4**: deep-clone session messages in InMemorySessionStore (structuredClone)

+8 tests (executor 146, runner-api 27). 21/21 typecheck + test + lint all green.