### PR TITLE
fix: 8 P2 issues from Codex review (#54)

### DIFF
--- a/agentflow/examples/server-embed/__tests__/sse.test.ts
+++ b/agentflow/examples/server-embed/__tests__/sse.test.ts
@@ -67,3 +67,25 @@ describe("server-embed demo", () => {
     runner.close();
   });
 });
+
+describe("P2-6: stream — checkpoint does not break generator", () => {
+  it("drains all events including workflow:complete even with checkpoint", async () => {
+    const runner = createRunner();
+    const types: string[] = [];
+
+    // Simulate what the fixed server.ts does: don't break on checkpoint
+    for await (const ev of runner.stream(
+      triageWorkflow,
+      {},
+      {
+        onCheckpoint: async () => true,
+      },
+    )) {
+      types.push(ev.type);
+    }
+
+    expect(types).toContain("checkpoint");
+    expect(types[types.length - 1]).toBe("workflow:complete");
+    runner.close();
+  });
+});

--- a/agentflow/examples/server-embed/__tests__/sse.test.ts
+++ b/agentflow/examples/server-embed/__tests__/sse.test.ts
@@ -6,6 +6,8 @@
  * pauses at the HITL checkpoint until onCheckpoint resolves.
  */
 
+import { createServer } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { registerRunner, unregisterRunner } from "@ageflow/core";
 import type { Runner as AgentRunner } from "@ageflow/core";
 import { createRunner } from "@ageflow/server";
@@ -64,6 +66,58 @@ describe("server-embed demo", () => {
     }
     expect(events).toContain("checkpoint");
     expect(events[events.length - 1]).toBe("workflow:error");
+    runner.close();
+  });
+});
+
+// ─── Helpers for HTTP-level tests ─────────────────────────────────────────────
+
+function buildResumeHandler(
+  runner: ReturnType<typeof createRunner>,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const runId = (req.url ?? "").split("/")[2] ?? "";
+    let body = "";
+    req.on("data", (c: string) => {
+      body += c;
+    });
+    req.on("end", () => {
+      let approved: boolean;
+      try {
+        approved = JSON.parse(body).approved === true;
+      } catch {
+        res.writeHead(400).end("invalid JSON");
+        return;
+      }
+      try {
+        runner.resume(runId, approved);
+        res.writeHead(204).end();
+      } catch (err) {
+        res.writeHead(404).end(String(err));
+      }
+    });
+  };
+}
+
+describe("P2-5: resume endpoint — malformed JSON returns 400", () => {
+  it("returns 400 when body is not valid JSON", async () => {
+    const runner = createRunner();
+    const handler = buildResumeHandler(runner);
+    const srv = createServer(handler);
+    await new Promise<void>((resolve) => srv.listen(0, resolve));
+    const port = (srv.address() as { port: number }).port;
+
+    const res = await fetch(
+      `http://localhost:${port}/runs/nonexistent/resume`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{ not valid json ",
+      },
+    );
+    expect(res.status).toBe(400);
+
+    await new Promise<void>((resolve) => srv.close(() => resolve()));
     runner.close();
   });
 });

--- a/agentflow/examples/server-embed/server.ts
+++ b/agentflow/examples/server-embed/server.ts
@@ -56,7 +56,13 @@ const server = createServer(async (req, res) => {
       body += c;
     });
     req.on("end", () => {
-      const approved = JSON.parse(body).approved === true;
+      let approved: boolean;
+      try {
+        approved = JSON.parse(body).approved === true;
+      } catch {
+        res.writeHead(400).end("invalid JSON");
+        return;
+      }
       try {
         runner.resume(runId, approved);
         res.writeHead(204).end();

--- a/agentflow/examples/server-embed/server.ts
+++ b/agentflow/examples/server-embed/server.ts
@@ -33,7 +33,9 @@ const server = createServer(async (req, res) => {
     try {
       for await (const ev of runner.stream(triageWorkflow, {})) {
         res.write(`data: ${JSON.stringify(ev)}\n\n`);
-        if (ev.type === "checkpoint") break;
+        // Do NOT break on checkpoint — keep draining until workflow:complete so
+        // the run reaches a terminal state. The client can POST /runs/:id/resume
+        // while the generator is suspended at the checkpoint.
       }
       res.end();
     } catch (err) {

--- a/agentflow/packages/executor/src/__tests__/node-runner.retry-event.test.ts
+++ b/agentflow/packages/executor/src/__tests__/node-runner.retry-event.test.ts
@@ -4,6 +4,37 @@ import { z } from "zod";
 import { runNode } from "../node-runner.js";
 
 describe("runNode onRetry callback", () => {
+  it("does NOT fire onRetry when max=1 and the single attempt fails (phantom event)", async () => {
+    const alwaysFail = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        throw new Error("subprocess always fails");
+      },
+    };
+    const a = defineAgent({
+      runner: "x",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      prompt: () => "p",
+      retry: { max: 1, on: ["subprocess_error"], backoff: "fixed" },
+    });
+    const onRetry = vi.fn();
+    await expect(
+      runNode(
+        { agent: a, input: {} },
+        {},
+        alwaysFail,
+        "t",
+        undefined,
+        undefined,
+        undefined,
+        onRetry,
+      ),
+    ).rejects.toThrow();
+    // With max=1 there is no retry — onRetry must not be called
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
   it("invokes onRetry(attempt, reason) before each retry attempt", async () => {
     let attempts = 0;
     const flaky = {

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -369,6 +369,48 @@ describe("P1-2: AbortSignal stops executor", () => {
   });
 });
 
+describe("P2-1: task:error attempt count", () => {
+  it("emits task:error with attempt equal to max retries when all attempts fail", async () => {
+    let tries = 0;
+    const alwaysFail: Runner = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        tries += 1;
+        throw new Error("subprocess always fails");
+      },
+    };
+    registerRunner("always-fail", alwaysFail);
+    try {
+      const a = defineAgent({
+        runner: "always-fail",
+        input: z.object({}),
+        output: z.object({ x: z.string() }),
+        prompt: () => "p",
+        retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+      });
+      const wfFail = defineWorkflow({
+        name: "fail3",
+        tasks: { t: { agent: a, input: {} } },
+      });
+      const ex = new WorkflowExecutor(wfFail);
+      const events: WorkflowEvent[] = [];
+      try {
+        for await (const ev of ex.stream({})) events.push(ev);
+      } catch {
+        // driver throws — collect events
+      }
+      const taskErr = events.find((e) => e.type === "task:error");
+      expect(taskErr).toBeDefined();
+      if (taskErr?.type === "task:error") {
+        // 3 attempts were made; attempt should be 3, not hardcoded 0
+        expect(taskErr.attempt).toBe(3);
+      }
+    } finally {
+      unregisterRunner("always-fail");
+    }
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -218,11 +218,11 @@ export async function runNode<
           errorCode,
         });
 
-        // Notify caller about the upcoming retry attempt
-        onRetry?.(attempt + 1, errorMessage);
-
-        // Apply backoff before next attempt (not after last attempt)
+        // Apply backoff before next attempt (not after last attempt).
+        // Only fire onRetry when another attempt will actually happen.
         if (attempt < maxAttempts - 1) {
+          // Notify caller about the upcoming retry attempt
+          onRetry?.(attempt + 1, errorMessage);
           const backoffMs = calculateBackoffMs(
             resolvedDef.retry.backoff,
             attempt,

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -1,4 +1,4 @@
-import { getRunner, resolveAgentDef } from "@ageflow/core";
+import { NodeMaxRetriesError, getRunner, resolveAgentDef } from "@ageflow/core";
 import type {
   AgentDef,
   CheckpointEvent,
@@ -708,6 +708,10 @@ export class WorkflowExecutor<T extends TasksMap> {
               const latencyMs = Date.now() - taskStart;
               hooks?.onTaskError?.(taskName as keyof T & string, e, latencyMs);
 
+              // Derive actual attempt count from NodeMaxRetriesError when available
+              const attemptCount =
+                err instanceof NodeMaxRetriesError ? err.attempts.length : 1;
+
               // Emit task:error event (terminal: true — retries exhausted or non-retryable)
               push({
                 type: "task:error",
@@ -720,7 +724,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                   message: e.message,
                   ...(e.stack !== undefined ? { stack: e.stack } : {}),
                 },
-                attempt: 0,
+                attempt: attemptCount,
                 terminal: true,
               });
 

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
@@ -277,6 +277,32 @@ describe("ApiRunner.validate", () => {
     expect(res.error).toContain("ECONNREFUSED");
   });
 
+  it("P2-8: validate() passes AbortSignal.timeout so stalled proxy is bounded", async () => {
+    // Verify that the signal option is forwarded — we capture the RequestInit
+    // and check that signal is an AbortSignal (i.e. the fetch was timeout-bound).
+    let capturedSignal: AbortSignal | undefined;
+    const hangingFetch = vi
+      .fn()
+      .mockImplementation((_url: string, init: RequestInit) => {
+        capturedSignal = init.signal as AbortSignal | undefined;
+        // Return a never-resolving promise to simulate a stalled proxy
+        return new Promise<never>(() => {});
+      });
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      requestTimeout: 5_000,
+      fetch: hangingFetch as unknown as typeof fetch,
+    });
+    // Fire-and-forget (we just need the fetch to have been called)
+    const validatePromise = runner.validate();
+    // Yield to the microtask queue so fetch is called
+    await new Promise((r) => setTimeout(r, 0));
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    // Clean up — abort to prevent timer leak
+    validatePromise.catch(() => {});
+  });
+
   it("trailing slash on baseUrl is normalized", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ data: [{ id: "m" }] }), {

--- a/agentflow/packages/runners/api/src/__tests__/tool-loop.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/tool-loop.test.ts
@@ -199,6 +199,38 @@ describe("runToolLoop", () => {
     ).rejects.toBeInstanceOf(ToolNotFoundError);
   });
 
+  it("P2-7: handles missing usage field (defaults to 0) for servers that omit it", async () => {
+    const noUsage = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "done",
+            tool_calls: undefined,
+          },
+          finish_reason: "stop",
+        },
+      ],
+      // usage intentionally omitted (Ollama-style)
+    } as unknown as ChatCompletionResponse;
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(noUsage));
+    const res = await runToolLoop({
+      baseUrl: "https://example",
+      apiKey: "k",
+      headers: {},
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "llama3",
+      messages: [{ role: "user", content: "hi" }],
+      tools: undefined,
+      registry: {},
+      maxRounds: 10,
+      requestTimeout: 1000,
+    });
+    expect(res.tokensIn).toBe(0);
+    expect(res.tokensOut).toBe(0);
+    expect(res.finalText).toBe("done");
+  });
+
   it("throws MaxToolRoundsError when ceiling exceeded", async () => {
     const withToolCall: ChatCompletionResponse = {
       choices: [

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -39,6 +39,7 @@ export class ApiRunner implements Runner {
           Authorization: `Bearer ${this.apiKey}`,
           ...this.headers,
         },
+        signal: AbortSignal.timeout(this.requestTimeout),
       });
       if (!res.ok) {
         return {

--- a/agentflow/packages/runners/api/src/tool-loop.ts
+++ b/agentflow/packages/runners/api/src/tool-loop.ts
@@ -49,8 +49,8 @@ export async function runToolLoop(
     };
 
     const resp = await postChat(input, body);
-    tokensIn += resp.usage.prompt_tokens;
-    tokensOut += resp.usage.completion_tokens;
+    tokensIn += resp.usage?.prompt_tokens ?? 0;
+    tokensOut += resp.usage?.completion_tokens ?? 0;
 
     const choice = resp.choices[0];
     if (!choice) {

--- a/agentflow/packages/server/src/__tests__/runner.cancel.test.ts
+++ b/agentflow/packages/server/src/__tests__/runner.cancel.test.ts
@@ -76,4 +76,16 @@ describe("cancel", () => {
     expect(() => runner.cancel("nope")).not.toThrow();
     runner.close();
   });
+
+  it("P2-4: cancel() is no-op on already-done run (does not overwrite state)", async () => {
+    const runner = createRunner();
+    // Wait for the run to complete naturally
+    const handle = await new Promise<{ runId: string }>((resolve) => {
+      const h = runner.fire(wf, {}, { onComplete: () => resolve(h) });
+    });
+    // Run is now done — cancel() must not overwrite state
+    runner.cancel(handle.runId);
+    expect(runner.get(handle.runId)?.state).toBe("done");
+    runner.close();
+  });
 });

--- a/agentflow/packages/server/src/__tests__/runner.fire.test.ts
+++ b/agentflow/packages/server/src/__tests__/runner.fire.test.ts
@@ -84,6 +84,25 @@ describe("fire()", () => {
     }
   });
 
+  it("P2-3: run reaches done state even when onEvent throws", async () => {
+    const runner = createRunner();
+    // onEvent throws on every call — must not prevent run from completing
+    const done = new Promise<void>((resolve) => {
+      runner.fire(
+        wf,
+        {},
+        {
+          onEvent: () => {
+            throw new Error("onEvent kaboom");
+          },
+          onComplete: () => resolve(),
+        },
+      );
+    });
+    await done;
+    runner.close();
+  });
+
   it("returns a RunHandle synchronously with state=running", () => {
     const runner = createRunner();
     const handle = runner.fire(wf, {});

--- a/agentflow/packages/server/src/runner.ts
+++ b/agentflow/packages/server/src/runner.ts
@@ -145,7 +145,14 @@ export function createRunner(config: RunnerConfig = {}): Runner {
                 void
               >
             ).next();
-            if (!step.done) options?.onEvent?.(step.value);
+            if (!step.done) {
+              try {
+                options?.onEvent?.(step.value);
+              } catch {
+                // onEvent exceptions must not exit the drain loop — the run
+                // must still reach a terminal state so the registry TTL fires.
+              }
+            }
           } while (!step.done);
           options?.onComplete?.(step.value);
         } catch (err) {

--- a/agentflow/packages/server/src/runner.ts
+++ b/agentflow/packages/server/src/runner.ts
@@ -191,7 +191,16 @@ export function createRunner(config: RunnerConfig = {}): Runner {
         const { resolve } = h.pendingCheckpoint;
         resolve(false);
       }
-      h.markCancelled();
+      // Only mark cancelled when the run is not already in a terminal state.
+      // Calling cancel() on a done/failed/cancelled run must be a no-op so the
+      // terminal result is never overwritten.
+      if (
+        h.state !== "done" &&
+        h.state !== "failed" &&
+        h.state !== "cancelled"
+      ) {
+        h.markCancelled();
+      }
     },
 
     get: (runId) => registry.get(runId),


### PR DESCRIPTION
Addresses all 8 code-level P2 findings:

- P2-1: thread attempt count into task:error events
- P2-2: gate task:retry emission on attempt < max
- P2-3: wrap fire() onEvent in try/catch
- P2-4: cancel() is no-op on terminal runs
- P2-5: server-embed guards JSON.parse + returns 400
- P2-6: server-embed doesn't break generator on checkpoint
- P2-7: runner-api defaults usage fields to 0
- P2-8: runner-api validate() has AbortSignal.timeout

+8 tests (507 → 515). 21/21 typecheck + test + lint green.

Remaining 4 docs-only P2 items (Authorization header, ChatMessage export, Azure api-version, systemPrompt on resume) deferred to separate PR.