### PR TITLE
fix: final 4 items from Codex review — closes #54

### DIFF
--- a/agentflow/packages/runners/api/README.md
+++ b/agentflow/packages/runners/api/README.md
@@ -57,8 +57,12 @@ const summarize = defineAgent({
 | LM Studio     | `http://localhost:1234/v1`                                             |
 | Azure OpenAI  | `https://<resource>.openai.azure.com/openai/deployments/<model>`      |
 
-For Azure you must pass the `api-version` query param via the `headers` option
-(see Configuration below).
+For Azure you must include `?api-version=...` directly in `baseUrl` — the runner
+appends `/chat/completions` to `baseUrl` as a path segment and does not merge
+query parameters separately. Do **not** pass `api-version` via `headers`; Azure
+rejects requests where it appears only as a header.
+
+Example: `baseUrl: "https://<resource>.openai.azure.com/openai/deployments/<model>?api-version=2024-02-01"`
 
 ## Configuration
 
@@ -77,7 +81,7 @@ new ApiRunner({
   maxToolRounds: 10,             // max tool-call loops before MaxToolRoundsError (default 10)
   requestTimeout: 120_000,       // ms before AbortController fires (default 120 000)
   headers: {                     // extra headers forwarded on every request
-    "api-version": "2024-02-01", // e.g. Azure api-version
+    "x-custom-header": "value",  // e.g. custom tracing headers
   },
   fetch: myFetchImpl,            // injectable fetch (default: globalThis.fetch)
 })

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.test.ts
@@ -319,4 +319,38 @@ describe("ApiRunner.validate", () => {
     const url = fetchMock.mock.calls[0]?.[0] as string;
     expect(url).toBe("https://example.test/v1/models");
   });
+
+  it("P2-9: user-supplied authorization header variant does not clash with Bearer token", async () => {
+    // Config supplies headers.authorization (lowercase) — must be stripped so that
+    // only the canonical Bearer token ends up in the fetch call.
+    let capturedHeaders: Record<string, string> | undefined;
+    const capturingFetch = vi
+      .fn()
+      .mockImplementation((_url: string, init: RequestInit) => {
+        capturedHeaders = init.headers as Record<string, string>;
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: [{ id: "m" }] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      });
+
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "my-secret-key",
+      headers: { authorization: "user-Bearer X" },
+      fetch: capturingFetch as unknown as typeof fetch,
+    });
+
+    await runner.validate();
+
+    // Must have exactly ONE Authorization entry (case-insensitive scan)
+    const authEntries = Object.entries(capturedHeaders ?? {}).filter(
+      ([k]) => k.toLowerCase() === "authorization",
+    );
+    expect(authEntries.length).toBe(1);
+    // Must use our Bearer token, not the user-supplied value
+    expect(authEntries[0]?.[1]).toBe("Bearer my-secret-key");
+  });
 });

--- a/agentflow/packages/runners/api/src/__tests__/exports.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/exports.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+// Verify that ChatMessage is re-exported from the public API surface.
+// This is a compile-time check: if ChatMessage is not exported, TypeScript
+// will fail to compile this import and the test suite will not run.
+import type { ChatMessage } from "../index.js";
+
+describe("public API exports", () => {
+  it("ChatMessage type is exported from index and usable as annotation", () => {
+    const msg: ChatMessage = { role: "user", content: "hello" };
+    expect(msg.role).toBe("user");
+    expect(msg.content).toBe("hello");
+  });
+});

--- a/agentflow/packages/runners/api/src/__tests__/message-builder.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/message-builder.test.ts
@@ -37,15 +37,30 @@ describe("buildInitialMessages", () => {
     expect(msgs[3]).toEqual({ role: "user", content: "next" });
   });
 
-  it("does not duplicate system when history already has one", () => {
-    const history: ChatMessage[] = [{ role: "system", content: "old" }];
+  it("P2-6: replaces stale system message with new systemPrompt on resumed sessions", () => {
+    // Executor regenerates system prompt with per-task output schema on every
+    // spawn. The new systemPrompt must replace the old one so stale schema
+    // instructions do not persist across resumed sessions.
+    const history: ChatMessage[] = [
+      { role: "system", content: "old schema" },
+      { role: "user", content: "earlier" },
+      { role: "assistant", content: "earlier reply" },
+    ];
     const msgs = buildInitialMessages({
-      prompt: "p",
-      systemPrompt: "new",
+      prompt: "next",
+      systemPrompt: "new schema",
       history,
     });
-    // history wins — new systemPrompt only prepended if history has no system
-    expect(msgs.filter((m) => m.role === "system").length).toBe(1);
-    expect(msgs[0]).toEqual({ role: "system", content: "old" });
+    // Exactly one system message
+    const systemMsgs = msgs.filter((m) => m.role === "system");
+    expect(systemMsgs.length).toBe(1);
+    // Must be the NEW prompt, not the old one
+    expect(systemMsgs[0]).toEqual({ role: "system", content: "new schema" });
+    // Must appear first
+    expect(msgs[0]).toEqual({ role: "system", content: "new schema" });
+    // Old system message must be gone — remaining history preserved
+    expect(msgs.filter((m) => m.content === "old schema").length).toBe(0);
+    // User prompt is last
+    expect(msgs[msgs.length - 1]).toEqual({ role: "user", content: "next" });
   });
 });

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -33,11 +33,16 @@ export class ApiRunner implements Runner {
 
   async validate(): Promise<{ ok: boolean; version?: string; error?: string }> {
     try {
+      const sanitized = Object.fromEntries(
+        Object.entries(this.headers).filter(
+          ([k]) => k.toLowerCase() !== "authorization",
+        ),
+      );
       const res = await this.fetch(`${this.baseUrl}/models`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
-          ...this.headers,
+          ...sanitized,
         },
         signal: AbortSignal.timeout(this.requestTimeout),
       });

--- a/agentflow/packages/runners/api/src/index.ts
+++ b/agentflow/packages/runners/api/src/index.ts
@@ -12,3 +12,4 @@ export type {
   SessionStore,
   ToolCallRecord,
 } from "./types.js";
+export type { ChatMessage } from "./openai-types.js";

--- a/agentflow/packages/runners/api/src/message-builder.ts
+++ b/agentflow/packages/runners/api/src/message-builder.ts
@@ -9,19 +9,24 @@ export interface BuildMessagesInput {
 
 /**
  * Build the initial messages[] array for a new (or resumed) session.
- * Rule: system message present in history takes precedence; otherwise
- * the provided systemPrompt is prepended when non-empty.
+ *
+ * When a systemPrompt is provided it always wins: any prior system message in
+ * history is replaced so that stale per-task output-schema instructions do not
+ * persist across resumed sessions.  When no systemPrompt is provided the
+ * history is used as-is (existing system message, if any, is kept).
  */
 export function buildInitialMessages(input: BuildMessagesInput): ChatMessage[] {
   const history = input.history ?? [];
-  const hasSystem = history.some((m) => m.role === "system");
   const out: ChatMessage[] = [];
 
-  if (!hasSystem && input.systemPrompt && input.systemPrompt.length > 0) {
+  if (input.systemPrompt && input.systemPrompt.length > 0) {
+    // Prepend new system prompt and strip any prior system message from history
     out.push({ role: "system", content: input.systemPrompt });
+    out.push(...history.filter((m) => m.role !== "system"));
+  } else {
+    out.push(...history);
   }
 
-  out.push(...history);
   out.push({ role: "user", content: input.prompt });
   return out;
 }

--- a/agentflow/packages/runners/api/src/tool-loop.ts
+++ b/agentflow/packages/runners/api/src/tool-loop.ts
@@ -124,12 +124,17 @@ async function postChat(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), input.requestTimeout);
   try {
+    const sanitized = Object.fromEntries(
+      Object.entries(input.headers).filter(
+        ([k]) => k.toLowerCase() !== "authorization",
+      ),
+    );
     const resp = await input.fetch(`${input.baseUrl}/chat/completions`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${input.apiKey}`,
-        ...input.headers,
+        Authorization: `Bearer ${input.apiKey}`,
+        ...sanitized,
       },
       body: JSON.stringify(body),
       signal: controller.signal,


### PR DESCRIPTION
Final 4 fixes to close #54:
- Authorization header case-variant sanitization (api-runner + tool-loop)
- ChatMessage exported from public API
- Azure api-version: README corrected to URL query-string pattern
- systemPrompt replaces stale system message on resumed sessions

31 tests (+2). 21/21 typecheck + test + lint green.