### PR TITLE
feat(mcp-server): #18 Phase 4 — 5 async tools (start/get_status/get_result/resume/cancel)

### DIFF
--- a/agentflow/packages/mcp-server/src/__tests__/async-mode.test-d.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/async-mode.test-d.ts
@@ -1,0 +1,14 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { describe, expectTypeOf, it } from "vitest";
+import { buildJobTools } from "../job-tools.js";
+import { buildToolDefinition } from "../tool-registry.js";
+
+declare const wf: WorkflowDef;
+
+describe("async-mode type guards", () => {
+  it("start_<wf> inputSchema type matches sync tool's inputSchema type", () => {
+    const sync = buildToolDefinition(wf);
+    const [start] = buildJobTools(wf);
+    expectTypeOf(start?.inputSchema).toEqualTypeOf<typeof sync.inputSchema>();
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
@@ -1,0 +1,249 @@
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { McpToolResult } from "../../server.js";
+import { createMcpServer } from "../../server.js";
+
+const agent = defineAgent({
+  runner: "fake",
+  input: z.object({ q: z.string() }),
+  output: z.object({ a: z.string() }),
+  prompt: () => "p",
+});
+
+const workflow = defineWorkflow({
+  name: "ask",
+  tasks: { t: { agent, input: { q: "hi" } } },
+});
+
+describe("async mode: listTools (#18)", () => {
+  it("returns 1 tool when async is omitted (default)", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["ask"]);
+  });
+
+  it("returns 1 tool when async: false", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: false,
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["ask"]);
+  });
+
+  it("returns 6 tools when async: true (sync + 5 job tools)", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    const tools = await h.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      [
+        "ask",
+        "cancel_workflow",
+        "get_workflow_result",
+        "get_workflow_status",
+        "resume_workflow",
+        "start_ask",
+      ].sort(),
+    );
+    h.dispose?.();
+  });
+});
+
+describe("async mode: start_<wf> (#18)", () => {
+  it("returns a jobId and registers a RunHandle in state 'running'", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    // Inject a no-op executor so we can observe the RunHandle without real work.
+    h._testRunExecutor = async () => ({ a: "done" });
+
+    const res = await h.callTool("start_ask", { q: "hello" });
+    expect(res.isError).toBe(false);
+    if (!res.isError) {
+      expect(res.structuredContent).toMatchObject({
+        jobId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      });
+    }
+    h.dispose?.();
+  });
+
+  it("rejects invalid input with INPUT_VALIDATION_FAILED", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    const res = await h.callTool("start_ask", { q: 42 });
+    expect(res.isError).toBe(true);
+    if (res.isError) {
+      expect(res.structuredContent.errorCode).toBe("INPUT_VALIDATION_FAILED");
+    }
+    h.dispose?.();
+  });
+});
+
+describe("async mode: inflight lock (#18)", () => {
+  it("two concurrent start_* calls: second returns BUSY", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    let release!: () => void;
+    h._testRunExecutor = () =>
+      new Promise((res) => {
+        release = () => res({ a: "ok" });
+      });
+
+    const first = h.callTool("start_ask", { q: "1" });
+    const second = await h.callTool("start_ask", { q: "2" });
+    expect(second.isError).toBe(true);
+    if (second.isError) expect(second.structuredContent.errorCode).toBe("BUSY");
+
+    release();
+    await first;
+    // Wait a macrotask cycle so onComplete fires and inflight resets.
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    const third = await h.callTool("start_ask", { q: "3" });
+    expect(third.isError).toBe(false);
+    h.dispose?.();
+  });
+
+  it("get_workflow_status is callable while a job is running", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    let release!: () => void;
+    h._testRunExecutor = () =>
+      new Promise((res) => {
+        release = () => res({ a: "ok" });
+      });
+
+    const startRes = await h.callTool("start_ask", { q: "q" });
+    if (startRes.isError) throw new Error("start failed");
+    const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+    // While inflight — observer must not be blocked.
+    const status = await h.callTool("get_workflow_status", { jobId });
+    expect(status.isError).toBe(false);
+    if (!status.isError) {
+      expect(status.structuredContent.state).toBe("running");
+    }
+
+    release();
+    h.dispose?.();
+  });
+});
+
+describe("async mode: cancel_workflow (#18)", () => {
+  it("start → cancel → status=cancelled → get_workflow_result yields JOB_CANCELLED", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: true,
+    });
+    let release!: () => void;
+    h._testRunExecutor = () =>
+      new Promise((res) => {
+        release = () => res({ a: "ok" });
+      });
+
+    const startRes = await h.callTool("start_ask", { q: "q" });
+    if (startRes.isError) throw new Error("start failed");
+    const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+    const cancelRes = await h.callTool("cancel_workflow", { jobId });
+    expect(cancelRes.isError).toBe(false);
+    if (!cancelRes.isError) {
+      expect(cancelRes.structuredContent).toMatchObject({
+        cancelled: true,
+        priorState: "running",
+      });
+    }
+
+    const status = await h.callTool("get_workflow_status", { jobId });
+    if (!status.isError)
+      expect(status.structuredContent.state).toBe("cancelled");
+
+    const result = await h.callTool("get_workflow_result", { jobId });
+    expect(result.isError).toBe(true);
+    if (result.isError)
+      expect(result.structuredContent.errorCode).toBe("JOB_CANCELLED");
+
+    // Idempotent second cancel.
+    const cancel2 = await h.callTool("cancel_workflow", { jobId });
+    if (!cancel2.isError) {
+      expect(cancel2.structuredContent).toMatchObject({
+        cancelled: false,
+        priorState: "cancelled",
+      });
+    }
+
+    release();
+    h.dispose?.();
+  });
+});
+
+describe("async mode: JOB_NOT_FOUND (#18)", () => {
+  it.each([
+    "get_workflow_status",
+    "get_workflow_result",
+    "cancel_workflow",
+    "resume_workflow",
+  ])(
+    "%s with unknown jobId → JOB_NOT_FOUND or INVALID_RUN_STATE",
+    async (toolName) => {
+      const h = createMcpServer({
+        workflow,
+        cliCeilings: {},
+        hitlStrategy: "auto",
+        async: true,
+      });
+      const res = await h.callTool(toolName, { jobId: "nope", approved: true });
+      expect(res.isError).toBe(true);
+      if (res.isError) {
+        expect(["JOB_NOT_FOUND", "INVALID_RUN_STATE"]).toContain(
+          res.structuredContent.errorCode,
+        );
+      }
+      h.dispose?.();
+    },
+  );
+});
+
+describe("async mode: ASYNC_MODE_DISABLED (#18)", () => {
+  it("calling a job tool when async=false returns ASYNC_MODE_DISABLED", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: {},
+      hitlStrategy: "auto",
+      async: false,
+    });
+    const res = await h.callTool("start_ask", { q: "hello" });
+    expect(res.isError).toBe(true);
+    if (res.isError) {
+      expect(res.structuredContent.errorCode).toBe("ASYNC_MODE_DISABLED");
+    }
+  });
+});

--- a/agentflow/packages/mcp-server/src/__tests__/job-tools.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/job-tools.test.ts
@@ -1,0 +1,87 @@
+import { defineAgent, defineWorkflow } from "@ageflow/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildJobTools } from "../job-tools.js";
+import { buildToolDefinition } from "../tool-registry.js";
+
+const agent = defineAgent({
+  runner: "fake",
+  input: z.object({ q: z.string() }),
+  output: z.object({ a: z.string() }),
+  prompt: () => "p",
+});
+
+const workflow = defineWorkflow({
+  name: "ask",
+  tasks: { t: { agent, input: { q: "hi" } } },
+});
+
+describe("buildJobTools", () => {
+  it("returns exactly 5 tools with canonical names", () => {
+    const tools = buildJobTools(workflow);
+    expect(tools.map((t) => t.name)).toEqual([
+      "start_ask",
+      "get_workflow_status",
+      "get_workflow_result",
+      "resume_workflow",
+      "cancel_workflow",
+    ]);
+  });
+
+  it("start_<wf> input schema mirrors the sync tool's input schema", () => {
+    const sync = buildToolDefinition(workflow);
+    const [startTool] = buildJobTools(workflow);
+    expect(startTool?.inputSchema).toEqual(sync.inputSchema);
+  });
+
+  it("start_<wf> output schema is { jobId: string }", () => {
+    const [startTool] = buildJobTools(workflow);
+    expect(startTool?.outputSchema).toMatchObject({
+      type: "object",
+      required: ["jobId"],
+      properties: { jobId: { type: "string" } },
+    });
+  });
+
+  it("observer tools share the { jobId } input schema", () => {
+    const tools = buildJobTools(workflow);
+    for (const name of [
+      "get_workflow_status",
+      "get_workflow_result",
+      "cancel_workflow",
+    ]) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool?.inputSchema).toMatchObject({
+        type: "object",
+        required: ["jobId"],
+        properties: { jobId: { type: "string" } },
+      });
+    }
+  });
+
+  it("resume_workflow input is { jobId, approved }", () => {
+    const tools = buildJobTools(workflow);
+    const resume = tools.find((t) => t.name === "resume_workflow");
+    expect(resume?.inputSchema).toMatchObject({
+      type: "object",
+      required: ["jobId", "approved"],
+      properties: {
+        jobId: { type: "string" },
+        approved: { type: "boolean" },
+      },
+    });
+  });
+
+  it("get_workflow_status output schema covers state + currentTask + progress", () => {
+    const tools = buildJobTools(workflow);
+    const status = tools.find((t) => t.name === "get_workflow_status");
+    const props = (
+      status?.outputSchema as { properties: Record<string, unknown> }
+    ).properties;
+    expect(props).toHaveProperty("state");
+    expect(props).toHaveProperty("currentTask");
+    expect(props).toHaveProperty("progress");
+    expect(props).toHaveProperty("createdAt");
+    expect(props).toHaveProperty("lastEventAt");
+  });
+});

--- a/agentflow/packages/mcp-server/src/index.ts
+++ b/agentflow/packages/mcp-server/src/index.ts
@@ -9,3 +9,4 @@ export { startStdioTransport } from "./stdio-transport.js";
 export type { StdioTransportOptions } from "./stdio-transport.js";
 export type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
 export { ErrorCode, McpServerError } from "./errors.js";
+export { buildJobTools } from "./job-tools.js";

--- a/agentflow/packages/mcp-server/src/job-dispatch.ts
+++ b/agentflow/packages/mcp-server/src/job-dispatch.ts
@@ -1,4 +1,362 @@
-import { createRunner } from "@ageflow/server";
+import type {
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  WorkflowDef,
+  WorkflowEvent,
+} from "@ageflow/core";
+import { registerRunner, unregisterRunner } from "@ageflow/core";
+import { type Runner, createRunner } from "@ageflow/server";
+import { ErrorCode, McpServerError, formatErrorResult } from "./errors.js";
+import { JobEventRecorder } from "./job-event-recorder.js";
+import type { McpToolResult } from "./server.js";
+import type { ToolDefinition } from "./tool-registry.js";
 
-// Placeholder to keep the module non-empty. Real impl lands in Phase 4.
-export const _unused = createRunner;
+export interface JobDispatchContext {
+  readonly runner: Runner;
+  readonly recorder: JobEventRecorder;
+  readonly workflow: WorkflowDef;
+  readonly tool: ToolDefinition; // sync tool (for output validation)
+  readonly jobTools: readonly ToolDefinition[]; // full job-tool array
+  /** Executor injection hook from tests (mirrors sync path's _testRunExecutor). */
+  testRunExecutor?: (input: unknown) => Promise<unknown>;
+  /** Task count in the workflow (for progress.tasksTotal). */
+  readonly taskCount: number;
+  /** Called from fire() onComplete/onError to release the inflight lock. */
+  readonly releaseInflight: () => void;
+}
+
+export async function dispatchStart(
+  _toolName: string,
+  args: unknown,
+  ctx: JobDispatchContext,
+): Promise<McpToolResult> {
+  // Validate input via the sync tool's input Zod (shared between sync + async)
+  const inputTaskDef = ctx.workflow.tasks[ctx.tool.inputTask] as {
+    agent: { input: import("zod").ZodType };
+  };
+  const parsed = inputTaskDef.agent.input.safeParse(args);
+  if (!parsed.success) {
+    // Release inflight lock on validation failure (caller already set it)
+    ctx.releaseInflight();
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.INPUT_VALIDATION_FAILED,
+        `schema validation failed: ${String(parsed.error)}`,
+        { error: parsed.error },
+      ),
+    );
+  }
+
+  // If a test executor is injected, temporarily register a fake runner that
+  // delegates to it. This ensures runner.fire() still registers the handle in
+  // the RunRegistry, so observer tools (get_workflow_status, cancel_workflow,
+  // etc.) can find it via runner.get(runId).
+  //
+  // In test mode, dispatchStart awaits job completion so that tests can do
+  //   `await h.callTool("start_ask", ...)` and then immediately call observer
+  //   tools without races. (In production, start_* returns jobId immediately
+  //   and the runner background loop is truly fire-and-forget.)
+  if (ctx.testRunExecutor !== undefined) {
+    const testExec = ctx.testRunExecutor;
+    // Get the runner name used by the input task's agent
+    const inputAgent = ctx.workflow.tasks[ctx.tool.inputTask] as {
+      agent: { runner: string; output: import("zod").ZodType };
+    };
+    const runnerName = inputAgent.agent.runner;
+
+    // Register a temporary runner for the duration of this fire() call
+    const fakeRunner = {
+      validate: async () => ({ ok: true }),
+      spawn: async (
+        _spawnArgs: RunnerSpawnArgs,
+      ): Promise<RunnerSpawnResult> => {
+        const output = await testExec(parsed.data);
+        return {
+          stdout: JSON.stringify(output),
+          sessionHandle: "test",
+          tokensIn: 0,
+          tokensOut: 0,
+        };
+      },
+    };
+    registerRunner(runnerName, fakeRunner);
+
+    const handle = ctx.runner.fire(ctx.workflow, parsed.data, {
+      onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
+      onComplete: () => {
+        unregisterRunner(runnerName);
+        ctx.releaseInflight();
+      },
+      onError: () => {
+        unregisterRunner(runnerName);
+        ctx.releaseInflight();
+      },
+    });
+
+    const jobId = handle.runId;
+    // Return the result immediately so the caller has the jobId.
+    // completionPromise is available for tests that need to sync on completion.
+    return {
+      content: [{ type: "text", text: JSON.stringify({ jobId }) }],
+      structuredContent: { jobId },
+      isError: false,
+    };
+  }
+
+  const handle = ctx.runner.fire(ctx.workflow, parsed.data, {
+    // onCheckpoint is intentionally OMITTED — triggers server's deferred path
+    // (handle.markAwaitingCheckpoint(ev, resolver)) so resume_workflow can clear it.
+    onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
+    onComplete: () => {
+      ctx.releaseInflight();
+    },
+    onError: () => {
+      ctx.releaseInflight();
+    },
+  });
+
+  return {
+    content: [{ type: "text", text: JSON.stringify({ jobId: handle.runId }) }],
+    structuredContent: { jobId: handle.runId },
+    isError: false,
+  };
+}
+
+export function dispatchGetStatus(
+  args: unknown,
+  ctx: JobDispatchContext,
+): McpToolResult {
+  const jobId = parseJobId(args);
+  if (typeof jobId !== "string") return jobId;
+  const handle = ctx.runner.get(jobId);
+  if (!handle) {
+    return formatErrorResult(
+      new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, {
+        jobId,
+      }),
+    );
+  }
+  const snap = ctx.recorder.snapshot(jobId);
+  const currentTask =
+    handle.state === "awaiting-checkpoint" && handle.pendingCheckpoint
+      ? {
+          name: handle.pendingCheckpoint.taskName,
+          kind: "checkpoint" as const,
+          message: handle.pendingCheckpoint.message,
+        }
+      : snap?.lastTaskStart
+        ? { name: snap.lastTaskStart.taskName, kind: "task" as const }
+        : undefined;
+  const progress = snap
+    ? {
+        tasksCompleted: snap.tasksCompleted,
+        tasksTotal: ctx.taskCount,
+        ...(snap.lastBudgetWarning !== undefined
+          ? {
+              spentUsd: snap.lastBudgetWarning.spentUsd,
+              limitUsd: snap.lastBudgetWarning.limitUsd,
+            }
+          : {}),
+      }
+    : undefined;
+
+  const structured = {
+    state: handle.state,
+    createdAt: handle.createdAt,
+    lastEventAt: handle.lastEventAt,
+    ...(currentTask !== undefined ? { currentTask } : {}),
+    ...(progress !== undefined ? { progress } : {}),
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(structured) }],
+    structuredContent: structured,
+    isError: false,
+  };
+}
+
+export function dispatchGetResult(
+  args: unknown,
+  ctx: JobDispatchContext,
+): McpToolResult {
+  const jobId = parseJobId(args);
+  if (typeof jobId !== "string") return jobId;
+  const handle = ctx.runner.get(jobId);
+  if (!handle) {
+    return formatErrorResult(
+      new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, {
+        jobId,
+      }),
+    );
+  }
+
+  if (handle.state === "running" || handle.state === "awaiting-checkpoint") {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ pending: true }) }],
+      structuredContent: { pending: true },
+      isError: false,
+    };
+  }
+  if (handle.state === "cancelled") {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.JOB_CANCELLED,
+        `job ${jobId} was cancelled`,
+        { jobId },
+      ),
+    );
+  }
+  if (handle.state === "failed") {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.WORKFLOW_FAILED,
+        handle.error?.message ?? "workflow failed",
+        { jobId, error: handle.error },
+      ),
+    );
+  }
+  // done — re-validate the output task's result through the output Zod schema.
+  const raw = handle.result?.outputs[ctx.tool.outputTask];
+  const outputTaskDef = ctx.workflow.tasks[ctx.tool.outputTask] as {
+    agent: { output: import("zod").ZodType };
+  };
+  const parsedOutput = outputTaskDef.agent.output.safeParse(raw);
+  if (!parsedOutput.success) {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.OUTPUT_VALIDATION_FAILED,
+        `schema validation failed: ${String(parsedOutput.error)}`,
+        { error: parsedOutput.error },
+      ),
+    );
+  }
+  const structured = {
+    state: "done" as const,
+    output: parsedOutput.data,
+    metrics: handle.result?.metrics,
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(structured) }],
+    structuredContent: structured as Record<string, unknown>,
+    isError: false,
+  };
+}
+
+export function dispatchCancel(
+  args: unknown,
+  ctx: JobDispatchContext,
+): McpToolResult {
+  const jobId = parseJobId(args);
+  if (typeof jobId !== "string") return jobId;
+  const handle = ctx.runner.get(jobId);
+  if (!handle) {
+    return formatErrorResult(
+      new McpServerError(ErrorCode.JOB_NOT_FOUND, `unknown jobId: ${jobId}`, {
+        jobId,
+      }),
+    );
+  }
+  if (handle.state !== "running" && handle.state !== "awaiting-checkpoint") {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ cancelled: false, priorState: handle.state }),
+        },
+      ],
+      structuredContent: { cancelled: false, priorState: handle.state },
+      isError: false,
+    };
+  }
+  const priorState = handle.state;
+  ctx.runner.cancel(jobId);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ cancelled: true, priorState }),
+      },
+    ],
+    structuredContent: { cancelled: true, priorState },
+    isError: false,
+  };
+}
+
+export function dispatchResume(
+  args: unknown,
+  ctx: JobDispatchContext,
+): McpToolResult {
+  const parsed = parseResumeArgs(args);
+  if ("isError" in parsed) return parsed;
+  try {
+    ctx.runner.resume(parsed.jobId, parsed.approved);
+  } catch (err) {
+    return formatErrorResult(err);
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify({ resumed: true }) }],
+    structuredContent: { resumed: true },
+    isError: false,
+  };
+}
+
+/**
+ * Parse jobId from args. Returns the string jobId or an error McpToolResult.
+ */
+function parseJobId(args: unknown): string | McpToolResult {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    typeof (args as { jobId?: unknown }).jobId !== "string"
+  ) {
+    return formatErrorResult(
+      new McpServerError(ErrorCode.INPUT_VALIDATION_FAILED, "missing jobId", {
+        args,
+      }),
+    );
+  }
+  return (args as { jobId: string }).jobId;
+}
+
+function parseResumeArgs(
+  args: unknown,
+): { jobId: string; approved: boolean } | McpToolResult {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    typeof (args as { jobId?: unknown }).jobId !== "string" ||
+    typeof (args as { approved?: unknown }).approved !== "boolean"
+  ) {
+    return formatErrorResult(
+      new McpServerError(
+        ErrorCode.INPUT_VALIDATION_FAILED,
+        "missing jobId or approved",
+        { args },
+      ),
+    );
+  }
+  return args as { jobId: string; approved: boolean };
+}
+
+/** Factory used by server.ts to build the per-server dispatch context. */
+export function createJobDispatchContext(args: {
+  workflow: WorkflowDef;
+  tool: ToolDefinition;
+  jobTools: readonly ToolDefinition[];
+  jobTtlMs?: number;
+  jobCheckpointTtlMs?: number;
+  releaseInflight: () => void;
+}): JobDispatchContext {
+  const runner = createRunner({
+    ttlMs: args.jobTtlMs ?? 30 * 60_000,
+    checkpointTtlMs: args.jobCheckpointTtlMs ?? 60 * 60_000,
+  });
+  return {
+    runner,
+    recorder: new JobEventRecorder(),
+    workflow: args.workflow,
+    tool: args.tool,
+    jobTools: args.jobTools,
+    taskCount: Object.keys(args.workflow.tasks).length,
+    releaseInflight: args.releaseInflight,
+  };
+}

--- a/agentflow/packages/mcp-server/src/job-tools.ts
+++ b/agentflow/packages/mcp-server/src/job-tools.ts
@@ -1,0 +1,154 @@
+import type { WorkflowDef } from "@ageflow/core";
+import { type ToolDefinition, buildToolDefinition } from "./tool-registry.js";
+
+const JOB_ID_SCHEMA = {
+  type: "object",
+  required: ["jobId"],
+  properties: {
+    jobId: { type: "string", description: "Job identifier (UUID)" },
+  },
+  additionalProperties: false,
+} as const;
+
+const RESUME_SCHEMA = {
+  type: "object",
+  required: ["jobId", "approved"],
+  properties: {
+    jobId: { type: "string", description: "Job identifier (UUID)" },
+    approved: {
+      type: "boolean",
+      description: "true to approve checkpoint, false to reject",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const STATUS_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["state", "createdAt", "lastEventAt"],
+  properties: {
+    state: {
+      type: "string",
+      enum: ["running", "awaiting-checkpoint", "done", "failed", "cancelled"],
+    },
+    currentTask: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        kind: { type: "string", enum: ["task", "checkpoint"] },
+        message: { type: "string" },
+      },
+    },
+    progress: {
+      type: "object",
+      properties: {
+        tasksCompleted: { type: "number" },
+        tasksTotal: { type: "number" },
+        spentUsd: { type: "number" },
+        limitUsd: { type: "number" },
+      },
+    },
+    createdAt: { type: "number" },
+    lastEventAt: { type: "number" },
+  },
+} as const;
+
+const RESULT_OUTPUT_SCHEMA = {
+  type: "object",
+  // Either { pending: true } OR { state: "done", output: ..., metrics: ... }
+  properties: {
+    pending: { type: "boolean" },
+    state: { type: "string" },
+    output: {},
+    metrics: { type: "object" },
+  },
+} as const;
+
+const CANCEL_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["cancelled", "priorState"],
+  properties: {
+    cancelled: { type: "boolean" },
+    priorState: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const RESUME_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["resumed"],
+  properties: { resumed: { type: "boolean" } },
+  additionalProperties: false,
+} as const;
+
+/**
+ * Build the 5 MCP tool definitions exposed in async mode:
+ *
+ *   start_<workflow.name>   — fire-and-forget; returns { jobId }
+ *   get_workflow_status     — poll state + progress
+ *   get_workflow_result     — fetch validated output (or { pending: true })
+ *   resume_workflow         — approve/reject a checkpoint
+ *   cancel_workflow         — best-effort cancel
+ *
+ * Named after the workflow so clients get per-workflow input typing
+ * (spec §Open questions #1). Observer tools are generic because any
+ * call references a runId that a `start_*` produced.
+ */
+export function buildJobTools(
+  workflow: WorkflowDef,
+): readonly ToolDefinition[] {
+  const sync = buildToolDefinition(workflow);
+  const wf = workflow.name;
+  return [
+    {
+      name: `start_${wf}`,
+      description: `Start workflow "${wf}" asynchronously. Returns a jobId for polling.`,
+      inputSchema: sync.inputSchema,
+      outputSchema: {
+        type: "object",
+        required: ["jobId"],
+        properties: {
+          jobId: { type: "string", description: "UUID for polling" },
+        },
+        additionalProperties: false,
+      },
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "get_workflow_status",
+      description: "Poll the current state of an async workflow job.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: STATUS_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "get_workflow_result",
+      description:
+        "Fetch the validated output of a completed async workflow job. Returns { pending: true } while still running.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: RESULT_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "resume_workflow",
+      description:
+        "Resolve an awaiting-checkpoint job. Pass approved=true to continue, false to reject.",
+      inputSchema: RESUME_SCHEMA,
+      outputSchema: RESUME_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+    {
+      name: "cancel_workflow",
+      description:
+        "Cancel an async workflow job. Idempotent: returns cancelled=false if the job is already terminal.",
+      inputSchema: JOB_ID_SCHEMA,
+      outputSchema: CANCEL_OUTPUT_SCHEMA,
+      inputTask: sync.inputTask,
+      outputTask: sync.outputTask,
+    },
+  ];
+}

--- a/agentflow/packages/mcp-server/src/job-tools.ts
+++ b/agentflow/packages/mcp-server/src/job-tools.ts
@@ -1,16 +1,17 @@
 import type { WorkflowDef } from "@ageflow/core";
+import type { McpJsonSchema } from "./schema-convert.js";
 import { type ToolDefinition, buildToolDefinition } from "./tool-registry.js";
 
-const JOB_ID_SCHEMA = {
+const JOB_ID_SCHEMA: McpJsonSchema = {
   type: "object",
   required: ["jobId"],
   properties: {
     jobId: { type: "string", description: "Job identifier (UUID)" },
   },
   additionalProperties: false,
-} as const;
+};
 
-const RESUME_SCHEMA = {
+const RESUME_SCHEMA: McpJsonSchema = {
   type: "object",
   required: ["jobId", "approved"],
   properties: {
@@ -21,9 +22,9 @@ const RESUME_SCHEMA = {
     },
   },
   additionalProperties: false,
-} as const;
+};
 
-const STATUS_OUTPUT_SCHEMA = {
+const STATUS_OUTPUT_SCHEMA: McpJsonSchema = {
   type: "object",
   required: ["state", "createdAt", "lastEventAt"],
   properties: {
@@ -51,9 +52,9 @@ const STATUS_OUTPUT_SCHEMA = {
     createdAt: { type: "number" },
     lastEventAt: { type: "number" },
   },
-} as const;
+};
 
-const RESULT_OUTPUT_SCHEMA = {
+const RESULT_OUTPUT_SCHEMA: McpJsonSchema = {
   type: "object",
   // Either { pending: true } OR { state: "done", output: ..., metrics: ... }
   properties: {
@@ -62,9 +63,9 @@ const RESULT_OUTPUT_SCHEMA = {
     output: {},
     metrics: { type: "object" },
   },
-} as const;
+};
 
-const CANCEL_OUTPUT_SCHEMA = {
+const CANCEL_OUTPUT_SCHEMA: McpJsonSchema = {
   type: "object",
   required: ["cancelled", "priorState"],
   properties: {
@@ -72,14 +73,14 @@ const CANCEL_OUTPUT_SCHEMA = {
     priorState: { type: "string" },
   },
   additionalProperties: false,
-} as const;
+};
 
-const RESUME_OUTPUT_SCHEMA = {
+const RESUME_OUTPUT_SCHEMA: McpJsonSchema = {
   type: "object",
   required: ["resumed"],
   properties: { resumed: { type: "boolean" } },
   additionalProperties: false,
-} as const;
+};
 
 /**
  * Build the 5 MCP tool definitions exposed in async mode:

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -9,6 +9,16 @@ import {
   formatErrorResult,
 } from "./errors.js";
 import { type McpConnectionLike, buildMcpHooks } from "./hitl-bridge.js";
+import {
+  type JobDispatchContext,
+  createJobDispatchContext,
+  dispatchCancel,
+  dispatchGetResult,
+  dispatchGetStatus,
+  dispatchResume,
+  dispatchStart,
+} from "./job-dispatch.js";
+import { buildJobTools } from "./job-tools.js";
 import { ProgressStreamer, type SendProgress } from "./progress-streamer.js";
 import { type ToolDefinition, buildToolDefinition } from "./tool-registry.js";
 import type { CliCeilings, EffectiveCeilings, HitlStrategy } from "./types.js";
@@ -26,6 +36,12 @@ export interface McpServerOptions {
   readonly workflow: WorkflowDef;
   readonly cliCeilings: CliCeilings;
   readonly hitlStrategy: HitlStrategy;
+  /** Opt-in async job mode. Default: false. */
+  readonly async?: boolean;
+  /** Override the default 30-minute job TTL (async mode only). */
+  readonly jobTtlMs?: number;
+  /** Override the default 1-hour checkpoint TTL (async mode only). */
+  readonly jobCheckpointTtlMs?: number;
   /** Custom stderr writer (for testing); defaults to process.stderr.write. */
   readonly stderr?: (line: string) => void;
   /**
@@ -61,6 +77,8 @@ export interface McpServerHandle {
     signal: AbortSignal,
     effective: EffectiveCeilings,
   ) => Promise<unknown>;
+  /** Stop background TTL reaper (async mode only). Idempotent. */
+  dispose?(): void;
 }
 
 /**
@@ -79,16 +97,62 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
       process.stderr.write(line);
     });
   const tool = buildToolDefinition(opts.workflow);
+  const jobTools = opts.async === true ? buildJobTools(opts.workflow) : [];
 
   let inflight = false;
+  let dispatchCtx: JobDispatchContext | undefined; // lazy — created on first start_*
+
+  const startName = `start_${opts.workflow.name}`;
+  const OBSERVER_TOOLS = new Set([
+    "get_workflow_status",
+    "get_workflow_result",
+    "cancel_workflow",
+    "resume_workflow",
+  ]);
+
+  function ensureDispatchCtx(): JobDispatchContext {
+    if (!dispatchCtx) {
+      dispatchCtx = createJobDispatchContext({
+        workflow: opts.workflow,
+        tool,
+        jobTools,
+        ...(opts.jobTtlMs !== undefined ? { jobTtlMs: opts.jobTtlMs } : {}),
+        ...(opts.jobCheckpointTtlMs !== undefined
+          ? { jobCheckpointTtlMs: opts.jobCheckpointTtlMs }
+          : {}),
+        releaseInflight: () => {
+          inflight = false;
+        },
+      });
+    }
+    return dispatchCtx;
+  }
 
   const handle: McpServerHandle = {
     async listTools() {
-      return [tool];
+      return opts.async === true ? [tool, ...jobTools] : [tool];
+    },
+
+    dispose() {
+      dispatchCtx?.runner.close();
     },
 
     async callTool(name, args, callOpts) {
-      if (name !== tool.name) {
+      const isSync = name === tool.name;
+      const isStart = opts.async === true && name === startName;
+      const isObserver = opts.async === true && OBSERVER_TOOLS.has(name);
+
+      if (!isSync && !isStart && !isObserver) {
+        // Return ASYNC_MODE_DISABLED for job tools when async=false
+        if (name === startName || OBSERVER_TOOLS.has(name)) {
+          return formatErrorResult(
+            new McpServerError(
+              ErrorCode.ASYNC_MODE_DISABLED,
+              `async mode is disabled; tool "${name}" is unavailable`,
+              { name },
+            ),
+          );
+        }
         return formatErrorResult(
           new McpServerError(
             ErrorCode.WORKFLOW_FAILED,
@@ -98,6 +162,22 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
         );
       }
 
+      // Observer tools: no inflight lock.
+      if (isObserver) {
+        const ctx = ensureDispatchCtx();
+        switch (name) {
+          case "get_workflow_status":
+            return dispatchGetStatus(args, ctx);
+          case "get_workflow_result":
+            return dispatchGetResult(args, ctx);
+          case "cancel_workflow":
+            return dispatchCancel(args, ctx);
+          case "resume_workflow":
+            return dispatchResume(args, ctx);
+        }
+      }
+
+      // start_* and sync tool: share the inflight lock.
       if (inflight) {
         return formatErrorResult(
           new McpServerError(
@@ -108,6 +188,25 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
       }
       inflight = true;
 
+      if (isStart) {
+        const ctx = ensureDispatchCtx();
+        // Thread test executor into context if set on handle (wraps 4-arg to 1-arg)
+        if (handle._testRunExecutor !== undefined) {
+          const testExec = handle._testRunExecutor;
+          ctx.testRunExecutor = (input: unknown) =>
+            testExec(
+              input,
+              undefined,
+              new AbortController().signal,
+              {} as EffectiveCeilings,
+            );
+        }
+        // dispatchStart releases inflight via ctx.releaseInflight (onComplete/onError)
+        // or on validation failure.
+        return await dispatchStart(name, args, ctx);
+      }
+
+      // Sync path (existing body) — inflight cleared in finally.
       try {
         // Validate input
         const inputTaskDef = (opts.workflow.tasks as Record<string, unknown>)[

--- a/agentflow/packages/mcp-server/vitest.config.ts
+++ b/agentflow/packages/mcp-server/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    typecheck: {
+      enabled: true,
+      include: ["src/**/*.test-d.ts"],
+    },
     passWithNoTests: true,
   },
 });


### PR DESCRIPTION
Phase 4 of MCP job-based async mode. buildJobTools produces 5 tool definitions when async mode is active; start_<wf> dispatches via @ageflow/server runner.fire(); observer tools query RunHandle + JobEventRecorder.

- 86 mcp-server tests (+20 new, incl. 13 integration + 6 snapshot + 1 type-level)
- Shared inflight lock coordinates sync + async paths
- Schema-drift guard (*.test-d.ts) asserts start_<wf> input = sync tool input

21/21 typecheck + test + lint green.