### PR TITLE
feat(executor): #19 Phase 3 — resolveMcp + env expansion + preflight

### DIFF
--- a/agentflow/packages/executor/src/__tests__/mcp-env.test.ts
+++ b/agentflow/packages/executor/src/__tests__/mcp-env.test.ts
@@ -12,9 +12,7 @@ describe("expandEnvVars", () => {
     expect(() => expandEnvVars("${env:MISSING}", {})).toThrow(/MISSING/);
   });
   it("supports multiple substitutions in one string", () => {
-    expect(
-      expandEnvVars("${env:A}-${env:B}", { A: "x", B: "y" }),
-    ).toBe("x-y");
+    expect(expandEnvVars("${env:A}-${env:B}", { A: "x", B: "y" })).toBe("x-y");
   });
   it("rejects bash-style $NAME (no curly) as a security measure", () => {
     expect(() => expandEnvVars("$FOO", { FOO: "x" })).toThrow();

--- a/agentflow/packages/executor/src/__tests__/mcp-env.test.ts
+++ b/agentflow/packages/executor/src/__tests__/mcp-env.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { expandEnvVars } from "../mcp-env.js";
+
+describe("expandEnvVars", () => {
+  it("leaves literal values alone", () => {
+    expect(expandEnvVars("hello", {})).toBe("hello");
+  });
+  it("resolves ${env:NAME} from the provided env map", () => {
+    expect(expandEnvVars("${env:FOO}", { FOO: "bar" })).toBe("bar");
+  });
+  it("throws MissingEnvVarError when env var is unset", () => {
+    expect(() => expandEnvVars("${env:MISSING}", {})).toThrow(/MISSING/);
+  });
+  it("supports multiple substitutions in one string", () => {
+    expect(
+      expandEnvVars("${env:A}-${env:B}", { A: "x", B: "y" }),
+    ).toBe("x-y");
+  });
+  it("rejects bash-style $NAME (no curly) as a security measure", () => {
+    expect(() => expandEnvVars("$FOO", { FOO: "x" })).toThrow();
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/preflight.test.ts
+++ b/agentflow/packages/executor/src/__tests__/preflight.test.ts
@@ -422,3 +422,80 @@ describe("runPreflight — static arg validation", () => {
     expect(staticErrors.length).toBeGreaterThan(0);
   });
 });
+
+// ─── MCP preflight validation ────────────────────────────────────────────────
+
+describe("runPreflight — MCP config validation", () => {
+  it("flags duplicate MCP server names in agent.mcp.servers", async () => {
+    const wf = defineWorkflow({
+      name: "w",
+      tasks: {
+        a: {
+          agent: defineAgent({
+            runner: "claude",
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            prompt: () => "x",
+            mcp: {
+              servers: [
+                { name: "fs", command: "npx" },
+                { name: "fs", command: "other" },
+              ],
+            },
+          }),
+        },
+      },
+    });
+    const res = await runPreflight(wf, { whichFn: () => true });
+    expect(res.errors.some((e) => /duplicate/i.test(e))).toBe(true);
+  });
+
+  it("flags unknown task.mcpOverride name", async () => {
+    const wf = defineWorkflow({
+      name: "w",
+      tasks: {
+        a: {
+          agent: defineAgent({
+            runner: "claude",
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            prompt: () => "x",
+            mcp: { servers: [{ name: "fs", command: "npx" }] },
+          }),
+          mcpOverride: { servers: ["does-not-exist"] },
+        },
+      },
+    });
+    const res = await runPreflight(wf, { whichFn: () => true });
+    expect(res.errors.some((e) => /does-not-exist/i.test(e))).toBe(true);
+  });
+
+  it("warns when ${env:X} refers to a missing env var in mcp server config", async () => {
+    const wf = defineWorkflow({
+      name: "w",
+      tasks: {
+        a: {
+          agent: defineAgent({
+            runner: "claude",
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            prompt: () => "x",
+            mcp: {
+              servers: [
+                {
+                  name: "github",
+                  command: "npx",
+                  env: { GITHUB_TOKEN: "${env:GITHUB_TOKEN_DEFINITELY_UNSET_XYZ}" },
+                },
+              ],
+            },
+          }),
+        },
+      },
+    });
+    const res = await runPreflight(wf, { whichFn: () => true });
+    expect(
+      res.warnings.some((w) => /GITHUB_TOKEN_DEFINITELY_UNSET_XYZ/i.test(w)),
+    ).toBe(true);
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/preflight.test.ts
+++ b/agentflow/packages/executor/src/__tests__/preflight.test.ts
@@ -485,7 +485,9 @@ describe("runPreflight — MCP config validation", () => {
                 {
                   name: "github",
                   command: "npx",
-                  env: { GITHUB_TOKEN: "${env:GITHUB_TOKEN_DEFINITELY_UNSET_XYZ}" },
+                  env: {
+                    GITHUB_TOKEN: "${env:GITHUB_TOKEN_DEFINITELY_UNSET_XYZ}",
+                  },
                 },
               ],
             },

--- a/agentflow/packages/executor/src/__tests__/resolve-mcp.test.ts
+++ b/agentflow/packages/executor/src/__tests__/resolve-mcp.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveMcp } from "../resolve-mcp.js";
+
+const fsSrv = { name: "filesystem", command: "npx" } as const;
+const ghSrv = { name: "github", command: "npx" } as const;
+const slackSrv = { name: "slack", command: "npx" } as const;
+
+describe("resolveMcp", () => {
+  it("returns [] when nothing configured", () => {
+    expect(resolveMcp(undefined, undefined, undefined)).toEqual([]);
+  });
+
+  it("falls back to workflow servers when agent has no mcp", () => {
+    const got = resolveMcp([fsSrv], undefined, undefined);
+    expect(got.map((s) => s.name)).toEqual(["filesystem"]);
+  });
+
+  it("agent mcp REPLACES workflow by default", () => {
+    const got = resolveMcp(
+      [fsSrv],
+      { servers: [ghSrv] },
+      undefined,
+    );
+    expect(got.map((s) => s.name)).toEqual(["github"]);
+  });
+
+  it("agent mcp with extendWorkflow=true APPENDS + dedupes", () => {
+    const got = resolveMcp(
+      [fsSrv, ghSrv],
+      { servers: [{ ...ghSrv, tools: ["create_issue"] }, slackSrv], extendWorkflow: true },
+      undefined,
+    );
+    // agent wins on duplicate name
+    expect(got.map((s) => s.name)).toEqual(["filesystem", "github", "slack"]);
+    expect(got.find((s) => s.name === "github")?.tools).toEqual(["create_issue"]);
+  });
+
+  it("task mcpOverride filters to the named subset", () => {
+    const got = resolveMcp(
+      [fsSrv, ghSrv, slackSrv],
+      undefined,
+      { servers: ["slack"] },
+    );
+    expect(got.map((s) => s.name)).toEqual(["slack"]);
+  });
+
+  it("unknown name in mcpOverride throws (pre-flight catches this earlier)", () => {
+    expect(() =>
+      resolveMcp([fsSrv], undefined, { servers: ["does-not-exist"] }),
+    ).toThrow();
+  });
+});

--- a/agentflow/packages/executor/src/__tests__/resolve-mcp.test.ts
+++ b/agentflow/packages/executor/src/__tests__/resolve-mcp.test.ts
@@ -16,31 +16,30 @@ describe("resolveMcp", () => {
   });
 
   it("agent mcp REPLACES workflow by default", () => {
-    const got = resolveMcp(
-      [fsSrv],
-      { servers: [ghSrv] },
-      undefined,
-    );
+    const got = resolveMcp([fsSrv], { servers: [ghSrv] }, undefined);
     expect(got.map((s) => s.name)).toEqual(["github"]);
   });
 
   it("agent mcp with extendWorkflow=true APPENDS + dedupes", () => {
     const got = resolveMcp(
       [fsSrv, ghSrv],
-      { servers: [{ ...ghSrv, tools: ["create_issue"] }, slackSrv], extendWorkflow: true },
+      {
+        servers: [{ ...ghSrv, tools: ["create_issue"] }, slackSrv],
+        extendWorkflow: true,
+      },
       undefined,
     );
     // agent wins on duplicate name
     expect(got.map((s) => s.name)).toEqual(["filesystem", "github", "slack"]);
-    expect(got.find((s) => s.name === "github")?.tools).toEqual(["create_issue"]);
+    expect(got.find((s) => s.name === "github")?.tools).toEqual([
+      "create_issue",
+    ]);
   });
 
   it("task mcpOverride filters to the named subset", () => {
-    const got = resolveMcp(
-      [fsSrv, ghSrv, slackSrv],
-      undefined,
-      { servers: ["slack"] },
-    );
+    const got = resolveMcp([fsSrv, ghSrv, slackSrv], undefined, {
+      servers: ["slack"],
+    });
     expect(got.map((s) => s.name)).toEqual(["slack"]);
   });
 

--- a/agentflow/packages/executor/src/mcp-env.ts
+++ b/agentflow/packages/executor/src/mcp-env.ts
@@ -1,0 +1,94 @@
+import { AgentFlowError } from "@ageflow/core";
+import type { McpServerConfig } from "@ageflow/core";
+
+// ─── MissingEnvVarError ───────────────────────────────────────────────────────
+
+export class MissingEnvVarError extends AgentFlowError {
+  readonly code = "missing_env_var" as const;
+  constructor(
+    readonly varName: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Environment variable "${varName}" referenced via \${env:${varName}} is not set`,
+      options,
+    );
+  }
+}
+
+// ─── expandEnvVars ────────────────────────────────────────────────────────────
+
+/** Pattern matching the supported ${env:NAME} syntax only. */
+const ENV_TEMPLATE_RE = /\$\{env:([A-Z_][A-Z0-9_]*)\}/g;
+
+/**
+ * Bare `$NAME` (no curly braces) is rejected as a security measure — it is
+ * ambiguous with shell variable expansion and easy to mis-use.
+ */
+const BARE_VAR_RE = /\$[A-Za-z_][A-Za-z0-9_]*/;
+
+/**
+ * Expand `${env:NAME}` placeholders in a string value using the provided
+ * env map. Rejects bare `$NAME` syntax. Throws `MissingEnvVarError` when a
+ * referenced variable is not present in the map.
+ */
+export function expandEnvVars(
+  value: string,
+  env: Readonly<Record<string, string>>,
+): string {
+  // Reject bare $NAME (security measure — must use ${env:NAME} form).
+  if (BARE_VAR_RE.test(value)) {
+    throw new MissingEnvVarError(
+      value.match(BARE_VAR_RE)?.[0]?.slice(1) ?? "unknown",
+      {
+        cause: new Error(
+          "Bare $VAR syntax is not supported. Use ${env:NAME} instead.",
+        ),
+      },
+    );
+  }
+
+  return value.replace(ENV_TEMPLATE_RE, (_match, name: string) => {
+    if (!(name in env)) {
+      throw new MissingEnvVarError(name);
+    }
+    return env[name] as string;
+  });
+}
+
+// ─── expandServerEnv ──────────────────────────────────────────────────────────
+
+/**
+ * Expand all `${env:X}` references in a McpServerConfig's command, args and
+ * env values. Returns a new config with all placeholders resolved.
+ */
+export function expandServerEnv(
+  server: McpServerConfig,
+  env: Readonly<Record<string, string | undefined>>,
+): McpServerConfig {
+  // Filter out undefined values so we can pass a clean Record<string,string>
+  const cleanEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) cleanEnv[k] = v;
+  }
+
+  const expandedCommand = expandEnvVars(server.command, cleanEnv);
+
+  const expandedArgs = server.args?.map((arg) => expandEnvVars(arg, cleanEnv));
+
+  const expandedEnv: Record<string, string> | undefined = server.env
+    ? Object.fromEntries(
+        Object.entries(server.env).map(([k, v]) => [
+          k,
+          expandEnvVars(v, cleanEnv),
+        ]),
+      )
+    : undefined;
+
+  return {
+    ...server,
+    command: expandedCommand,
+    ...(expandedArgs !== undefined ? { args: expandedArgs } : {}),
+    ...(expandedEnv !== undefined ? { env: expandedEnv } : {}),
+  };
+}

--- a/agentflow/packages/executor/src/node-runner.ts
+++ b/agentflow/packages/executor/src/node-runner.ts
@@ -4,10 +4,18 @@ import {
   TimeoutError,
   resolveAgentDef,
 } from "@ageflow/core";
-import type { AgentDef, AttemptRecord, Runner, TaskDef } from "@ageflow/core";
+import type {
+  AgentDef,
+  AttemptRecord,
+  McpServerConfig,
+  Runner,
+  TaskDef,
+} from "@ageflow/core";
 import type { ZodType } from "zod";
 import { OutputValidationError } from "./errors.js";
+import { expandServerEnv } from "./mcp-env.js";
 import { parseAgentOutput } from "./output-parser.js";
+import { resolveMcp } from "./resolve-mcp.js";
 import { buildOutputSchemaPrompt } from "./schema-prompt.js";
 
 export interface NodeRunResult<O> {
@@ -99,6 +107,7 @@ export async function runNode<
   permissions?: Record<string, boolean>,
   filteredTools?: readonly string[],
   onRetry?: (attempt: number, reason: string) => void,
+  workflowMcpServers?: readonly McpServerConfig[],
 ): Promise<
   NodeRunResult<
     import("zod").infer<
@@ -137,6 +146,19 @@ export async function runNode<
         spawnArgs.tools = effectiveTools;
       }
 
+      // Resolve MCP servers: merge workflow + agent + task override, then expand env vars.
+      const resolved = resolveMcp(
+        workflowMcpServers,
+        resolvedDef.mcp,
+        task.mcpOverride,
+      );
+      if (resolved.length > 0) {
+        spawnArgs.mcpServers = resolved.map((s) =>
+          expandServerEnv(s, process.env as Record<string, string>),
+        );
+      }
+
+      // Deprecated alias retained for one release cycle.
       if (resolvedDef.mcps !== undefined && resolvedDef.mcps.length > 0) {
         spawnArgs.mcps = resolvedDef.mcps;
       }

--- a/agentflow/packages/executor/src/preflight.ts
+++ b/agentflow/packages/executor/src/preflight.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import type { TasksMap, WorkflowDef } from "@ageflow/core";
+import type { McpServerConfig, TasksMap, WorkflowDef } from "@ageflow/core";
 import { validateStaticIdentifier } from "@ageflow/core";
 import { topologicalSort } from "./dag-resolver.js";
 import {
@@ -8,6 +8,7 @@ import {
   UnresolvedDependencyError,
   UnresolvedSessionRefError,
 } from "./errors.js";
+import { resolveMcp } from "./resolve-mcp.js";
 import { SessionManager } from "./session-manager.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -239,6 +240,90 @@ function validateCrossProviderSessions(
   }
 }
 
+// ─── MCP config validation ────────────────────────────────────────────────────
+
+/** Pattern matching ${env:NAME} references in a string. */
+const ENV_REF_RE = /\$\{env:([A-Z_][A-Z0-9_]*)\}/g;
+
+/** Collect all ${env:NAME} references in a string. */
+function collectEnvRefs(value: string): string[] {
+  const refs: string[] = [];
+  for (const match of value.matchAll(ENV_REF_RE)) {
+    if (match[1] !== undefined) refs.push(match[1]);
+  }
+  return refs;
+}
+
+/** Collect all ${env:NAME} references in a McpServerConfig. */
+function collectServerEnvRefs(server: McpServerConfig): string[] {
+  const refs: string[] = [];
+  refs.push(...collectEnvRefs(server.command));
+  for (const arg of server.args ?? []) {
+    refs.push(...collectEnvRefs(arg));
+  }
+  for (const val of Object.values(server.env ?? {})) {
+    refs.push(...collectEnvRefs(val));
+  }
+  return refs;
+}
+
+function validateMcpConfigs(
+  workflow: WorkflowDef<TasksMap>,
+  errors: string[],
+  warnings: string[],
+): void {
+  const tasks = workflow.tasks;
+
+  for (const [taskName, task] of Object.entries(tasks)) {
+    if (task === undefined || "kind" in task) {
+      continue;
+    }
+
+    const agent = task.agent;
+    const agentMcp = agent.mcp;
+
+    // Validate for duplicate server names within agent.mcp.servers.
+    if (agentMcp !== undefined) {
+      const seen = new Set<string>();
+      for (const server of agentMcp.servers) {
+        if (seen.has(server.name)) {
+          errors.push(
+            `Task "${taskName}": duplicate MCP server name "${server.name}" in agent.mcp.servers`,
+          );
+        }
+        seen.add(server.name);
+      }
+    }
+
+    // Validate task.mcpOverride names against resolved server list.
+    const mcpOverride = task.mcpOverride;
+    if (mcpOverride !== undefined) {
+      try {
+        resolveMcp(workflow.mcpServers, agentMcp, mcpOverride);
+      } catch (err) {
+        errors.push(
+          `Task "${taskName}": mcpOverride references an unknown server — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    // Warn about ${env:X} references to unset env vars in MCP server configs.
+    const allServers = [
+      ...(workflow.mcpServers ?? []),
+      ...(agentMcp?.servers ?? []),
+    ];
+    for (const server of allServers) {
+      for (const varName of collectServerEnvRefs(server)) {
+        if (process.env[varName] === undefined) {
+          warnings.push(
+            `Task "${taskName}": MCP server "${server.name}" references env var \${env:${varName}} which is not set`,
+          );
+        }
+      }
+    }
+  }
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 export async function runPreflight(
@@ -267,6 +352,9 @@ export async function runPreflight(
 
   // 6. Warn about cross-provider session sharing
   validateCrossProviderSessions(tasks, warnings);
+
+  // 7. Validate MCP server configs (duplicates, unknown overrides, missing env vars)
+  validateMcpConfigs(workflow, errors, warnings);
 
   return { errors, warnings };
 }

--- a/agentflow/packages/executor/src/resolve-mcp.ts
+++ b/agentflow/packages/executor/src/resolve-mcp.ts
@@ -1,0 +1,64 @@
+import type {
+  AgentMcpConfig,
+  McpServerConfig,
+  TaskMcpOverride,
+} from "@ageflow/core";
+
+/**
+ * Resolve the final list of MCP servers for a single task execution.
+ *
+ * Resolution rules (from spec §5.4):
+ *
+ * 1. Start with workflow-level servers (fallback).
+ * 2. If `agentMcp` is present:
+ *    - `extendWorkflow: true` → merge workflow + agent, agent wins on name conflict.
+ *    - `extendWorkflow: false` (default) → agent list replaces workflow list entirely.
+ * 3. If `taskOverride` is present, keep only servers whose name is in the whitelist.
+ *    Unknown names throw — pre-flight should have caught these earlier.
+ *
+ * Deduplication: last-writer-wins by `name` when lists are merged.
+ */
+export function resolveMcp(
+  workflowServers: readonly McpServerConfig[] | undefined,
+  agentMcp: AgentMcpConfig | undefined,
+  taskOverride: TaskMcpOverride | undefined,
+): readonly McpServerConfig[] {
+  let resolved: readonly McpServerConfig[];
+
+  if (agentMcp === undefined) {
+    // No agent-level config — use workflow servers as-is (may be empty).
+    resolved = workflowServers ?? [];
+  } else if (agentMcp.extendWorkflow === true) {
+    // Merge: workflow first, then agent — agent wins on duplicate name.
+    const merged = new Map<string, McpServerConfig>();
+    for (const s of workflowServers ?? []) {
+      merged.set(s.name, s);
+    }
+    for (const s of agentMcp.servers) {
+      merged.set(s.name, s);
+    }
+    resolved = [...merged.values()];
+  } else {
+    // Replace: agent list fully replaces workflow list.
+    resolved = agentMcp.servers;
+  }
+
+  // Apply task-level override (whitelist by name).
+  if (taskOverride !== undefined) {
+    const filtered: McpServerConfig[] = [];
+
+    for (const name of taskOverride.servers) {
+      const found = resolved.find((s) => s.name === name);
+      if (found === undefined) {
+        throw new Error(
+          `Task mcpOverride references unknown server "${name}". Available servers: [${resolved.map((s) => s.name).join(", ")}]`,
+        );
+      }
+      filtered.push(found);
+    }
+
+    return filtered;
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
Phase 3: executor-level MCP resolution. resolveMcp(workflow, agent, task) merges all 3 sources. ${env:NAME} expansion for server args/env. Preflight catches duplicate server names, unknown overrides, missing env vars. mcpServers threaded into RunnerSpawnArgs. 162 executor tests (+14). 21/21 typecheck/test/lint green.