### PR TITLE
feat(runners): #19 Phase 4-5 — Claude + Codex MCP integration

### DIFF
--- a/agentflow/packages/runners/claude/src/__tests__/claude-runner.mcp.test.ts
+++ b/agentflow/packages/runners/claude/src/__tests__/claude-runner.mcp.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { ClaudeRunner } from "../claude-runner.js";
+import type { SpawnFn, SpawnResult } from "../claude-runner.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSpawnResult(
+  stdout: string,
+  exitCode = 0,
+  stderr = "",
+): SpawnResult {
+  const encoder = new TextEncoder();
+
+  const makeStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(encoder.encode(stdout)),
+    stderr: makeStream(encoder.encode(stderr)),
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+function makeJsonlOutput(resultContent: string): string {
+  const resultLine = JSON.stringify({
+    type: "result",
+    result: resultContent,
+    session_id: "sess-123",
+    usage: { input_tokens: 10, output_tokens: 20 },
+  });
+  return `${resultLine}\n`;
+}
+
+// ─── MCP flag tests ────────────────────────────────────────────────────────────
+
+describe("ClaudeRunner MCP flags", () => {
+  it("passes --mcp-config + --strict-mcp-config when mcpServers is set", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new ClaudeRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      mcpServers: [
+        {
+          name: "filesystem",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+          tools: ["read_file"],
+        },
+      ],
+    });
+    expect(capturedCmd).toContain("--mcp-config");
+    expect(capturedCmd).toContain("--strict-mcp-config");
+    // Allowlist projected to fully-qualified MCP tool name.
+    const allowIdx = capturedCmd.indexOf("--allowedTools");
+    expect(allowIdx).toBeGreaterThan(-1);
+    expect(capturedCmd[allowIdx + 1]).toContain("mcp__filesystem__read_file");
+  });
+
+  it("omits MCP flags when mcpServers is unset (no behaviour change)", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new ClaudeRunner({ spawn });
+    await runner.spawn({ prompt: "p" });
+    expect(capturedCmd).not.toContain("--mcp-config");
+    expect(capturedCmd).not.toContain("--strict-mcp-config");
+  });
+
+  it("omits --allowedTools for MCP servers without a tools allowlist", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new ClaudeRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      mcpServers: [{ name: "x", command: "y" }],
+    });
+    expect(capturedCmd).toContain("--mcp-config");
+    expect(capturedCmd).toContain("--strict-mcp-config");
+    expect(capturedCmd).not.toContain("--allowedTools");
+  });
+
+  it("merges MCP allowed tools with existing args.tools", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new ClaudeRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      tools: ["bash"],
+      mcpServers: [{ name: "fs", command: "npx", tools: ["read_file"] }],
+    });
+    const allowIdx = capturedCmd.indexOf("--allowedTools");
+    expect(allowIdx).toBeGreaterThan(-1);
+    const allowValue = capturedCmd[allowIdx + 1] ?? "";
+    expect(allowValue).toContain("bash");
+    expect(allowValue).toContain("mcp__fs__read_file");
+  });
+
+  it("passes mcp-config JSON with the correct server shape", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new ClaudeRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      mcpServers: [
+        {
+          name: "github",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+          env: { GITHUB_TOKEN: "tok" },
+        },
+      ],
+    });
+    const mcpIdx = capturedCmd.indexOf("--mcp-config");
+    expect(mcpIdx).toBeGreaterThan(-1);
+    const jsonStr = capturedCmd[mcpIdx + 1] ?? "";
+    const parsed = JSON.parse(jsonStr) as {
+      mcpServers: Record<
+        string,
+        { command: string; args?: string[]; env?: Record<string, string> }
+      >;
+    };
+    expect(parsed.mcpServers.github).toBeDefined();
+    expect(parsed.mcpServers.github?.command).toBe("npx");
+    expect(parsed.mcpServers.github?.env?.GITHUB_TOKEN).toBe("tok");
+  });
+});

--- a/agentflow/packages/runners/claude/src/__tests__/mcp-render.test.ts
+++ b/agentflow/packages/runners/claude/src/__tests__/mcp-render.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { renderMcpJson } from "../mcp-render.js";
+
+describe("renderMcpJson", () => {
+  it("returns an empty mcpServers object for []", () => {
+    expect(renderMcpJson([])).toEqual({ mcpServers: {} });
+  });
+
+  it("maps McpServerConfig to Claude CLI's expected shape", () => {
+    const json = renderMcpJson([
+      {
+        name: "filesystem",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        env: { NODE_OPTIONS: "--max-old-space-size=512" },
+      },
+    ]);
+    expect(json).toEqual({
+      mcpServers: {
+        filesystem: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+          env: { NODE_OPTIONS: "--max-old-space-size=512" },
+        },
+      },
+    });
+  });
+
+  it("omits env when empty", () => {
+    const json = renderMcpJson([{ name: "x", command: "y" }]);
+    expect(json.mcpServers.x).toEqual({ command: "y" });
+  });
+
+  it("does NOT leak tools allowlist into the JSON (that goes via CLI flags)", () => {
+    const json = renderMcpJson([{ name: "x", command: "y", tools: ["a"] }]);
+    expect(json.mcpServers.x).toEqual({ command: "y" });
+  });
+});

--- a/agentflow/packages/runners/claude/src/claude-runner.ts
+++ b/agentflow/packages/runners/claude/src/claude-runner.ts
@@ -1,5 +1,10 @@
-import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
+import {
+  AgentFlowError,
+  AgentHitlConflictError,
+  mcpToolFqn,
+} from "@ageflow/core";
 import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
+import { renderMcpJson } from "./mcp-render.js";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
@@ -155,6 +160,30 @@ export class ClaudeRunner implements Runner {
         .map(([tool]) => tool);
       if (deniedTools.length > 0) {
         cliArgs.push("--disallowedTools", deniedTools.join(","));
+      }
+    }
+
+    // Emit MCP flags when mcpServers are provided
+    if (args.mcpServers !== undefined && args.mcpServers.length > 0) {
+      const mcpConfigJson = JSON.stringify(renderMcpJson(args.mcpServers));
+      cliArgs.push("--mcp-config", mcpConfigJson, "--strict-mcp-config");
+
+      // Collect allowed MCP tool FQNs from servers that have an explicit allowlist
+      const mcpAllowed: string[] = [];
+      for (const s of args.mcpServers) {
+        if (s.tools === undefined) continue;
+        for (const t of s.tools) mcpAllowed.push(mcpToolFqn(s.name, t));
+      }
+
+      if (mcpAllowed.length > 0) {
+        // Merge with existing --allowedTools if the caller already passed args.tools
+        const existingIdx = cliArgs.indexOf("--allowedTools");
+        if (existingIdx !== -1) {
+          cliArgs[existingIdx + 1] =
+            `${cliArgs[existingIdx + 1]},${mcpAllowed.join(",")}`;
+        } else {
+          cliArgs.push("--allowedTools", mcpAllowed.join(","));
+        }
       }
     }
 

--- a/agentflow/packages/runners/claude/src/mcp-render.ts
+++ b/agentflow/packages/runners/claude/src/mcp-render.ts
@@ -1,0 +1,45 @@
+import type { McpServerConfig } from "@ageflow/core";
+
+// ─── Claude CLI MCP config shape ──────────────────────────────────────────────
+
+interface ClaudeMcpServerEntry {
+  command: string;
+  args?: readonly string[];
+  env?: Readonly<Record<string, string>>;
+}
+
+interface ClaudeMcpConfig {
+  mcpServers: Record<string, ClaudeMcpServerEntry>;
+}
+
+/**
+ * Render an array of McpServerConfig into the JSON shape expected by
+ * Claude CLI's `--mcp-config` flag.
+ *
+ * Notes:
+ * - `tools` allowlist is NOT included here — it is passed as `--allowedTools`
+ *   CLI flags in the spawner, using the `mcp__<server>__<tool>` FQN format.
+ * - `env` is omitted entirely when the server config has no env entries.
+ * - `args` is omitted when empty/undefined.
+ */
+export function renderMcpJson(
+  servers: readonly McpServerConfig[],
+): ClaudeMcpConfig {
+  const mcpServers: Record<string, ClaudeMcpServerEntry> = {};
+
+  for (const srv of servers) {
+    const entry: ClaudeMcpServerEntry = { command: srv.command };
+
+    if (srv.args !== undefined && srv.args.length > 0) {
+      entry.args = srv.args;
+    }
+
+    if (srv.env !== undefined && Object.keys(srv.env).length > 0) {
+      entry.env = srv.env;
+    }
+
+    mcpServers[srv.name] = entry;
+  }
+
+  return { mcpServers };
+}

--- a/agentflow/packages/runners/codex/src/__tests__/codex-runner.mcp.test.ts
+++ b/agentflow/packages/runners/codex/src/__tests__/codex-runner.mcp.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { CodexRunner } from "../codex-runner.js";
+import type { SpawnFn, SpawnResult } from "../codex-runner.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSpawnResult(
+  stdout: string,
+  exitCode = 0,
+  stderr = "",
+): SpawnResult {
+  const encoder = new TextEncoder();
+
+  const makeStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+
+  return {
+    stdout: makeStream(encoder.encode(stdout)),
+    stderr: makeStream(encoder.encode(stderr)),
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+function makeJsonlOutput(text: string): string {
+  return [
+    JSON.stringify({ type: "thread.started", thread_id: "t-1" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", text },
+    }),
+    JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 5, output_tokens: 5 },
+    }),
+  ].join("\n");
+}
+
+// ─── MCP flag tests ────────────────────────────────────────────────────────────
+
+describe("CodexRunner MCP flags", () => {
+  it("emits -c mcp_servers.* flags when mcpServers is set", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new CodexRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      mcpServers: [
+        {
+          name: "filesystem",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+          tools: ["read_file"],
+        },
+      ],
+    });
+    expect(capturedCmd).toContain("-c");
+    expect(capturedCmd).toContain("mcp_servers.filesystem.command=npx");
+    expect(capturedCmd).toContain(
+      'mcp_servers.filesystem.args=["-y","@modelcontextprotocol/server-filesystem","/tmp"]',
+    );
+    expect(capturedCmd).toContain('mcp_servers.filesystem.tools=["read_file"]');
+  });
+
+  it("omits MCP flags when mcpServers is unset (no behaviour change)", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new CodexRunner({ spawn });
+    await runner.spawn({ prompt: "p" });
+    const hasMcp = capturedCmd.some((a) => a.startsWith("mcp_servers."));
+    expect(hasMcp).toBe(false);
+  });
+
+  it("places MCP flags before the prompt positional", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new CodexRunner({ spawn });
+    await runner.spawn({
+      prompt: "my-prompt",
+      mcpServers: [{ name: "x", command: "y" }],
+    });
+    const mcpIdx = capturedCmd.findIndex((a) => a.startsWith("mcp_servers."));
+    const promptIdx = capturedCmd.indexOf("my-prompt");
+    expect(mcpIdx).toBeGreaterThan(-1);
+    expect(promptIdx).toBeGreaterThan(-1);
+    expect(mcpIdx).toBeLessThan(promptIdx);
+  });
+
+  it("emits env as TOML inline table", async () => {
+    let capturedCmd: string[] = [];
+    const spawn: SpawnFn = (cmd) => {
+      capturedCmd = cmd;
+      return makeSpawnResult(makeJsonlOutput("ok"));
+    };
+    const runner = new CodexRunner({ spawn });
+    await runner.spawn({
+      prompt: "p",
+      mcpServers: [
+        { name: "gh", command: "npx", env: { GITHUB_TOKEN: "tok" } },
+      ],
+    });
+    expect(capturedCmd).toContain('mcp_servers.gh.env={GITHUB_TOKEN="tok"}');
+  });
+});

--- a/agentflow/packages/runners/codex/src/__tests__/mcp-render.test.ts
+++ b/agentflow/packages/runners/codex/src/__tests__/mcp-render.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { renderCodexMcpFlags } from "../mcp-render.js";
+
+describe("renderCodexMcpFlags", () => {
+  it("returns [] for empty input", () => {
+    expect(renderCodexMcpFlags([])).toEqual([]);
+  });
+
+  it("emits one -c pair per field", () => {
+    const flags = renderCodexMcpFlags([
+      {
+        name: "filesystem",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        env: { FOO: "bar" },
+        tools: ["read_file"],
+      },
+    ]);
+    expect(flags).toContain("-c");
+    expect(flags).toContain("mcp_servers.filesystem.command=npx");
+    expect(flags).toContain(
+      'mcp_servers.filesystem.args=["-y","@modelcontextprotocol/server-filesystem","/tmp"]',
+    );
+    expect(flags).toContain('mcp_servers.filesystem.env={FOO="bar"}');
+    expect(flags).toContain('mcp_servers.filesystem.tools=["read_file"]');
+  });
+
+  it("escapes quotes/backslashes inside args (TOML-safe)", () => {
+    const flags = renderCodexMcpFlags([
+      { name: "x", command: "y", args: ['she said "hi"'] },
+    ]);
+    expect(flags.join(" ")).toMatch(/she said \\"hi\\"/);
+  });
+
+  it("omits args/env/tools entries when not set", () => {
+    const flags = renderCodexMcpFlags([{ name: "x", command: "y" }]);
+    expect(flags).toContain("mcp_servers.x.command=y");
+    const hasArgs = flags.some((f) => f.includes("mcp_servers.x.args"));
+    const hasEnv = flags.some((f) => f.includes("mcp_servers.x.env"));
+    const hasTools = flags.some((f) => f.includes("mcp_servers.x.tools"));
+    expect(hasArgs).toBe(false);
+    expect(hasEnv).toBe(false);
+    expect(hasTools).toBe(false);
+  });
+});

--- a/agentflow/packages/runners/codex/src/codex-runner.ts
+++ b/agentflow/packages/runners/codex/src/codex-runner.ts
@@ -1,5 +1,6 @@
 import { AgentFlowError, AgentHitlConflictError } from "@ageflow/core";
 import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
+import { renderCodexMcpFlags } from "./mcp-render.js";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
@@ -169,6 +170,12 @@ export class CodexRunner implements Runner {
       finalPrompt = `${args.systemPrompt}\n\n---\n\n${args.prompt}`;
     }
 
+    // Emit MCP flags when mcpServers are provided (placed after subArgs, before prompt)
+    const mcpFlags =
+      args.mcpServers !== undefined && args.mcpServers.length > 0
+        ? renderCodexMcpFlags(args.mcpServers)
+        : [];
+
     // Session resumption uses a positional subcommand, not a flag
     let cmd: string[];
     if (args.sessionHandle !== undefined && args.sessionHandle !== "") {
@@ -176,12 +183,13 @@ export class CodexRunner implements Runner {
         "codex",
         "exec",
         ...subArgs,
+        ...mcpFlags,
         "resume",
         args.sessionHandle,
         finalPrompt,
       ];
     } else {
-      cmd = ["codex", "exec", ...subArgs, finalPrompt];
+      cmd = ["codex", "exec", ...subArgs, ...mcpFlags, finalPrompt];
     }
 
     const proc = this._spawn(cmd);

--- a/agentflow/packages/runners/codex/src/mcp-render.ts
+++ b/agentflow/packages/runners/codex/src/mcp-render.ts
@@ -1,0 +1,69 @@
+import type { McpServerConfig } from "@ageflow/core";
+
+/**
+ * Escape a string value for use inside a TOML inline string (double-quoted).
+ * Escapes backslashes first, then double-quotes.
+ */
+function tomlEscape(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Render a string array as a TOML/JSON-compatible array literal.
+ * Each element is a double-quoted TOML string with proper escaping.
+ * Example: ["a", "b"] → '["a","b"]'
+ */
+function renderStringArray(values: readonly string[]): string {
+  return `[${values.map((v) => `"${tomlEscape(v)}"`).join(",")}]`;
+}
+
+/**
+ * Render an env map as a TOML inline table.
+ * Example: { FOO: "bar" } → '{FOO="bar"}'
+ */
+function renderEnvTable(env: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(env)
+    .map(([k, v]) => `${k}="${tomlEscape(v)}"`)
+    .join(",");
+  return `{${entries}}`;
+}
+
+/**
+ * Render an array of McpServerConfig into Codex CLI `-c` override flags.
+ *
+ * Each server produces one or more `-c mcp_servers.<name>.<field>=<value>` pairs.
+ * The `tools` allowlist IS included here (unlike the Claude runner) because
+ * Codex `-c` overrides are the only mechanism for tool filtering.
+ *
+ * Output interleaves `-c` with the key=value string so the caller can spread
+ * directly into the `codex exec` args array.
+ */
+export function renderCodexMcpFlags(
+  servers: readonly McpServerConfig[],
+): string[] {
+  const flags: string[] = [];
+
+  for (const srv of servers) {
+    const prefix = `mcp_servers.${srv.name}`;
+
+    // command — always present
+    flags.push("-c", `${prefix}.command=${srv.command}`);
+
+    // args — only when non-empty
+    if (srv.args !== undefined && srv.args.length > 0) {
+      flags.push("-c", `${prefix}.args=${renderStringArray(srv.args)}`);
+    }
+
+    // env — only when non-empty
+    if (srv.env !== undefined && Object.keys(srv.env).length > 0) {
+      flags.push("-c", `${prefix}.env=${renderEnvTable(srv.env)}`);
+    }
+
+    // tools allowlist — only when set
+    if (srv.tools !== undefined && srv.tools.length > 0) {
+      flags.push("-c", `${prefix}.tools=${renderStringArray(srv.tools)}`);
+    }
+  }
+
+  return flags;
+}


### PR DESCRIPTION
Phase 4: Claude runner passes mcpServers via inline --mcp-config JSON + --strict-mcp-config; allowlist via mcp__<server>__<tool>.
Phase 5: Codex runner uses -c mcp_servers.<name>.command=... overrides.

claude-runner 32 tests (+9), codex-runner 28 tests (+8). 21/21 green.

Plan deviation: inline JSON instead of temp file (Claude CLI supports both).