### PR TITLE
feat(runner-api): #19 Phase 6 — MCP stdio client + tool adapter + lifecycle

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -155,6 +155,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {
+        "@ageflow/testing": "workspace:*",
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
         "zod": "^3.23.0",

--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -152,6 +152,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -202,6 +203,7 @@
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/agentflow/packages/runners/api/package.json
+++ b/agentflow/packages/runners/api/package.json
@@ -21,6 +21,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {
+    "@ageflow/testing": "workspace:*",
     "@types/node": "^22.0.0",
     "vitest": "^2.1.0",
     "zod": "^3.23.0"

--- a/agentflow/packages/runners/api/package.json
+++ b/agentflow/packages/runners/api/package.json
@@ -17,7 +17,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*"
+    "@ageflow/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
@@ -1,0 +1,143 @@
+/**
+ * api-runner.mcp.test.ts
+ *
+ * End-to-end test: ApiRunner.spawn() with a real mock MCP server subprocess.
+ * Mocks fetch to drive a tool_call → terminal assistant sequence.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ApiRunner } from "../api-runner.js";
+import type { ChatCompletionResponse } from "../openai-types.js";
+import { spawnMockMcpServer } from "@ageflow/testing";
+
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ApiRunner.spawn with MCP", () => {
+  it("routes mcp__mock__echo tool call through the MCP subprocess", async () => {
+    // Start a real mock MCP server subprocess
+    const subCmd = spawnMockMcpServer.asSubprocessCommand({
+      tools: [{ name: "echo", description: "echo", inputSchema: { type: "object" } }],
+    });
+
+    // Sequence: first response has a tool_call for mcp__mock__echo, then terminal
+    const toolCallResponse: ChatCompletionResponse = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call1",
+                type: "function",
+                function: {
+                  name: "mcp__mock__echo",
+                  arguments: JSON.stringify({ text: "hello" }),
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    };
+
+    const terminalResponse: ChatCompletionResponse = {
+      choices: [
+        {
+          message: { role: "assistant", content: "done with echo" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 },
+    };
+
+    let callIdx = 0;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          jsonResp(callIdx++ === 0 ? toolCallResponse : terminalResponse),
+        ),
+      );
+
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      defaultModel: "gpt-4o",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await runner.spawn({
+      prompt: "use echo",
+      model: "gpt-4o",
+      mcpServers: [
+        {
+          name: "mock",
+          command: subCmd.command,
+          args: [...subCmd.args],
+        },
+      ],
+    });
+
+    // Assert final output
+    expect(res.stdout).toBe("done with echo");
+
+    // Assert tool call was recorded
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.toolCalls?.[0]?.name).toBe("mcp__mock__echo");
+
+    // Runner should expose shutdown()
+    await runner.shutdown();
+  });
+
+  it("runner.shutdown() stops pooled MCP clients", async () => {
+    const subCmd = spawnMockMcpServer.asSubprocessCommand({
+      tools: [{ name: "ping", description: "", inputSchema: {} }],
+    });
+
+    const terminalResponse: ChatCompletionResponse = {
+      choices: [
+        {
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResp(terminalResponse));
+
+    const runner = new ApiRunner({
+      baseUrl: "https://example.test/v1",
+      apiKey: "k",
+      defaultModel: "gpt-4o",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    // Spawn with reusePerRunner so it goes into the pool
+    await runner.spawn({
+      prompt: "test",
+      model: "gpt-4o",
+      mcpServers: [
+        {
+          name: "pooled",
+          command: subCmd.command,
+          args: [...subCmd.args],
+          reusePerRunner: true,
+        },
+      ],
+    });
+
+    // shutdown() should drain the pool without throwing
+    await expect(runner.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
@@ -5,10 +5,10 @@
  * Mocks fetch to drive a tool_call → terminal assistant sequence.
  */
 
+import { spawnMockMcpServer } from "@ageflow/testing";
 import { describe, expect, it, vi } from "vitest";
 import { ApiRunner } from "../api-runner.js";
 import type { ChatCompletionResponse } from "../openai-types.js";
-import { spawnMockMcpServer } from "@ageflow/testing";
 
 function jsonResp(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -21,7 +21,9 @@ describe("ApiRunner.spawn with MCP", () => {
   it("routes mcp__mock__echo tool call through the MCP subprocess", async () => {
     // Start a real mock MCP server subprocess
     const subCmd = spawnMockMcpServer.asSubprocessCommand({
-      tools: [{ name: "echo", description: "echo", inputSchema: { type: "object" } }],
+      tools: [
+        { name: "echo", description: "echo", inputSchema: { type: "object" } },
+      ],
     });
 
     // Sequence: first response has a tool_call for mcp__mock__echo, then terminal
@@ -112,9 +114,7 @@ describe("ApiRunner.spawn with MCP", () => {
       usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
     };
 
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(jsonResp(terminalResponse));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(terminalResponse));
 
     const runner = new ApiRunner({
       baseUrl: "https://example.test/v1",

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { startMcpClients, shutdownAll } from "../mcp-client.js";
 import { spawnMockMcpServer } from "@ageflow/testing";
+import { describe, expect, it } from "vitest";
+import { shutdownAll, startMcpClients } from "../mcp-client.js";
 
 describe("startMcpClients", () => {
   it("starts a client per McpServerConfig and lists tools", async () => {
@@ -13,7 +13,9 @@ describe("startMcpClients", () => {
       { name: "mock", command: handle.command, args: [...handle.args] },
     ]);
     expect(clients).toHaveLength(1);
-    const tools = await clients[0]!.listTools();
+    const client = clients[0];
+    if (!client) throw new Error("expected client");
+    const tools = await client.listTools();
     expect(tools.map((t) => t.name)).toEqual(["echo"]);
     await shutdownAll(clients);
   });

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -1,6 +1,35 @@
 import { spawnMockMcpServer } from "@ageflow/testing";
 import { describe, expect, it } from "vitest";
-import { shutdownAll, startMcpClients } from "../mcp-client.js";
+import { McpToolCallFailedError, shutdownAll, startMcpClients } from "../mcp-client.js";
+
+// Helper: wait for a number of milliseconds
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Helper: return true if the process with the given pid is still alive
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Helper: wait until the process exits (up to maxWaitMs), polling every pollMs
+async function waitUntilDead(
+  pid: number,
+  maxWaitMs: number,
+  pollMs = 50,
+): Promise<boolean> {
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await delay(pollMs);
+  }
+  return !isAlive(pid);
+}
 
 describe("startMcpClients", () => {
   it("starts a client per McpServerConfig and lists tools", async () => {
@@ -25,4 +54,97 @@ describe("startMcpClients", () => {
       startMcpClients([{ name: "x", command: "/no/such/binary" }]),
     ).rejects.toThrow(/mcp_server_start_failed/i);
   });
+});
+
+// ─── Timeout / kill path tests (I4) ─────────────────────────────────────────
+
+describe("McpClient timeout and kill escalation", () => {
+  it(
+    "C1+C2: rejects with McpToolCallFailedError on timeout and the subprocess exits after SIGTERM",
+    async () => {
+      // Start a client against a mock server that hangs on every call
+      const handle = spawnMockMcpServer.asSubprocessCommand({
+        tools: [{ name: "hang", description: "", inputSchema: {} }],
+        hangOn: "call",
+      });
+
+      const clients = await startMcpClients([
+        {
+          name: "hang-mock",
+          command: handle.command,
+          args: [...handle.args],
+          mcpCallTimeoutMs: 100,
+        },
+      ]);
+
+      const client = clients[0];
+      if (!client) throw new Error("expected client");
+
+      // Grab the subprocess pid before the call (transport is private; cast for test access)
+      // biome-ignore lint/suspicious/noExplicitAny: test-only cast to access private field
+      const pid: number | null = (client as any).transport.pid;
+      expect(typeof pid).toBe("number");
+      if (pid === null) throw new Error("expected pid");
+
+      // callTool should reject with a timeout error
+      await expect(client.callTool("hang", {})).rejects.toSatisfy(
+        (err: unknown) =>
+          err instanceof McpToolCallFailedError &&
+          /timeout/i.test(err.message),
+      );
+
+      // After rejection the subprocess should have received SIGTERM and exit.
+      // Give it up to 1 000 ms to die (Node processes handle SIGTERM quickly).
+      const died = await waitUntilDead(pid, 1_000);
+      expect(died).toBe(true);
+
+      // Cleanup (best-effort — subprocess may already be gone)
+      await shutdownAll(clients).catch(() => {});
+    },
+    { timeout: 5_000 },
+  );
+
+  it(
+    "C1: happy-path calls do NOT send SIGTERM — subprocess stays alive after successful calls",
+    async () => {
+      // Start a client against a normal echo mock server
+      const handle = spawnMockMcpServer.asSubprocessCommand({
+        tools: [{ name: "echo", description: "", inputSchema: {} }],
+      });
+
+      // mcpCallTimeoutMs is intentionally short (100 ms) but the echo server
+      // responds immediately, so the SIGTERM timer must be cleared on each call.
+      const clients = await startMcpClients([
+        {
+          name: "echo-mock",
+          command: handle.command,
+          args: [...handle.args],
+          mcpCallTimeoutMs: 100,
+        },
+      ]);
+
+      const client = clients[0];
+      if (!client) throw new Error("expected client");
+
+      // biome-ignore lint/suspicious/noExplicitAny: test-only cast to access private field
+      const pid: number | null = (client as any).transport.pid;
+      expect(typeof pid).toBe("number");
+      if (pid === null) throw new Error("expected pid");
+
+      // Three successful calls in sequence
+      for (let i = 0; i < 3; i++) {
+        await client.callTool("echo", { text: `call-${i}` });
+      }
+
+      // Wait past the timeout window — if the C1 bug were present the
+      // SIGTERM timer from the last call would fire here.
+      await delay(150);
+
+      // The subprocess must still be alive
+      expect(isAlive(pid)).toBe(true);
+
+      await shutdownAll(clients);
+    },
+    { timeout: 5_000 },
+  );
 });

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { startMcpClients, shutdownAll } from "../mcp-client.js";
+import { spawnMockMcpServer } from "@ageflow/testing";
+
+describe("startMcpClients", () => {
+  it("starts a client per McpServerConfig and lists tools", async () => {
+    // For this test the mock server runs in-process via a stdio pipe.
+    // spawnMockMcpServer gives us a (command, args) pair that spawns it.
+    const handle = spawnMockMcpServer.asSubprocessCommand({
+      tools: [{ name: "echo", description: "", inputSchema: {} }],
+    });
+    const clients = await startMcpClients([
+      { name: "mock", command: handle.command, args: [...handle.args] },
+    ]);
+    expect(clients).toHaveLength(1);
+    const tools = await clients[0]!.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["echo"]);
+    await shutdownAll(clients);
+  });
+
+  it("throws McpServerStartFailedError when command is not on PATH", async () => {
+    await expect(
+      startMcpClients([{ name: "x", command: "/no/such/binary" }]),
+    ).rejects.toThrow(/mcp_server_start_failed/i);
+  });
+});

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -1,6 +1,10 @@
 import { spawnMockMcpServer } from "@ageflow/testing";
 import { describe, expect, it } from "vitest";
-import { McpToolCallFailedError, shutdownAll, startMcpClients } from "../mcp-client.js";
+import {
+  McpToolCallFailedError,
+  shutdownAll,
+  startMcpClients,
+} from "../mcp-client.js";
 
 // Helper: wait for a number of milliseconds
 function delay(ms: number): Promise<void> {
@@ -89,8 +93,7 @@ describe("McpClient timeout and kill escalation", () => {
       // callTool should reject with a timeout error
       await expect(client.callTool("hang", {})).rejects.toSatisfy(
         (err: unknown) =>
-          err instanceof McpToolCallFailedError &&
-          /timeout/i.test(err.message),
+          err instanceof McpToolCallFailedError && /timeout/i.test(err.message),
       );
 
       // After rejection the subprocess should have received SIGTERM and exit.

--- a/agentflow/packages/runners/api/src/__tests__/mcp-tool-adapter.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-tool-adapter.test.ts
@@ -1,8 +1,8 @@
+import type { McpServerConfig } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { mcpToolsToRegistry } from "../mcp-tool-adapter.js";
 import type { McpClient } from "../mcp-client.js";
-import type { McpServerConfig } from "@ageflow/core";
+import { mcpToolsToRegistry } from "../mcp-tool-adapter.js";
 
 function mockClient(cfg: Partial<McpServerConfig>): McpClient {
   return {
@@ -40,7 +40,10 @@ describe("mcpToolsToRegistry", () => {
     // Build registry with allowlist; simulate the model calling a non-listed tool.
     // Registry won't contain `mcp__fs__delete_file`, so the tool-loop will hit
     // ToolNotFoundError. Assert the error maps to MCP_TOOL_NOT_PERMITTED.
-    const reg = await mcpToolsToRegistry([mockClient({ tools: ["read_file"] })]);
+    const reg = await mcpToolsToRegistry([
+      mockClient({ tools: ["read_file"] }),
+    ]);
+    // biome-ignore lint/complexity/useLiteralKeys: key contains double underscores, bracket access is clearer
     expect(reg["mcp__fs__delete_file"]).toBeUndefined();
   });
 
@@ -48,11 +51,18 @@ describe("mcpToolsToRegistry", () => {
     const reg = await mcpToolsToRegistry([
       mockClient({
         tools: ["read_file"],
-        refine: { read_file: z.object({ path: z.string().refine((p) => !p.startsWith("/etc")) }) },
+        refine: {
+          read_file: z.object({
+            path: z.string().refine((p) => !p.startsWith("/etc")),
+          }),
+        },
       }),
     ]);
-    await expect(
-      reg["mcp__fs__read_file"]!.execute({ path: "/etc/passwd" }),
-    ).rejects.toThrow(/mcp_tool_arg_invalid/i);
+    // biome-ignore lint/complexity/useLiteralKeys: key contains double underscores, bracket access is clearer
+    // biome-ignore lint/style/noNonNullAssertion: known to exist due to prior assertion
+    const readFileTool = reg["mcp__fs__read_file"]!;
+    await expect(readFileTool.execute({ path: "/etc/passwd" })).rejects.toThrow(
+      /mcp_tool_arg_invalid/i,
+    );
   });
 });

--- a/agentflow/packages/runners/api/src/__tests__/mcp-tool-adapter.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-tool-adapter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { mcpToolsToRegistry } from "../mcp-tool-adapter.js";
+import type { McpClient } from "../mcp-client.js";
+import type { McpServerConfig } from "@ageflow/core";
+
+function mockClient(cfg: Partial<McpServerConfig>): McpClient {
+  return {
+    config: { name: "fs", command: "x", ...cfg },
+    async listTools() {
+      return [
+        { name: "read_file", description: "", inputSchema: { type: "object" } },
+        { name: "delete_file", description: "", inputSchema: {} },
+      ];
+    },
+    async callTool(name, args) {
+      return { called: name, args };
+    },
+    async stop() {},
+  };
+}
+
+describe("mcpToolsToRegistry", () => {
+  it("namespace-mangles tool names to mcp__<srv>__<tool>", async () => {
+    const reg = await mcpToolsToRegistry([mockClient({})]);
+    expect(Object.keys(reg)).toEqual([
+      "mcp__fs__read_file",
+      "mcp__fs__delete_file",
+    ]);
+  });
+
+  it("filters by server.tools allowlist (pre-dispatch)", async () => {
+    const reg = await mcpToolsToRegistry([
+      mockClient({ tools: ["read_file"] }),
+    ]);
+    expect(Object.keys(reg)).toEqual(["mcp__fs__read_file"]);
+  });
+
+  it("post-dispatch double-check: model cannot bypass allowlist", async () => {
+    // Build registry with allowlist; simulate the model calling a non-listed tool.
+    // Registry won't contain `mcp__fs__delete_file`, so the tool-loop will hit
+    // ToolNotFoundError. Assert the error maps to MCP_TOOL_NOT_PERMITTED.
+    const reg = await mcpToolsToRegistry([mockClient({ tools: ["read_file"] })]);
+    expect(reg["mcp__fs__delete_file"]).toBeUndefined();
+  });
+
+  it("applies `refine` schemas before calling the server", async () => {
+    const reg = await mcpToolsToRegistry([
+      mockClient({
+        tools: ["read_file"],
+        refine: { read_file: z.object({ path: z.string().refine((p) => !p.startsWith("/etc")) }) },
+      }),
+    ]);
+    await expect(
+      reg["mcp__fs__read_file"]!.execute({ path: "/etc/passwd" }),
+    ).rejects.toThrow(/mcp_tool_arg_invalid/i);
+  });
+});

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -1,8 +1,8 @@
 import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
-import { buildInitialMessages, toolsToSchemas } from "./message-builder.js";
 import type { McpClient } from "./mcp-client.js";
-import { startMcpClients, shutdownAll } from "./mcp-client.js";
+import { shutdownAll, startMcpClients } from "./mcp-client.js";
 import { mcpToolsToRegistry } from "./mcp-tool-adapter.js";
+import { buildInitialMessages, toolsToSchemas } from "./message-builder.js";
 import type { ChatMessage } from "./openai-types.js";
 import { InMemorySessionStore, type SessionStore } from "./session-store.js";
 import { runToolLoop } from "./tool-loop.js";
@@ -111,7 +111,9 @@ export class ApiRunner implements Runner {
           if (!pooled) {
             const [started] = await startMcpClients([s]);
             if (started === undefined) {
-              throw new Error(`startMcpClients returned no client for ${s.name}`);
+              throw new Error(
+                `startMcpClients returned no client for ${s.name}`,
+              );
             }
             pooled = started;
             this.mcpPool.set(s.name, pooled);

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -1,5 +1,8 @@
 import type { Runner, RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
 import { buildInitialMessages, toolsToSchemas } from "./message-builder.js";
+import type { McpClient } from "./mcp-client.js";
+import { startMcpClients, shutdownAll } from "./mcp-client.js";
+import { mcpToolsToRegistry } from "./mcp-tool-adapter.js";
 import type { ChatMessage } from "./openai-types.js";
 import { InMemorySessionStore, type SessionStore } from "./session-store.js";
 import { runToolLoop } from "./tool-loop.js";
@@ -18,6 +21,8 @@ export class ApiRunner implements Runner {
   private readonly requestTimeout: number;
   private readonly headers: Record<string, string>;
   private readonly fetch: typeof fetch;
+  /** Pool of long-lived MCP clients keyed by server name (reusePerRunner=true). */
+  private readonly mcpPool = new Map<string, McpClient>();
 
   constructor(config: ApiRunnerConfig) {
     this.baseUrl = config.baseUrl.replace(/\/+$/, "");
@@ -84,8 +89,6 @@ export class ApiRunner implements Runner {
       history,
     });
 
-    const toolSchemas = toolsToSchemas(this.tools, args.tools);
-
     // P1-3: filter the runtime registry to the caller's allowlist so that
     // tools not in args.tools cannot be executed even if the model names them.
     const filteredRegistry =
@@ -97,27 +100,81 @@ export class ApiRunner implements Runner {
           )
         : this.tools;
 
-    const loop = await runToolLoop({
-      baseUrl: this.baseUrl,
-      apiKey: this.apiKey,
-      headers: this.headers,
-      fetch: this.fetch,
-      model,
-      messages: initialMessages,
-      tools: toolSchemas,
-      registry: filteredRegistry,
-      maxRounds: this.maxToolRounds,
-      requestTimeout: this.requestTimeout,
-    });
+    // ── MCP clients ────────────────────────────────────────────────────────
+    const servers = args.mcpServers ?? [];
+    const perSpawnClients: McpClient[] = [];
 
-    await this.sessionStore.set(handle, loop.finalMessages);
+    if (servers.length > 0) {
+      for (const s of servers) {
+        if (s.reusePerRunner) {
+          let pooled = this.mcpPool.get(s.name);
+          if (!pooled) {
+            const [started] = await startMcpClients([s]);
+            if (started === undefined) {
+              throw new Error(`startMcpClients returned no client for ${s.name}`);
+            }
+            pooled = started;
+            this.mcpPool.set(s.name, pooled);
+          }
+          perSpawnClients.push(pooled);
+        } else {
+          const [c] = await startMcpClients([s]);
+          if (c === undefined) {
+            throw new Error(`startMcpClients returned no client for ${s.name}`);
+          }
+          perSpawnClients.push(c);
+        }
+      }
+    }
 
-    return {
-      stdout: loop.finalText,
-      sessionHandle: handle,
-      tokensIn: loop.tokensIn,
-      tokensOut: loop.tokensOut,
-      toolCalls: loop.toolCalls,
-    };
+    try {
+      const mcpRegistry = await mcpToolsToRegistry(perSpawnClients);
+      const merged: ToolRegistry = { ...filteredRegistry, ...mcpRegistry };
+
+      const mergedToolsArg: string[] | undefined =
+        args.tools !== undefined
+          ? [...args.tools, ...Object.keys(mcpRegistry)]
+          : Object.keys(mcpRegistry).length > 0
+            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpRegistry)]
+            : args.tools;
+
+      const toolSchemas = toolsToSchemas(merged, mergedToolsArg);
+
+      const loop = await runToolLoop({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        headers: this.headers,
+        fetch: this.fetch,
+        model,
+        messages: initialMessages,
+        tools: toolSchemas,
+        registry: merged,
+        maxRounds: this.maxToolRounds,
+        requestTimeout: this.requestTimeout,
+      });
+
+      await this.sessionStore.set(handle, loop.finalMessages);
+
+      return {
+        stdout: loop.finalText,
+        sessionHandle: handle,
+        tokensIn: loop.tokensIn,
+        tokensOut: loop.tokensOut,
+        toolCalls: loop.toolCalls,
+      };
+    } finally {
+      // Stop per-spawn clients only — pooled clients live until shutdown().
+      const toStop = perSpawnClients.filter((c) => !c.config.reusePerRunner);
+      await Promise.allSettled(toStop.map((c) => c.stop()));
+    }
+  }
+
+  /**
+   * Drain the pooled MCP clients. Invoked by the workflow executor on
+   * workflow completion / abort (Phase 7 wires this call; runner exposes it now).
+   */
+  async shutdown(): Promise<void> {
+    await shutdownAll([...this.mcpPool.values()]);
+    this.mcpPool.clear();
   }
 }

--- a/agentflow/packages/runners/api/src/mcp-client.ts
+++ b/agentflow/packages/runners/api/src/mcp-client.ts
@@ -13,7 +13,7 @@
  */
 
 import { AgentFlowError } from "@ageflow/core";
-import type { McpServerConfig, Logger, McpToolDescriptor } from "@ageflow/core";
+import type { Logger, McpServerConfig, McpToolDescriptor } from "@ageflow/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
@@ -85,11 +85,13 @@ class McpClientImpl implements McpClient {
 
   async listTools(): Promise<McpToolDescriptor[]> {
     const res = await this.client.listTools();
-    return res.tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-    }));
+    return res.tools.map(
+      (t): McpToolDescriptor => ({
+        name: t.name,
+        ...(t.description !== undefined ? { description: t.description } : {}),
+        ...(t.inputSchema !== undefined ? { inputSchema: t.inputSchema } : {}),
+      }),
+    );
   }
 
   async callTool(
@@ -149,7 +151,10 @@ class McpClientImpl implements McpClient {
                 .map((c) => c.text ?? "")
                 .join(" ")
             : "";
-        throw new McpToolCallFailedError(name, new Error(content || "isError:true"));
+        throw new McpToolCallFailedError(
+          name,
+          new Error(content || "isError:true"),
+        );
       }
       return res;
     } finally {
@@ -163,7 +168,9 @@ class McpClientImpl implements McpClient {
     try {
       await this.client.close();
     } catch (err) {
-      this.logger?.warn(`McpClient.stop: close error for ${this.config.name}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger?.warn(
+        `McpClient.stop: close error for ${this.config.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 }
@@ -208,16 +215,21 @@ async function startOne(
         Object.entries(cfg.env).map(([k, v]) => [
           k,
           // Basic ${env:VAR} substitution (already resolved by executor; kept for safety)
-          v.replace(/\$\{env:([^}]+)\}/g, (_, name: string) => process.env[name] ?? ""),
+          v.replace(
+            /\$\{env:([^}]+)\}/g,
+            (_, name: string) => process.env[name] ?? "",
+          ),
         ]),
       )
     : {};
 
+  const hasEnv = Object.keys(env).length > 0;
+  const hasCwd = cfg.cwd !== undefined;
   const transport = new StdioClientTransport({
     command: cfg.command,
     args: cfg.args ? [...cfg.args] : [],
-    env: Object.keys(env).length > 0 ? env : undefined,
-    cwd: cfg.cwd,
+    ...(hasEnv ? { env } : {}),
+    ...(hasCwd ? { cwd: cfg.cwd } : {}),
     stderr: "pipe",
   });
 
@@ -243,6 +255,8 @@ async function startOne(
 /**
  * Shut down all clients concurrently. Errors are ignored.
  */
-export async function shutdownAll(clients: readonly McpClient[]): Promise<void> {
+export async function shutdownAll(
+  clients: readonly McpClient[],
+): Promise<void> {
   await Promise.allSettled(clients.map((c) => c.stop()));
 }

--- a/agentflow/packages/runners/api/src/mcp-client.ts
+++ b/agentflow/packages/runners/api/src/mcp-client.ts
@@ -1,0 +1,248 @@
+/**
+ * mcp-client.ts
+ *
+ * Thin wrapper over @modelcontextprotocol/sdk StdioClientTransport + Client.
+ * Exposes McpClient, startMcpClients(), and shutdownAll().
+ *
+ * Error classes:
+ *   McpServerStartFailedError  — spawn / initialize failed
+ *   McpToolCallFailedError     — tool invocation returned isError:true or threw
+ *
+ * Per-call timeout: mcpCallTimeoutMs (default 30 s). On timeout, server is
+ * sent SIGTERM then SIGKILL after 5 s.
+ */
+
+import { AgentFlowError } from "@ageflow/core";
+import type { McpServerConfig, Logger, McpToolDescriptor } from "@ageflow/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+export type { McpToolDescriptor };
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class McpServerStartFailedError extends AgentFlowError {
+  readonly code = "mcp_server_start_failed" as const;
+  constructor(
+    readonly serverName: string,
+    cause?: unknown,
+  ) {
+    const msg =
+      cause instanceof Error ? cause.message : String(cause ?? "unknown");
+    super(`mcp_server_start_failed: ${serverName}: ${msg}`, {
+      cause: cause instanceof Error ? cause : undefined,
+    });
+  }
+}
+
+export class McpToolCallFailedError extends AgentFlowError {
+  readonly code = "mcp_tool_call_failed" as const;
+  constructor(
+    readonly toolName: string,
+    cause?: unknown,
+  ) {
+    const msg =
+      cause instanceof Error ? cause.message : String(cause ?? "unknown");
+    super(`mcp_tool_call_failed: ${toolName}: ${msg}`, {
+      cause: cause instanceof Error ? cause : undefined,
+    });
+  }
+}
+
+// ─── Public interface ─────────────────────────────────────────────────────────
+
+export interface McpClient {
+  readonly config: McpServerConfig;
+  listTools(): Promise<McpToolDescriptor[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+  stop(): Promise<void>;
+}
+
+const DEFAULT_CALL_TIMEOUT_MS = 30_000;
+const SIGKILL_GRACE_MS = 5_000;
+
+// ─── Implementation ───────────────────────────────────────────────────────────
+
+class McpClientImpl implements McpClient {
+  readonly config: McpServerConfig;
+  private readonly client: Client;
+  private readonly transport: StdioClientTransport;
+  private readonly callTimeoutMs: number;
+  private readonly logger: Logger | undefined;
+
+  constructor(
+    config: McpServerConfig,
+    client: Client,
+    transport: StdioClientTransport,
+    logger?: Logger,
+  ) {
+    this.config = config;
+    this.client = client;
+    this.transport = transport;
+    this.callTimeoutMs = config.mcpCallTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+    this.logger = logger;
+  }
+
+  async listTools(): Promise<McpToolDescriptor[]> {
+    const res = await this.client.listTools();
+    return res.tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }));
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown> {
+    const timeoutMs = this.callTimeoutMs;
+
+    const doCall = this.client.callTool({ name, arguments: args });
+
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const timeout = new Promise<never>((_, reject) => {
+      const t = setTimeout(() => {
+        // Try SIGTERM first, then SIGKILL after grace period
+        const pid = this.transport.pid;
+        if (pid !== null) {
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // process may already be gone
+          }
+          killTimer = setTimeout(() => {
+            if (pid !== null) {
+              try {
+                process.kill(pid, "SIGKILL");
+              } catch {
+                // ignore
+              }
+            }
+          }, SIGKILL_GRACE_MS);
+        }
+        reject(
+          new McpToolCallFailedError(
+            name,
+            new Error(`timeout after ${timeoutMs}ms`),
+          ),
+        );
+      }, timeoutMs);
+      // Allow the process to exit without waiting for this timer
+      t.unref?.();
+      return t;
+    });
+
+    try {
+      const res = await Promise.race([doCall, timeout]);
+      // Treat isError:true as an error
+      if (
+        res !== null &&
+        typeof res === "object" &&
+        "isError" in res &&
+        res.isError === true
+      ) {
+        const content =
+          "content" in res && Array.isArray(res.content)
+            ? (res.content as Array<{ type: string; text?: string }>)
+                .map((c) => c.text ?? "")
+                .join(" ")
+            : "";
+        throw new McpToolCallFailedError(name, new Error(content || "isError:true"));
+      }
+      return res;
+    } finally {
+      if (killTimer !== undefined) {
+        clearTimeout(killTimer);
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    try {
+      await this.client.close();
+    } catch (err) {
+      this.logger?.warn(`McpClient.stop: close error for ${this.config.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+// ─── Public factory ───────────────────────────────────────────────────────────
+
+/**
+ * Start one McpClient per McpServerConfig entry by spawning each as a stdio subprocess.
+ * All clients are started concurrently. On any failure, already-started clients are
+ * shut down and McpServerStartFailedError is thrown.
+ */
+export async function startMcpClients(
+  servers: readonly McpServerConfig[],
+  logger?: Logger,
+): Promise<McpClient[]> {
+  const started: McpClient[] = [];
+
+  for (const cfg of servers) {
+    let client: McpClientImpl;
+    try {
+      client = await startOne(cfg, logger);
+    } catch (err) {
+      // Rollback already-started clients
+      await Promise.allSettled(started.map((c) => c.stop()));
+      throw new McpServerStartFailedError(
+        cfg.name,
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+    started.push(client);
+  }
+
+  return started;
+}
+
+async function startOne(
+  cfg: McpServerConfig,
+  logger?: Logger,
+): Promise<McpClientImpl> {
+  const env: Record<string, string> = cfg.env
+    ? Object.fromEntries(
+        Object.entries(cfg.env).map(([k, v]) => [
+          k,
+          // Basic ${env:VAR} substitution (already resolved by executor; kept for safety)
+          v.replace(/\$\{env:([^}]+)\}/g, (_, name: string) => process.env[name] ?? ""),
+        ]),
+      )
+    : {};
+
+  const transport = new StdioClientTransport({
+    command: cfg.command,
+    args: cfg.args ? [...cfg.args] : [],
+    env: Object.keys(env).length > 0 ? env : undefined,
+    cwd: cfg.cwd,
+    stderr: "pipe",
+  });
+
+  // Tee stderr to logger — never forwarded to the model
+  transport.stderr?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString().trimEnd();
+    if (text) {
+      logger?.debug(`[mcp:${cfg.name}] ${text}`);
+    }
+  });
+
+  const sdkClient = new Client(
+    { name: "ageflow-runner-api", version: "0.2.0" },
+    { capabilities: {} },
+  );
+
+  // connect() will throw if the subprocess fails to start or initialize
+  await sdkClient.connect(transport);
+
+  return new McpClientImpl(cfg, sdkClient, transport, logger);
+}
+
+/**
+ * Shut down all clients concurrently. Errors are ignored.
+ */
+export async function shutdownAll(clients: readonly McpClient[]): Promise<void> {
+  await Promise.allSettled(clients.map((c) => c.stop()));
+}

--- a/agentflow/packages/runners/api/src/mcp-client.ts
+++ b/agentflow/packages/runners/api/src/mcp-client.ts
@@ -100,17 +100,31 @@ class McpClientImpl implements McpClient {
   ): Promise<unknown> {
     const timeoutMs = this.callTimeoutMs;
 
-    const doCall = this.client.callTool({ name, arguments: args });
+    // C3: AbortController so the SDK cleans up the in-flight RPC on timeout
+    const ctrl = new AbortController();
 
+    const doCall = this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { signal: ctrl.signal },
+    );
+
+    // C1: hoist the SIGTERM timer so the finally block can cancel it on the
+    //     happy path, preventing spurious SIGTERM after a successful call.
+    let sigtermTimer: ReturnType<typeof setTimeout> | undefined;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
+    // C2: track whether SIGTERM was sent so we do NOT cancel the SIGKILL timer
+    //     when the timeout path runs through finally.
+    let sentSigterm = false;
 
     const timeout = new Promise<never>((_, reject) => {
-      const t = setTimeout(() => {
+      sigtermTimer = setTimeout(() => {
         // Try SIGTERM first, then SIGKILL after grace period
         const pid = this.transport.pid;
         if (pid !== null) {
           try {
             process.kill(pid, "SIGTERM");
+            sentSigterm = true;
           } catch {
             // process may already be gone
           }
@@ -123,7 +137,11 @@ class McpClientImpl implements McpClient {
               }
             }
           }, SIGKILL_GRACE_MS);
+          killTimer.unref?.();
         }
+        // C3: abort the in-flight SDK request so the client cleans up the
+        //     pending request ID and does not process a late server reply.
+        ctrl.abort();
         reject(
           new McpToolCallFailedError(
             name,
@@ -132,8 +150,7 @@ class McpClientImpl implements McpClient {
         );
       }, timeoutMs);
       // Allow the process to exit without waiting for this timer
-      t.unref?.();
-      return t;
+      sigtermTimer.unref?.();
     });
 
     try {
@@ -158,7 +175,13 @@ class McpClientImpl implements McpClient {
       }
       return res;
     } finally {
-      if (killTimer !== undefined) {
+      // C1: always clear the SIGTERM timer — on the happy path it hasn't fired
+      //     yet and must be cancelled to prevent spurious kills.
+      clearTimeout(sigtermTimer);
+      // C2: only cancel the SIGKILL escalation if SIGTERM was never sent
+      //     (i.e. happy path). When sentSigterm is true we are on the timeout
+      //     path and the SIGKILL timer must be allowed to fire.
+      if (!sentSigterm && killTimer !== undefined) {
         clearTimeout(killTimer);
       }
     }

--- a/agentflow/packages/runners/api/src/mcp-client.ts
+++ b/agentflow/packages/runners/api/src/mcp-client.ts
@@ -103,11 +103,9 @@ class McpClientImpl implements McpClient {
     // C3: AbortController so the SDK cleans up the in-flight RPC on timeout
     const ctrl = new AbortController();
 
-    const doCall = this.client.callTool(
-      { name, arguments: args },
-      undefined,
-      { signal: ctrl.signal },
-    );
+    const doCall = this.client.callTool({ name, arguments: args }, undefined, {
+      signal: ctrl.signal,
+    });
 
     // C1: hoist the SIGTERM timer so the finally block can cancel it on the
     //     happy path, preventing spurious SIGTERM after a successful call.

--- a/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
+++ b/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
@@ -13,7 +13,12 @@
  *      Zod schema before forwarding to the server.
  */
 
-import { AgentFlowError, filterMcpTools, isMcpToolPermitted, mcpToolFqn } from "@ageflow/core";
+import {
+  AgentFlowError,
+  filterMcpTools,
+  isMcpToolPermitted,
+  mcpToolFqn,
+} from "@ageflow/core";
 import type { McpClient } from "./mcp-client.js";
 import type { ToolDefinition, ToolRegistry } from "./types.js";
 
@@ -76,7 +81,11 @@ export async function mcpToolsToRegistry(
 function buildToolDefinition(
   client: McpClient,
   toolName: string,
-  descriptor: { name: string; description?: string | undefined; inputSchema?: unknown },
+  descriptor: {
+    name: string;
+    description?: string | undefined;
+    inputSchema?: unknown;
+  },
 ): ToolDefinition {
   return {
     description: descriptor.description ?? "",
@@ -99,10 +108,7 @@ function buildToolDefinition(
       if (refineSchema !== undefined) {
         const result = refineSchema.safeParse(args);
         if (!result.success) {
-          throw new McpToolArgInvalidError(
-            toolName,
-            result.error,
-          );
+          throw new McpToolArgInvalidError(toolName, result.error);
         }
       }
 

--- a/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
+++ b/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
@@ -1,0 +1,112 @@
+/**
+ * mcp-tool-adapter.ts
+ *
+ * Walks each McpClient, calls listTools(), filters by allowlist (pre-dispatch),
+ * and wraps each remaining tool in a ToolDefinition for use in the ToolRegistry.
+ *
+ * Defence-in-depth:
+ *   1. Pre-dispatch: filterMcpTools() strips tools outside the allowlist before
+ *      they reach the model. Filtered tools never appear in the registry.
+ *   2. Post-dispatch: execute() re-checks isMcpToolPermitted() — should never
+ *      fire in normal operation but guards against unexpected code paths.
+ *   3. Refine: if server.refine[toolName] is set, args are parsed through the
+ *      Zod schema before forwarding to the server.
+ */
+
+import { AgentFlowError, filterMcpTools, isMcpToolPermitted, mcpToolFqn } from "@ageflow/core";
+import type { McpClient } from "./mcp-client.js";
+import type { ToolDefinition, ToolRegistry } from "./types.js";
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class McpToolNotPermittedError extends AgentFlowError {
+  readonly code = "mcp_tool_not_permitted" as const;
+  constructor(
+    readonly toolName: string,
+    readonly serverName: string,
+  ) {
+    super(
+      `mcp_tool_not_permitted: tool "${toolName}" is not in the allowlist for server "${serverName}"`,
+    );
+  }
+}
+
+export class McpToolArgInvalidError extends AgentFlowError {
+  readonly code = "mcp_tool_arg_invalid" as const;
+  constructor(
+    readonly toolName: string,
+    cause?: unknown,
+  ) {
+    const msg =
+      cause instanceof Error ? cause.message : String(cause ?? "invalid args");
+    super(`mcp_tool_arg_invalid: ${toolName}: ${msg}`, {
+      cause: cause instanceof Error ? cause : undefined,
+    });
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * For each McpClient, list its tools, apply allowlist filtering, and return
+ * a ToolRegistry keyed by `mcp__<serverName>__<toolName>`.
+ */
+export async function mcpToolsToRegistry(
+  clients: readonly McpClient[],
+): Promise<ToolRegistry> {
+  const registry: ToolRegistry = {};
+
+  for (const client of clients) {
+    const allTools = await client.listTools();
+    // Pre-dispatch: filter by allowlist
+    const permitted = filterMcpTools(client.config, allTools);
+
+    for (const tool of permitted) {
+      const fqn = mcpToolFqn(client.config.name, tool.name);
+      const toolDef = buildToolDefinition(client, tool.name, tool);
+      registry[fqn] = toolDef;
+    }
+  }
+
+  return registry;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function buildToolDefinition(
+  client: McpClient,
+  toolName: string,
+  descriptor: { name: string; description?: string | undefined; inputSchema?: unknown },
+): ToolDefinition {
+  return {
+    description: descriptor.description ?? "",
+    parameters:
+      descriptor.inputSchema !== null &&
+      typeof descriptor.inputSchema === "object"
+        ? (descriptor.inputSchema as Record<string, unknown>)
+        : { type: "object" },
+
+    execute: async (args: Record<string, unknown>): Promise<unknown> => {
+      const { config } = client;
+
+      // Post-dispatch re-check (defence in depth)
+      if (!isMcpToolPermitted(config, toolName)) {
+        throw new McpToolNotPermittedError(toolName, config.name);
+      }
+
+      // Refine validation
+      const refineSchema = config.refine?.[toolName];
+      if (refineSchema !== undefined) {
+        const result = refineSchema.safeParse(args);
+        if (!result.success) {
+          throw new McpToolArgInvalidError(
+            toolName,
+            result.error,
+          );
+        }
+      }
+
+      return client.callTool(toolName, args);
+    },
+  };
+}

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@ageflow/core": "workspace:*",
-    "@ageflow/executor": "workspace:*"
+    "@ageflow/executor": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/agentflow/packages/testing/src/__tests__/mock-mcp.test.ts
+++ b/agentflow/packages/testing/src/__tests__/mock-mcp.test.ts
@@ -33,7 +33,9 @@ describe("spawnMockMcpServer", () => {
       tools: [{ name: "slow", description: "", inputSchema: {} }],
       hangOn: "call",
     });
-    await expect(srv.callTool("slow", {}, { timeoutMs: 100 })).rejects.toThrow(/timeout/i);
+    await expect(srv.callTool("slow", {}, { timeoutMs: 100 })).rejects.toThrow(
+      /timeout/i,
+    );
     await srv.stop();
   });
 });

--- a/agentflow/packages/testing/src/__tests__/mock-mcp.test.ts
+++ b/agentflow/packages/testing/src/__tests__/mock-mcp.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { spawnMockMcpServer } from "../fixtures/mock-mcp.js";
+
+describe("spawnMockMcpServer", () => {
+  it("responds to tools/list with the parameterised tool set", async () => {
+    const srv = await spawnMockMcpServer({
+      tools: [
+        { name: "echo", description: "echo", inputSchema: { type: "object" } },
+      ],
+    });
+    const tools = await srv.listTools();
+    expect(tools.map((t) => t.name)).toEqual(["echo"]);
+    await srv.stop();
+  });
+
+  it("echo tool round-trips", async () => {
+    const srv = await spawnMockMcpServer({
+      tools: [{ name: "echo", description: "", inputSchema: {} }],
+    });
+    const res = await srv.callTool("echo", { text: "hi" });
+    expect(res).toEqual({ content: [{ type: "text", text: "hi" }] });
+    await srv.stop();
+  });
+
+  it("crash mode exits during initialize", async () => {
+    await expect(
+      spawnMockMcpServer({ tools: [], crashOn: "initialize" }),
+    ).rejects.toThrow();
+  });
+
+  it("hang mode never responds to tools/call (timeout expected)", async () => {
+    const srv = await spawnMockMcpServer({
+      tools: [{ name: "slow", description: "", inputSchema: {} }],
+      hangOn: "call",
+    });
+    await expect(srv.callTool("slow", {}, { timeoutMs: 100 })).rejects.toThrow(/timeout/i);
+    await srv.stop();
+  });
+});

--- a/agentflow/packages/testing/src/fixtures/mock-mcp-server-script.ts
+++ b/agentflow/packages/testing/src/fixtures/mock-mcp-server-script.ts
@@ -35,10 +35,11 @@ interface ScriptConfig {
 
 function parseArgs(): ScriptConfig {
   const idx = process.argv.indexOf("--config");
-  if (idx === -1 || !process.argv[idx + 1]) {
+  const configArg = process.argv[idx + 1];
+  if (idx === -1 || !configArg) {
     throw new Error("mock-mcp-server-script: --config argument is required");
   }
-  const raw = Buffer.from(process.argv[idx + 1]!, "base64").toString("utf-8");
+  const raw = Buffer.from(configArg, "base64").toString("utf-8");
   return JSON.parse(raw) as ScriptConfig;
 }
 
@@ -86,13 +87,16 @@ async function main(): Promise<void> {
 
     if (name === cfg.isErrorOn) {
       return {
-        content: [{ type: "text" as const, text: `error: tool ${name} failed` }],
+        content: [
+          { type: "text" as const, text: `error: tool ${name} failed` },
+        ],
         isError: true,
       };
     }
 
     // Default echo behaviour: return args as JSON text
-    const text = typeof args["text"] === "string" ? args["text"] : JSON.stringify(args);
+    const textArg = args.text;
+    const text = typeof textArg === "string" ? textArg : JSON.stringify(args);
     return {
       content: [{ type: "text" as const, text }],
       isError: false,
@@ -104,6 +108,8 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  process.stderr.write(`mock-mcp-server-script error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.stderr.write(
+    `mock-mcp-server-script error: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
   process.exit(1);
 });

--- a/agentflow/packages/testing/src/fixtures/mock-mcp-server-script.ts
+++ b/agentflow/packages/testing/src/fixtures/mock-mcp-server-script.ts
@@ -1,0 +1,109 @@
+/**
+ * mock-mcp-server-script.ts
+ *
+ * Subprocess entry point for a mock MCP server.
+ * Reads config from --config <base64-json> CLI argument.
+ * Connects over stdio using @modelcontextprotocol/sdk Server + StdioServerTransport.
+ *
+ * Config shape (MockMcpServerOpts serialised as base64 JSON, without refine):
+ *   { tools, crashOn?, hangOn?, isErrorOn? }
+ *
+ * Usage:
+ *   node mock-mcp-server-script.js --config <base64>
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+interface ToolSpec {
+  name: string;
+  description?: string;
+  // biome-ignore lint/suspicious/noExplicitAny: JSON schema is untyped
+  inputSchema?: Record<string, any>;
+}
+
+interface ScriptConfig {
+  tools: ToolSpec[];
+  crashOn?: "initialize" | "tools/list" | "call";
+  hangOn?: "initialize" | "tools/list" | "call";
+  isErrorOn?: string;
+}
+
+function parseArgs(): ScriptConfig {
+  const idx = process.argv.indexOf("--config");
+  if (idx === -1 || !process.argv[idx + 1]) {
+    throw new Error("mock-mcp-server-script: --config argument is required");
+  }
+  const raw = Buffer.from(process.argv[idx + 1]!, "base64").toString("utf-8");
+  return JSON.parse(raw) as ScriptConfig;
+}
+
+async function main(): Promise<void> {
+  const cfg = parseArgs();
+
+  if (cfg.crashOn === "initialize") {
+    process.stderr.write("mock-mcp: crashing on initialize\n");
+    process.exit(1);
+  }
+
+  const server = new Server(
+    { name: "mock-mcp", version: "0.0.1" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    if (cfg.hangOn === "tools/list") {
+      await new Promise(() => {}); // hang forever
+    }
+    if (cfg.crashOn === "tools/list") {
+      process.exit(1);
+    }
+    return {
+      tools: cfg.tools.map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        inputSchema: {
+          type: "object" as const,
+          ...(t.inputSchema ?? {}),
+        },
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (cfg.hangOn === "call") {
+      await new Promise(() => {}); // hang forever
+    }
+    if (cfg.crashOn === "call") {
+      process.exit(1);
+    }
+    const name = req.params.name;
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+
+    if (name === cfg.isErrorOn) {
+      return {
+        content: [{ type: "text" as const, text: `error: tool ${name} failed` }],
+        isError: true,
+      };
+    }
+
+    // Default echo behaviour: return args as JSON text
+    const text = typeof args["text"] === "string" ? args["text"] : JSON.stringify(args);
+    return {
+      content: [{ type: "text" as const, text }],
+      isError: false,
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`mock-mcp-server-script error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/agentflow/packages/testing/src/fixtures/mock-mcp.ts
+++ b/agentflow/packages/testing/src/fixtures/mock-mcp.ts
@@ -16,8 +16,8 @@
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -97,13 +97,15 @@ async function buildInProcessServer(opts: MockMcpServerOpts): Promise<Server> {
 
     if (name === opts.isErrorOn) {
       return {
-        content: [{ type: "text" as const, text: `error: tool ${name} failed` }],
+        content: [
+          { type: "text" as const, text: `error: tool ${name} failed` },
+        ],
         isError: true,
       };
     }
 
-    const text =
-      typeof args["text"] === "string" ? args["text"] : JSON.stringify(args);
+    const textArg = args.text;
+    const text = typeof textArg === "string" ? textArg : JSON.stringify(args);
     return {
       content: [{ type: "text" as const, text }],
       isError: false,
@@ -133,7 +135,8 @@ export async function spawnMockMcpServer(
   }
 
   const server = await buildInProcessServer(opts);
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
 
   await server.connect(serverTransport);
 

--- a/agentflow/packages/testing/src/fixtures/mock-mcp.ts
+++ b/agentflow/packages/testing/src/fixtures/mock-mcp.ts
@@ -1,0 +1,206 @@
+/**
+ * mock-mcp.ts
+ *
+ * Provides `spawnMockMcpServer()` — a parametrised mock MCP server for testing.
+ *
+ * In-process mode (default): uses InMemoryTransport to avoid subprocess overhead.
+ * Subprocess mode: `spawnMockMcpServer.asSubprocessCommand(opts)` returns
+ *   `{ command, args }` to start the server as a real subprocess over stdio.
+ *
+ * Modes:
+ *   crashOn  — exits/throws at the named lifecycle point
+ *   hangOn   — never responds at the named lifecycle point
+ *   isErrorOn — returns isError:true for the named tool
+ */
+
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MockToolSpec {
+  name: string;
+  description?: string;
+  // biome-ignore lint/suspicious/noExplicitAny: JSON schema is untyped
+  inputSchema?: Record<string, any>;
+}
+
+export interface MockMcpServerOpts {
+  tools: MockToolSpec[];
+  crashOn?: "initialize" | "tools/list" | "call";
+  hangOn?: "initialize" | "tools/list" | "call";
+  /** Tool name for which callTool returns isError:true. */
+  isErrorOn?: string;
+}
+
+export interface MockMcpServerHandle {
+  /** List tools the server exposes. */
+  listTools(): Promise<{ name: string; description?: string }[]>;
+  /** Call a tool. Optionally race against a timeout. */
+  callTool(
+    name: string,
+    args: Record<string, unknown>,
+    opts?: { timeoutMs?: number },
+  ): Promise<unknown>;
+  /** Shut down the mock server. */
+  stop(): Promise<void>;
+}
+
+export interface SubprocessCommand {
+  command: string;
+  args: string[];
+}
+
+// ─── In-process implementation ───────────────────────────────────────────────
+
+async function buildInProcessServer(opts: MockMcpServerOpts): Promise<Server> {
+  const server = new Server(
+    { name: "mock-mcp", version: "0.0.1" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    if (opts.hangOn === "tools/list") {
+      await new Promise<never>(() => {});
+    }
+    if (opts.crashOn === "tools/list") {
+      throw new Error("mock-mcp: crashing on tools/list");
+    }
+    return {
+      tools: opts.tools.map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        inputSchema: {
+          type: "object" as const,
+          ...(t.inputSchema ?? {}),
+        },
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (opts.hangOn === "call") {
+      await new Promise<never>(() => {});
+    }
+    if (opts.crashOn === "call") {
+      throw new Error("mock-mcp: crashing on call");
+    }
+    const name = req.params.name;
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+
+    if (name === opts.isErrorOn) {
+      return {
+        content: [{ type: "text" as const, text: `error: tool ${name} failed` }],
+        isError: true,
+      };
+    }
+
+    const text =
+      typeof args["text"] === "string" ? args["text"] : JSON.stringify(args);
+    return {
+      content: [{ type: "text" as const, text }],
+      isError: false,
+    };
+  });
+
+  return server;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Spawn a parametrised mock MCP server in-process using InMemoryTransport.
+ * Returns a handle with listTools / callTool / stop.
+ */
+export async function spawnMockMcpServer(
+  opts: MockMcpServerOpts,
+): Promise<MockMcpServerHandle> {
+  // crashOn:"initialize" — fail immediately before returning a handle
+  if (opts.crashOn === "initialize") {
+    throw new Error("mcp_server_start_failed: mock crash on initialize");
+  }
+
+  if (opts.hangOn === "initialize") {
+    // Never resolves
+    return new Promise<MockMcpServerHandle>(() => {});
+  }
+
+  const server = await buildInProcessServer(opts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.1" },
+    { capabilities: {} },
+  );
+  await client.connect(clientTransport);
+
+  const handle: MockMcpServerHandle = {
+    async listTools() {
+      const res = await client.listTools();
+      return res.tools;
+    },
+
+    async callTool(name, args, callOpts) {
+      const timeoutMs = callOpts?.timeoutMs;
+      const doCall = client.callTool({ name, arguments: args });
+      const normalise = (res: Awaited<typeof doCall>): unknown => {
+        // Strip isError:false so that equality checks don't need to include it.
+        // isError:true is preserved for error path assertions.
+        if ("isError" in res && res.isError === false) {
+          const { isError: _ignored, ...rest } = res;
+          return rest;
+        }
+        return res;
+      };
+      if (timeoutMs !== undefined) {
+        const timeout = new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("timeout: MCP tool call timed out")),
+            timeoutMs,
+          ),
+        );
+        const res = await Promise.race([doCall, timeout]);
+        return normalise(res);
+      }
+      const res = await doCall;
+      return normalise(res);
+    },
+
+    async stop() {
+      await client.close();
+      await server.close();
+    },
+  };
+
+  return handle;
+}
+
+/**
+ * Returns `{ command, args }` for spawning the mock server as a real subprocess.
+ * Used by mcp-client tests that need an actual stdio subprocess.
+ */
+spawnMockMcpServer.asSubprocessCommand = function asSubprocessCommand(
+  opts: MockMcpServerOpts,
+): SubprocessCommand {
+  const scriptPath = fileURLToPath(
+    new URL("./mock-mcp-server-script.js", import.meta.url),
+  );
+  const config = Buffer.from(
+    JSON.stringify({
+      tools: opts.tools,
+      ...(opts.crashOn !== undefined ? { crashOn: opts.crashOn } : {}),
+      ...(opts.hangOn !== undefined ? { hangOn: opts.hangOn } : {}),
+      ...(opts.isErrorOn !== undefined ? { isErrorOn: opts.isErrorOn } : {}),
+    }),
+  ).toString("base64");
+  return { command: process.execPath, args: [scriptPath, "--config", config] };
+};

--- a/agentflow/packages/testing/src/fixtures/mock-mcp.ts
+++ b/agentflow/packages/testing/src/fixtures/mock-mcp.ts
@@ -42,7 +42,7 @@ export interface MockMcpServerOpts {
 
 export interface MockMcpServerHandle {
   /** List tools the server exposes. */
-  listTools(): Promise<{ name: string; description?: string }[]>;
+  listTools(): Promise<{ name: string; description?: string | undefined }[]>;
   /** Call a tool. Optionally race against a timeout. */
   callTool(
     name: string,

--- a/agentflow/packages/testing/src/index.ts
+++ b/agentflow/packages/testing/src/index.ts
@@ -1,2 +1,9 @@
 export { createTestHarness } from "./test-harness.js";
 export type { TestHarness, TaskStats } from "./test-harness.js";
+export { spawnMockMcpServer } from "./fixtures/mock-mcp.js";
+export type {
+  MockMcpServerHandle,
+  MockMcpServerOpts,
+  MockToolSpec,
+  SubprocessCommand,
+} from "./fixtures/mock-mcp.js";


### PR DESCRIPTION
Implements Phase 6 of [plan](docs/superpowers/plans/2026-04-16-agents-use-mcp.md): the API runner's in-process MCP proxy.

## What

- `@modelcontextprotocol/sdk` dependency (runner-api + testing)
- `mock-mcp.ts` fixture — in-process + subprocess modes via `@ageflow/testing`
- `mcp-client.ts` — stdio client wrapper (`startMcpClients`, `shutdownAll`) with per-call timeout + SIGTERM/SIGKILL escalation
- `mcp-tool-adapter.ts` — bridges MCP tools into `ToolRegistry` via FQN (`mcp__<server>__<tool>`)
- End-to-end MCP integration in `ApiRunner` — spawns on demand, shuts down per call (default), exposes `Runner.shutdown()` for Phase 7 pooling
- Allowlist enforcement (pre-dispatch filter + post-dispatch reject) — defense in depth

## Tests

12 new tests across 4 files:
- `mock-mcp.test.ts` (4)
- `mcp-client.test.ts` (2)
- `mcp-tool-adapter.test.ts` (4)
- `api-runner.mcp.test.ts` (2)

Totals: runner-api **39 passing** (was 31), testing **16 passing** (was 12). Typecheck + lint: clean.

## Out of scope (Phase 7+)

- Wiring `Runner.shutdown()` into `WorkflowExecutor` lifecycle — Phase 7
- Security test suite (spoofing, path escape, injection-in-result) — Phase 8
- Dogfooding example — Phase 9

Closes part of #19.