### PR TITLE
feat(executor): #19 Phase 7 — Runner.shutdown() after workflow run

### DIFF
--- a/agentflow/packages/executor/src/__tests__/workflow-executor.shutdown.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.shutdown.test.ts
@@ -1,0 +1,88 @@
+import {
+  defineAgent,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
+import type { Runner, RunnerSpawnResult } from "@ageflow/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { WorkflowExecutor } from "../workflow-executor.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSpawnResult(data: unknown): RunnerSpawnResult {
+  return {
+    stdout: JSON.stringify(data),
+    sessionHandle: "sess-shutdown",
+    tokensIn: 1,
+    tokensOut: 1,
+  };
+}
+
+const trivialAgent = defineAgent({
+  runner: "shutdown-test-runner",
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  prompt: () => "ping",
+  retry: { max: 1, on: [], backoff: "fixed" },
+});
+
+const trivialWorkflow = defineWorkflow({
+  name: "shutdown-test-workflow",
+  tasks: {
+    ping: {
+      agent: trivialAgent,
+      input: {},
+    },
+  },
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("WorkflowExecutor — Runner.shutdown()", () => {
+  afterEach(() => {
+    unregisterRunner("shutdown-test-runner");
+  });
+
+  it("calls runner.shutdown() on workflow completion when defined", async () => {
+    let shutdownCalled = false;
+
+    const runner: Runner = {
+      async validate() {
+        return { ok: true };
+      },
+      async spawn() {
+        return makeSpawnResult({ ok: true });
+      },
+      async shutdown() {
+        shutdownCalled = true;
+      },
+    };
+
+    registerRunner("shutdown-test-runner", runner);
+
+    const executor = new WorkflowExecutor(trivialWorkflow);
+    await executor.run();
+
+    expect(shutdownCalled).toBe(true);
+  });
+
+  it("does not throw when runner does not implement shutdown", async () => {
+    // ClaudeRunner / CodexRunner backward-compat path — no shutdown method.
+    const runner: Runner = {
+      async validate() {
+        return { ok: true };
+      },
+      async spawn() {
+        return makeSpawnResult({ ok: true });
+      },
+    };
+
+    registerRunner("shutdown-test-runner", runner);
+
+    const executor = new WorkflowExecutor(trivialWorkflow);
+    // Must complete without throwing.
+    await expect(executor.run()).resolves.toBeDefined();
+  });
+});

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -1,4 +1,9 @@
-import { NodeMaxRetriesError, getRunner, resolveAgentDef } from "@ageflow/core";
+import {
+  NodeMaxRetriesError,
+  getRunner,
+  getRunners,
+  resolveAgentDef,
+} from "@ageflow/core";
 import type {
   AgentDef,
   CheckpointEvent,
@@ -237,6 +242,11 @@ export class WorkflowExecutor<T extends TasksMap> {
         });
         driverError = e;
         queue.close();
+      } finally {
+        // Shut down all registered runners (success OR error path).
+        // Errors from shutdown are logged as warnings and never mask the
+        // primary workflow result.
+        await this._shutdownRunners();
       }
     })();
     // Suppress the floating promise rejection (the IIFE returns void / never rejects).
@@ -755,5 +765,26 @@ export class WorkflowExecutor<T extends TasksMap> {
     };
 
     return { outputs, metrics };
+  }
+
+  /**
+   * Invoke `shutdown()` on every registered runner that implements it.
+   * Called after workflow completion (success OR error).
+   * Errors are logged as warnings so they never mask the primary workflow result.
+   */
+  private async _shutdownRunners(): Promise<void> {
+    const runners = getRunners();
+    await Promise.all(
+      [...runners.entries()].map(async ([name, runner]) => {
+        try {
+          await runner.shutdown?.();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `[AgentFlow] runner "${name}" shutdown() failed: ${msg}`,
+          );
+        }
+      }),
+    );
   }
 }


### PR DESCRIPTION
Wires \`Runner.shutdown?()\` into \`WorkflowExecutor\` per Phase 7 of [plan](docs/superpowers/plans/2026-04-16-agents-use-mcp.md#phase-7--runnershutdown-wired-into-the-executor).

## What

- `workflow-executor.ts` — \`finally\` block after stream completion calls \`_shutdownRunners()\`; iterates registered runners, \`await runner.shutdown?.()\` with optional chaining; per-runner errors are \`console.warn\`'d so they never mask the workflow result.
- \`workflow-executor.shutdown.test.ts\` — TDD: first commit adds failing tests, second commit implements.

## Tests

- Runner with \`shutdown\` → called once on success path ✓
- Runner without \`shutdown\` (Claude/Codex backward-compat) → no throw, executor completes ✓

Executor package: **162 → 164 tests passing**. Typecheck + lint clean.

## Scope boundary

Does NOT touch \`Runner\` interface (\`shutdown?()\` was added in an earlier phase). Touches only \`packages/executor/\`.

Closes part of #19.