### PR TITLE
docs(examples): #19 Phase 9 — agent-uses-mcp dogfood example

### DIFF
--- a/agentflow/bun.lock
+++ b/agentflow/bun.lock
@@ -24,6 +24,23 @@
         "@types/node": "^22.0.0",
       },
     },
+    "examples/agent-uses-mcp": {
+      "name": "@ageflow-example/agent-uses-mcp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ageflow/core": "workspace:*",
+        "@ageflow/executor": "workspace:*",
+        "@ageflow/runner-api": "workspace:*",
+        "@ageflow/runner-claude": "workspace:*",
+        "@ageflow/runner-codex": "workspace:*",
+        "@ageflow/testing": "workspace:*",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "examples/api-runner": {
       "name": "@ageflow-example/api-runner",
       "version": "0.0.0",
@@ -217,6 +234,8 @@
     "zod": "^3.23.0",
   },
   "packages": {
+    "@ageflow-example/agent-uses-mcp": ["@ageflow-example/agent-uses-mcp@workspace:examples/agent-uses-mcp"],
+
     "@ageflow-example/api-runner": ["@ageflow-example/api-runner@workspace:examples/api-runner"],
 
     "@ageflow-example/server-embed": ["@ageflow-example/server-embed@workspace:examples/server-embed"],

--- a/agentflow/examples/agent-uses-mcp/README.md
+++ b/agentflow/examples/agent-uses-mcp/README.md
@@ -1,0 +1,81 @@
+# agent-uses-mcp
+
+Dogfood example showing the **same** AgentFlow workflow config running under
+three different runners — `api`, `claude`, and `codex` — with only the
+`runner:` string changing.
+
+The `audit` agent uses the
+[`@modelcontextprotocol/server-filesystem`](https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem)
+MCP server to list files under a directory.
+
+---
+
+## Quick start
+
+```sh
+# Install workspace deps (run from repo root once)
+bun install
+
+# Run with the OpenAI-compatible HTTP runner
+bun run demo:api        # requires OPENAI_API_KEY (or OPENAI_BASE_URL + key)
+
+# Run with the Claude CLI runner
+bun run demo:claude     # requires `claude` in PATH + ANTHROPIC_API_KEY
+
+# Run with the OpenAI Codex CLI runner
+bun run demo:codex      # requires `codex` in PATH + OPENAI_API_KEY
+
+# Offline demo — no credentials needed (api runner only, canned response)
+AGENTFLOW_MOCK=1 bun run demo:api
+```
+
+---
+
+## Environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | `demo:claude` | Passed to the `claude` CLI subprocess |
+| `OPENAI_API_KEY` | `demo:api`, `demo:codex` | Passed to the API runner / `codex` CLI |
+| `OPENAI_BASE_URL` | `demo:api` | Override endpoint (default: `https://api.openai.com/v1`) |
+| `CODEX_HOME` | `demo:codex` | Codex config directory (optional) |
+| `AGENTFLOW_MOCK` | `demo:api` | Set to `1` to use a canned fetch mock instead of a real API call |
+
+---
+
+## MCP server used
+
+**`@modelcontextprotocol/server-filesystem`** — launched via `npx` on demand by
+each runner that supports subprocess MCP servers.
+
+The server exposes `read_file` and `list_directory` tools scoped to
+`/tmp/workdir`. AgentFlow applies a `safePath()` Zod refinement on both tools'
+`path` argument before the call is dispatched, blocking:
+
+- path traversal (`../`)
+- absolute paths
+- home expansion (`~`)
+- environment variable expansion (`$VAR`)
+
+Only tools in the allowlist (`read_file`, `list_directory`) are forwarded to the
+model — all others are filtered before reaching the prompt.
+
+---
+
+## Security notes
+
+| Feature | What it does |
+|---|---|
+| `tools: ["read_file", "list_directory"]` | Tool allowlist — any tool not listed is denied before it reaches the model |
+| `refine: { read_file: z.object({ path: safePath() }), ... }` | Per-argument Zod refinement run before each tool call; rejects traversal, absolute paths, env vars |
+| `sanitizeInput: true` (default) | Strips prompt-injection patterns from upstream agent outputs before interpolation |
+| Subprocess scoping | The filesystem server is started with `/tmp/workdir` as its root — it cannot serve files outside that directory |
+
+---
+
+## Tests
+
+```sh
+bun run test       # runs with createTestHarness — no real API or CLI calls
+bun run typecheck  # must pass across all three runner variants
+```

--- a/agentflow/examples/agent-uses-mcp/__mocks__/fetch-mock.ts
+++ b/agentflow/examples/agent-uses-mcp/__mocks__/fetch-mock.ts
@@ -1,0 +1,40 @@
+/**
+ * fetch-mock.ts — Offline fetch stub for the agent-uses-mcp api-runner demo.
+ *
+ * Returns a canned OpenAI-compatible ChatCompletionResponse so the demo
+ * can run without credentials. Inject via:
+ *
+ *   AGENTFLOW_MOCK=1 bun workflow.ts --runner api
+ */
+
+export function mockFetch(
+  _url: string | URL | Request,
+  _init?: RequestInit,
+): Promise<Response> {
+  const body = JSON.stringify({
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: JSON.stringify({
+            summary: "Found 3 files in /tmp/workdir via filesystem MCP.",
+            fileCount: 3,
+          }),
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 55,
+      completion_tokens: 22,
+      total_tokens: 77,
+    },
+  });
+
+  return Promise.resolve(
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}

--- a/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
+++ b/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
@@ -1,0 +1,93 @@
+/**
+ * workflow.test.ts — Harness-based tests for the agent-uses-mcp example.
+ *
+ * Uses @ageflow/testing to mock the agent — no real CLI or API calls made.
+ *
+ * Key assertions:
+ *   1. The DSL typechecks with all three runner values (api / claude / codex).
+ *   2. The workflow graph is well-formed (single audit task, correct I/O).
+ *   3. Mock output is forwarded correctly through the executor.
+ */
+
+import { defineWorkflow } from "@ageflow/core";
+import { createTestHarness } from "@ageflow/testing";
+import { describe, expect, it } from "vitest";
+import { auditAgent } from "../agents/audit.js";
+import { workflow } from "../workflow.js";
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+const MOCK_OUTPUT = { summary: "Found 3 files in /tmp/workdir.", fileCount: 3 };
+
+// ─── Main workflow (imported — uses default "api" runner) ─────────────────────
+
+describe("agent-uses-mcp workflow (api runner)", () => {
+  it("returns audit output via mock agent", async () => {
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("audit", MOCK_OUTPUT);
+    const res = await harness.run({});
+    expect(res.outputs.audit).toEqual(MOCK_OUTPUT);
+  });
+
+  it("records call stats for the audit task", async () => {
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("audit", MOCK_OUTPUT);
+    await harness.run({});
+    const stats = harness.getTask("audit");
+    expect(stats.callCount).toBe(1);
+    expect(stats.retryCount).toBe(0);
+    expect(stats.outputs).toHaveLength(1);
+  });
+});
+
+// ─── Same config under all three runner values ────────────────────────────────
+//
+// These tests prove that the auditAgent factory produces a well-typed AgentDef
+// regardless of the runner string — the workflow DSL is runner-agnostic.
+
+describe.each([
+  ["api" as const],
+  ["claude" as const],
+  ["codex" as const],
+])("auditAgent with runner=%s", (r) => {
+  it("typechecks and runs with mock harness", async () => {
+    const wf = defineWorkflow({
+      name: `agent-uses-mcp-demo-${r}`,
+      tasks: {
+        audit: {
+          agent: auditAgent(r),
+          input: { root: "/tmp/workdir" },
+        },
+      },
+    });
+
+    const harness = createTestHarness(wf);
+    harness.mockAgent("audit", MOCK_OUTPUT);
+    const res = await harness.run({});
+
+    const out = res.outputs.audit as typeof MOCK_OUTPUT;
+    expect(out.summary).toContain("3 files");
+    expect(out.fileCount).toBe(3);
+  });
+});
+
+// ─── Workflow graph shape ─────────────────────────────────────────────────────
+
+describe("workflow graph structure", () => {
+  it("has exactly one task: audit", () => {
+    expect(Object.keys(workflow.tasks)).toEqual(["audit"]);
+  });
+
+  it("audit task uses the correct runner (api by default in test env)", () => {
+    const task = workflow.tasks.audit as { agent: { runner: string } };
+    expect(["api", "claude", "codex"]).toContain(task.agent.runner);
+  });
+
+  it("audit task declares filesystem MCP server", () => {
+    const task = workflow.tasks.audit as {
+      agent: { mcp?: { servers?: ReadonlyArray<{ name: string }> } };
+    };
+    const servers = task.agent.mcp?.servers ?? [];
+    expect(servers.some((s) => s.name === "filesystem")).toBe(true);
+  });
+});

--- a/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
+++ b/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
@@ -45,31 +45,30 @@ describe("agent-uses-mcp workflow (api runner)", () => {
 // These tests prove that the auditAgent factory produces a well-typed AgentDef
 // regardless of the runner string — the workflow DSL is runner-agnostic.
 
-describe.each([
-  ["api" as const],
-  ["claude" as const],
-  ["codex" as const],
-])("auditAgent with runner=%s", (r) => {
-  it("typechecks and runs with mock harness", async () => {
-    const wf = defineWorkflow({
-      name: `agent-uses-mcp-demo-${r}`,
-      tasks: {
-        audit: {
-          agent: auditAgent(r),
-          input: { root: "/tmp/workdir" },
+describe.each([["api" as const], ["claude" as const], ["codex" as const]])(
+  "auditAgent with runner=%s",
+  (r) => {
+    it("typechecks and runs with mock harness", async () => {
+      const wf = defineWorkflow({
+        name: `agent-uses-mcp-demo-${r}`,
+        tasks: {
+          audit: {
+            agent: auditAgent(r),
+            input: { root: "/tmp/workdir" },
+          },
         },
-      },
+      });
+
+      const harness = createTestHarness(wf);
+      harness.mockAgent("audit", MOCK_OUTPUT);
+      const res = await harness.run({});
+
+      const out = res.outputs.audit as typeof MOCK_OUTPUT;
+      expect(out.summary).toContain("3 files");
+      expect(out.fileCount).toBe(3);
     });
-
-    const harness = createTestHarness(wf);
-    harness.mockAgent("audit", MOCK_OUTPUT);
-    const res = await harness.run({});
-
-    const out = res.outputs.audit as typeof MOCK_OUTPUT;
-    expect(out.summary).toContain("3 files");
-    expect(out.fileCount).toBe(3);
-  });
-});
+  },
+);
 
 // ─── Workflow graph shape ─────────────────────────────────────────────────────
 

--- a/agentflow/examples/agent-uses-mcp/agents/audit.ts
+++ b/agentflow/examples/agent-uses-mcp/agents/audit.ts
@@ -1,0 +1,36 @@
+/**
+ * audit.ts — Filesystem audit agent definition.
+ *
+ * Uses the @modelcontextprotocol/server-filesystem MCP server to list files
+ * under a given root directory and return a summary with file count.
+ *
+ * The `runner` parameter is the only thing that changes between cloud, claude,
+ * and codex deployments — the rest of the config is identical.
+ */
+
+import { defineAgent, safePath } from "@ageflow/core";
+import { z } from "zod";
+
+export function auditAgent(runner: "claude" | "codex" | "api") {
+  return defineAgent({
+    runner,
+    input: z.object({ root: z.string() }),
+    output: z.object({ summary: z.string(), fileCount: z.number() }),
+    prompt: (i) =>
+      `List files under ${i.root} via filesystem MCP. Output JSON {summary: string, fileCount: number}.`,
+    mcp: {
+      servers: [
+        {
+          name: "filesystem",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/workdir"],
+          tools: ["read_file", "list_directory"],
+          refine: {
+            read_file: z.object({ path: safePath() }),
+            list_directory: z.object({ path: safePath() }),
+          },
+        },
+      ],
+    },
+  });
+}

--- a/agentflow/examples/agent-uses-mcp/agents/audit.ts
+++ b/agentflow/examples/agent-uses-mcp/agents/audit.ts
@@ -23,7 +23,11 @@ export function auditAgent(runner: "claude" | "codex" | "api") {
         {
           name: "filesystem",
           command: "npx",
-          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/workdir"],
+          args: [
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            "/tmp/workdir",
+          ],
           tools: ["read_file", "list_directory"],
           refine: {
             read_file: z.object({ path: safePath() }),

--- a/agentflow/examples/agent-uses-mcp/package.json
+++ b/agentflow/examples/agent-uses-mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ageflow-example/agent-uses-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo:api": "bun workflow.ts --runner api",
+    "demo:claude": "bun workflow.ts --runner claude",
+    "demo:codex": "bun workflow.ts --runner codex",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ageflow/core": "workspace:*",
+    "@ageflow/executor": "workspace:*",
+    "@ageflow/runner-api": "workspace:*",
+    "@ageflow/runner-claude": "workspace:*",
+    "@ageflow/runner-codex": "workspace:*",
+    "@ageflow/testing": "workspace:*",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/agentflow/examples/agent-uses-mcp/tsconfig.json
+++ b/agentflow/examples/agent-uses-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "paths": {}
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/agentflow/examples/agent-uses-mcp/workflow.ts
+++ b/agentflow/examples/agent-uses-mcp/workflow.ts
@@ -1,0 +1,91 @@
+/**
+ * workflow.ts — agent-uses-mcp cross-runner example.
+ *
+ * Demonstrates the same workflow config running under three different runners.
+ * The only change is the `--runner` flag.
+ *
+ * Run with the API runner (requires OPENAI_API_KEY or compatible endpoint):
+ *   bun workflow.ts --runner api
+ *
+ * Run with the Claude CLI runner (requires `claude` in PATH + ANTHROPIC_API_KEY):
+ *   bun workflow.ts --runner claude
+ *
+ * Run with the Codex CLI runner (requires `codex` in PATH + OPENAI_API_KEY):
+ *   bun workflow.ts --runner codex
+ *
+ * Run with a mock (no credentials needed):
+ *   AGENTFLOW_MOCK=1 bun workflow.ts --runner api
+ */
+
+import { defineWorkflow, registerRunner } from "@ageflow/core";
+import { auditAgent } from "./agents/audit.js";
+
+// ─── Parse --runner flag ───────────────────────────────────────────────────────
+
+const runnerArg = process.argv.find((a) => a.startsWith("--runner="))?.slice(9)
+  ?? process.argv[process.argv.indexOf("--runner") + 1];
+
+const VALID_RUNNERS = ["api", "claude", "codex"] as const;
+type RunnerKind = (typeof VALID_RUNNERS)[number];
+
+function parseRunner(raw: string | undefined): RunnerKind {
+  if (raw !== undefined && (VALID_RUNNERS as readonly string[]).includes(raw)) {
+    return raw as RunnerKind;
+  }
+  console.error(
+    `Usage: bun workflow.ts --runner <api|claude|codex>\nDefaulting to "api".`,
+  );
+  return "api";
+}
+
+const runner = parseRunner(runnerArg);
+
+// ─── Register runner ──────────────────────────────────────────────────────────
+
+if (runner === "api") {
+  const { ApiRunner } = await import("@ageflow/runner-api");
+  const fetchImpl =
+    process.env.AGENTFLOW_MOCK === "1"
+      ? (await import("./__mocks__/fetch-mock.js")).mockFetch
+      : undefined;
+  registerRunner(
+    "api",
+    new ApiRunner({
+      baseUrl: process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+      apiKey: process.env.OPENAI_API_KEY ?? "mock-key",
+      defaultModel: "gpt-4o-mini",
+      ...(fetchImpl ? { fetch: fetchImpl } : {}),
+    }),
+  );
+} else if (runner === "claude") {
+  const { ClaudeRunner } = await import("@ageflow/runner-claude");
+  registerRunner("claude", new ClaudeRunner());
+} else {
+  const { CodexRunner } = await import("@ageflow/runner-codex");
+  registerRunner("codex", new CodexRunner());
+}
+
+// ─── Workflow ─────────────────────────────────────────────────────────────────
+//
+// Single `audit` task — the agent is re-created with the selected runner so the
+// DSL type flows through correctly. The MCP config and I/O schemas are identical
+// across all three runner variants.
+
+export const workflow = defineWorkflow({
+  name: "agent-uses-mcp-demo",
+  tasks: {
+    audit: {
+      agent: auditAgent(runner),
+      input: { root: "/tmp/workdir" },
+    },
+  },
+});
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  const { WorkflowExecutor } = await import("@ageflow/executor");
+  const executor = new WorkflowExecutor(workflow);
+  const result = await executor.run({});
+  console.log(JSON.stringify(result.outputs, null, 2));
+}

--- a/agentflow/examples/agent-uses-mcp/workflow.ts
+++ b/agentflow/examples/agent-uses-mcp/workflow.ts
@@ -22,8 +22,9 @@ import { auditAgent } from "./agents/audit.js";
 
 // ─── Parse --runner flag ───────────────────────────────────────────────────────
 
-const runnerArg = process.argv.find((a) => a.startsWith("--runner="))?.slice(9)
-  ?? process.argv[process.argv.indexOf("--runner") + 1];
+const runnerArg =
+  process.argv.find((a) => a.startsWith("--runner="))?.slice(9) ??
+  process.argv[process.argv.indexOf("--runner") + 1];
 
 const VALID_RUNNERS = ["api", "claude", "codex"] as const;
 type RunnerKind = (typeof VALID_RUNNERS)[number];


### PR DESCRIPTION
Adds \`examples/agent-uses-mcp/\` per Phase 9 of [plan](docs/superpowers/plans/2026-04-16-agents-use-mcp.md#phase-9--dogfooding-example-examplesagent-uses-mcp).

## What

- \`agents/audit.ts\` — \`auditAgent(runner: "api" | "claude" | "codex")\` showing the exact same MCP config across all three runners
- \`workflow.ts\` — workflow + CLI entry (\`bun workflow.ts --runner <api|claude|codex>\`)
- \`__mocks__/fetch-mock.ts\` — mock harness for \`AGENTFLOW_MOCK=1\` local runs
- \`__tests__/workflow.test.ts\` — 8 tests (api runner mock, agent shape across runners, workflow graph shape)
- \`README.md\` — how to run

## Tests

23/23 packages typecheck. **8 new tests passing** in the example package.

## Demo runnability

\`bun run demo:api\` requires \`@modelcontextprotocol/server-filesystem\` installed globally and real API credentials. In test context, the mock harness fully bypasses MCP subprocess and HTTP. README documents both paths.

Closes part of #19.