### PR TITLE
chore(release): #19 Phase 11 — bump versions 0.2.0 → 0.3.0 for MCP integration

### DIFF
--- a/agentflow/CLAUDE.md
+++ b/agentflow/CLAUDE.md
@@ -32,3 +32,4 @@ executor ← server
 ## Phase 1 complete: @agentflow/core
 ## Phases 2-6: executor, runners, testing, CLI, examples
 ## Phase 7+: @ageflow/server (#26)
+## Phase 7: agents use MCP servers (#19) — MCP integration across all 3 runners, API runner in-process MCP client; new `@modelcontextprotocol/sdk` runtime dep on `@ageflow/runner-api` and `@ageflow/testing`

--- a/agentflow/packages/cli/package.json
+++ b/agentflow/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/cli",
   "type": "module",

--- a/agentflow/packages/core/package.json
+++ b/agentflow/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/core",
   "type": "module",

--- a/agentflow/packages/executor/package.json
+++ b/agentflow/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/executor",
   "type": "module",

--- a/agentflow/packages/mcp-server/package.json
+++ b/agentflow/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Expose ageflow workflows as MCP tools (stdio transport, progress streaming, HITL via elicitation).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/mcp-server",
   "type": "module",

--- a/agentflow/packages/runners/api/package.json
+++ b/agentflow/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/api",
   "type": "module",

--- a/agentflow/packages/runners/claude/package.json
+++ b/agentflow/packages/runners/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-claude",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/claude",
   "type": "module",

--- a/agentflow/packages/runners/codex/package.json
+++ b/agentflow/packages/runners/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-codex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenAI Codex CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/runners/codex",
   "type": "module",

--- a/agentflow/packages/server/package.json
+++ b/agentflow/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Embeddable execution surface for ageflow workflows: stream, fire-and-forget, async HITL, cancellation.",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/server",
   "type": "module",

--- a/agentflow/packages/testing/package.json
+++ b/agentflow/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/agentflow/packages/testing",
   "type": "module",


### PR DESCRIPTION
Per Phase 11 of [plan](docs/superpowers/plans/2026-04-16-agents-use-mcp.md#phase-11--publish-prep). Version bump only — no publish.

## Changes

- All 9 workspace packages: 0.2.0 → 0.3.0 (minor — new feature: MCP integration in runners + DSL, non-breaking)
- Inter-package deps: unchanged (all use \`workspace:*\` protocol)
- \`agentflow/CLAUDE.md\`: Phase 7 line noting MCP integration across all 3 runners + new \`@modelcontextprotocol/sdk\` dep on runner-api + testing

## Checks

- \`bun install\`: clean
- \`bun run typecheck\`: 23/23 tasks pass
- \`bun run test\`: **561 tests passing**, 2 skipped, 0 failures
- \`bun run lint\`: 0 errors (24 pre-existing warnings)

## Out of scope

- \`npm publish\` — separate ops step after merge
- Phase 7 auto-shutdown lifecycle — blocked on #75 (process-vs-workflow scoped decision)

Closes part of #19.