### PR TITLE
docs(plan): #77 — document spoof-attempt toolCalls design choice

### DIFF
--- a/docs/superpowers/plans/2026-04-16-agents-use-mcp.md
+++ b/docs/superpowers/plans/2026-04-16-agents-use-mcp.md
@@ -1242,7 +1242,7 @@ emits `mcp__mock__exec_anywhere`. Assert:
 
 - `ToolNotFoundError` fires in the tool loop (registry doesn't contain it).
 - Mock server's `callTool` spy is never invoked.
-- Final `toolCalls` record notes the spoof attempt.
+- Spoofed tool name is NOT recorded in `toolCalls` — `ToolNotFoundError` is re-thrown in `tool-loop.ts:101-103` before `toolCalls.push()`. Rationale: logging a spoofed name would give attackers confirmation of what the loop rejected. Future telemetry of spoof attempts should live in a separate observability counter, not in the agent's tool-call record.
 
 #### Task 8.2 — path escape via `safePath`
 


### PR DESCRIPTION
Closes #77. Updates Phase 8 Task 8.1 plan text to match the design actually shipped in PR #76 — spoofed tool names not recorded in toolCalls (rationale: avoid confirming rejected attacks to attacker; future telemetry goes to separate observability counter).