### PR TITLE
fix(core/executor): #84 — workflowMcpServers threading, schema refine, FQN underscore parsing

### DIFF
--- a/agentflow/packages/core/src/__tests__/mcp-allowlist.test.ts
+++ b/agentflow/packages/core/src/__tests__/mcp-allowlist.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { filterMcpTools, isMcpToolPermitted } from "../mcp-allowlist.js";
+import {
+  filterMcpTools,
+  isMcpToolPermitted,
+  parseMcpToolFqn,
+} from "../mcp-allowlist.js";
 
 describe("filterMcpTools (pre-dispatch)", () => {
   it("returns all tools when server.tools is undefined", () => {
@@ -27,5 +31,38 @@ describe("isMcpToolPermitted (post-dispatch)", () => {
     const srv = { name: "fs", command: "x", tools: ["read"] } as const;
     expect(isMcpToolPermitted(srv, "read")).toBe(true);
     expect(isMcpToolPermitted(srv, "write")).toBe(false);
+  });
+});
+
+describe("parseMcpToolFqn", () => {
+  it("parses a simple server name without underscores", () => {
+    expect(parseMcpToolFqn("mcp__simple__tool")).toEqual({
+      server: "simple",
+      tool: "tool",
+    });
+  });
+
+  it("parses server names containing underscores (#84 regression)", () => {
+    expect(parseMcpToolFqn("mcp__github_enterprise__list_issues")).toEqual({
+      server: "github_enterprise",
+      tool: "list_issues",
+    });
+  });
+
+  it("parses server names with many underscores", () => {
+    expect(
+      parseMcpToolFqn("mcp__server_with_many_underscores__tool_name_here"),
+    ).toEqual({
+      server: "server_with_many_underscores",
+      tool: "tool_name_here",
+    });
+  });
+
+  it("returns undefined for non-MCP names", () => {
+    expect(parseMcpToolFqn("not_an_fqn")).toBeUndefined();
+  });
+
+  it("returns undefined for strings missing the mcp__ prefix", () => {
+    expect(parseMcpToolFqn("github_enterprise__list_issues")).toBeUndefined();
   });
 });

--- a/agentflow/packages/core/src/__tests__/mcp-server-config.test.ts
+++ b/agentflow/packages/core/src/__tests__/mcp-server-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { McpServerConfigSchema } from "../schemas.js";
 
 describe("McpServerConfigSchema", () => {
@@ -44,5 +45,23 @@ describe("McpServerConfigSchema", () => {
     expect(() =>
       McpServerConfigSchema.parse({ name: "x", command: "" }),
     ).toThrow();
+  });
+
+  it("accepts a refine map with Zod schema values (#84)", () => {
+    const result = McpServerConfigSchema.safeParse({
+      name: "filesystem",
+      command: "npx",
+      refine: { tool_name: z.object({ path: z.string() }) },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts refine as an empty object", () => {
+    const result = McpServerConfigSchema.safeParse({
+      name: "filesystem",
+      command: "npx",
+      refine: {},
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/agentflow/packages/core/src/mcp-allowlist.ts
+++ b/agentflow/packages/core/src/mcp-allowlist.ts
@@ -34,7 +34,7 @@ export function mcpToolFqn(serverName: string, toolName: string): string {
 export function parseMcpToolFqn(
   fqn: string,
 ): { server: string; tool: string } | undefined {
-  const m = fqn.match(/^mcp__([^_]+)__(.+)$/);
+  const m = fqn.match(/^mcp__(.+?)__(.+)$/);
   if (!m || m[1] === undefined || m[2] === undefined) return undefined;
   return { server: m[1], tool: m[2] };
 }

--- a/agentflow/packages/core/src/schemas.ts
+++ b/agentflow/packages/core/src/schemas.ts
@@ -256,7 +256,8 @@ export const McpServerConfigSchema = z
     env: z.record(z.string(), z.string()).optional(),
     cwd: z.string().optional(),
     tools: z.array(z.string()).readonly().optional(),
-    // refine is a runtime ZodType map — not Zod-validated itself (opaque)
+    // refine is a map of tool-name → ZodType — opaque at runtime, not recursively validated
+    refine: z.record(z.string(), z.unknown()).optional(),
     transport: z.literal("stdio").optional(),
     mcpCallTimeoutMs: z.number().int().positive().optional(),
     reusePerRunner: z.boolean().optional(),

--- a/agentflow/packages/executor/src/__tests__/workflow-executor.test.ts
+++ b/agentflow/packages/executor/src/__tests__/workflow-executor.test.ts
@@ -282,6 +282,56 @@ describe("WorkflowExecutor", () => {
     expect(receivedHandles[1]).toBe("session-handle-from-A");
   });
 
+  it("workflow mcpServers threaded to runNode: task with mcpOverride resolves without 'unknown server' error (#84)", async () => {
+    // Capture spawn args to verify mcpServers were forwarded
+    let capturedSpawnArgs: import("@ageflow/core").RunnerSpawnArgs | undefined;
+
+    const mockRunner: import("@ageflow/core").Runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn(async (args) => {
+        capturedSpawnArgs = args;
+        return {
+          stdout: JSON.stringify({ result: "ok" }),
+          sessionHandle: "s1",
+          tokensIn: 5,
+          tokensOut: 5,
+        };
+      }),
+    };
+    registerRunner("mock-mcp-wf", mockRunner);
+
+    const mcpAgent = defineAgent({
+      runner: "mock-mcp-wf",
+      input: z.object({ value: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ value }) => `Process: ${value}`,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const workflow = defineWorkflow({
+      name: "test-workflow-mcp",
+      mcpServers: [{ name: "fs", command: "npx" }],
+      tasks: {
+        taskA: {
+          agent: mcpAgent,
+          input: { value: "hello" },
+          mcpOverride: { servers: ["fs"] },
+        },
+      },
+    });
+
+    // Before the fix this would throw:
+    //   "Task mcpOverride references unknown server 'fs'. Available servers: []"
+    // because workflowMcpServers was not passed to runNode.
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).resolves.toBeDefined();
+
+    // Verify the resolved MCP server was forwarded to the runner spawn args
+    expect(capturedSpawnArgs?.mcpServers).toEqual([
+      expect.objectContaining({ name: "fs" }),
+    ]);
+  });
+
   it("returns correct metrics with taskCount = number of agent tasks", async () => {
     const workflow = defineWorkflow({
       name: "test-metrics",

--- a/agentflow/packages/executor/src/workflow-executor.ts
+++ b/agentflow/packages/executor/src/workflow-executor.ts
@@ -363,6 +363,8 @@ export class WorkflowExecutor<T extends TasksMap> {
                 sessionHandle,
                 permissions ?? undefined,
                 filteredTools,
+                undefined,
+                this.workflow.mcpServers,
               );
 
               const latencyMs = Date.now() - taskStart;
@@ -621,6 +623,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                     reason,
                   });
                 },
+                this.workflow.mcpServers,
               );
 
               const latencyMs = Date.now() - taskStart;


### PR DESCRIPTION
Three small bugs from issue #84 (items 4, 5, 6).

## Bugs fixed

- **#84 item 4 (P1)** — \`packages/executor/src/workflow-executor.ts\` — both \`runNode(...)\` call sites now pass \`this.workflow.mcpServers\` as the \`workflowMcpServers\` argument. Before: workflow-level MCP servers silently ignored by runners; \`task.mcpOverride\` referencing workflow servers threw \`unknown server\` at runtime despite preflight acceptance.
- **#84 item 5 (P2)** — \`packages/core/src/schemas.ts\` — added \`refine\` field to \`McpServerConfigSchema\`. Previously the strict schema rejected any config with \`refine: { ... }\` despite the TypeScript type declaring it.
- **#84 item 6 (P2)** — \`packages/core/src/mcp-allowlist.ts\` — \`parseMcpToolFqn\` regex changed from \`/^mcp__([^_]+)__(.+)$/\` to \`/^mcp__(.+?)__(.+)$/\` (non-greedy) so server names containing \`_\` (e.g., \`github_enterprise\`) parse correctly.

## Tests

- core: **151 → 158** (+7 — 5 FQN cases, 2 refine schema cases)
- executor: **162 → 163** (+1 — workflow.mcpServers threading)

Closes part of #84.