### PR TITLE
fix: #84 items 8 + 14 — runner-api version sync + example safePath alignment

### DIFF
--- a/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
+++ b/agentflow/examples/agent-uses-mcp/__tests__/workflow.test.ts
@@ -17,7 +17,7 @@ import { workflow } from "../workflow.js";
 
 // ─── Helper ───────────────────────────────────────────────────────────────────
 
-const MOCK_OUTPUT = { summary: "Found 3 files in /tmp/workdir.", fileCount: 3 };
+const MOCK_OUTPUT = { summary: "Found 3 files in .", fileCount: 3 };
 
 // ─── Main workflow (imported — uses default "api" runner) ─────────────────────
 
@@ -54,7 +54,7 @@ describe.each([["api" as const], ["claude" as const], ["codex" as const]])(
         tasks: {
           audit: {
             agent: auditAgent(r),
-            input: { root: "/tmp/workdir" },
+            input: { root: "." },
           },
         },
       });

--- a/agentflow/examples/agent-uses-mcp/agents/audit.ts
+++ b/agentflow/examples/agent-uses-mcp/agents/audit.ts
@@ -23,11 +23,7 @@ export function auditAgent(runner: "claude" | "codex" | "api") {
         {
           name: "filesystem",
           command: "npx",
-          args: [
-            "-y",
-            "@modelcontextprotocol/server-filesystem",
-            ".",
-          ],
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
           tools: ["read_file", "list_directory"],
           refine: {
             read_file: z.object({ path: safePath() }),

--- a/agentflow/examples/agent-uses-mcp/agents/audit.ts
+++ b/agentflow/examples/agent-uses-mcp/agents/audit.ts
@@ -26,7 +26,7 @@ export function auditAgent(runner: "claude" | "codex" | "api") {
           args: [
             "-y",
             "@modelcontextprotocol/server-filesystem",
-            "/tmp/workdir",
+            ".",
           ],
           tools: ["read_file", "list_directory"],
           refine: {

--- a/agentflow/examples/agent-uses-mcp/workflow.ts
+++ b/agentflow/examples/agent-uses-mcp/workflow.ts
@@ -77,7 +77,7 @@ export const workflow = defineWorkflow({
   tasks: {
     audit: {
       agent: auditAgent(runner),
-      input: { root: "/tmp/workdir" },
+      input: { root: "." },
     },
   },
 });

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "@ageflow/core";
 import { spawnMockMcpServer } from "@ageflow/testing";
 import { describe, expect, it, vi } from "vitest";
+import pkg from "../../package.json";
 import {
   McpServerStartFailedError,
   McpToolCallFailedError,
@@ -8,7 +9,6 @@ import {
   startMcpClients,
 } from "../mcp-client.js";
 import { RUNNER_VERSION } from "../types.js";
-import pkg from "../../package.json";
 
 // Helper: wait for a number of milliseconds
 function delay(ms: number): Promise<void> {

--- a/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/mcp-client.test.ts
@@ -7,6 +7,8 @@ import {
   shutdownAll,
   startMcpClients,
 } from "../mcp-client.js";
+import { RUNNER_VERSION } from "../types.js";
+import pkg from "../../package.json";
 
 // Helper: wait for a number of milliseconds
 function delay(ms: number): Promise<void> {
@@ -216,6 +218,14 @@ describe("startMcpClients logger (issue #71)", () => {
         },
       ]),
     ).rejects.toThrow(McpServerStartFailedError);
+  });
+});
+
+// ─── Issue #84 item 8: MCP Client version matches package.json ───────────────
+
+describe("RUNNER_VERSION (issue #84 item 8)", () => {
+  it("matches the version field in package.json", () => {
+    expect(RUNNER_VERSION).toBe(pkg.version);
   });
 });
 

--- a/agentflow/packages/runners/api/src/mcp-client.ts
+++ b/agentflow/packages/runners/api/src/mcp-client.ts
@@ -16,6 +16,7 @@ import { AgentFlowError } from "@ageflow/core";
 import type { Logger, McpServerConfig, McpToolDescriptor } from "@ageflow/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { RUNNER_VERSION } from "./types.js";
 
 export type { McpToolDescriptor };
 
@@ -254,7 +255,7 @@ async function startOne(
   });
 
   const sdkClient = new Client(
-    { name: "ageflow-runner-api", version: "0.2.0" },
+    { name: "ageflow-runner-api", version: RUNNER_VERSION },
     { capabilities: {} },
   );
 

--- a/agentflow/packages/runners/api/src/types.ts
+++ b/agentflow/packages/runners/api/src/types.ts
@@ -4,6 +4,12 @@ export type { SessionStore } from "./session-store.js";
 export type { ToolCallRecord } from "@ageflow/core";
 export type { Logger };
 
+/**
+ * Package version — keep in sync with package.json.
+ * Used as the MCP Client `version` in the protocol handshake.
+ */
+export const RUNNER_VERSION = "0.3.0" as const;
+
 export interface ToolDefinition {
   /** Human-readable description surfaced to the model. */
   description: string;


### PR DESCRIPTION
Two small fixes from issue #84.

## Item 8 (P2) — runner-api MCP Client version in sync

\`packages/runners/api/src/mcp-client.ts\` hardcoded \`version: \"0.2.0\"\` in the MCP Client handshake. Now reads from a \`RUNNER_VERSION\` constant kept in sync with \`package.json\` (currently \`0.3.0\`).

Test asserts \`RUNNER_VERSION === pkg.version\` so future bumps fail the test if the constant isn't updated.

## Item 14 (P2) — agent-uses-mcp example root path

The demo hardcoded \`root: \"/tmp/workdir\"\` (absolute path), but \`auditAgent\` validates paths with \`safePath({ allowAbsolute: false })\` — model was pushed toward absolute paths that got rejected as \`mcp_tool_arg_invalid\`.

Changed to \`root: \".\"\` (relative) in both \`workflow.ts\` and \`agents/audit.ts\`; test mock output updated accordingly.

## Checks

- Typecheck: PASS (23/23)
- runner-api: 55 passing
- example-agent-uses-mcp: 8 passing

Note on item 8: used a \`RUNNER_VERSION\` constant instead of JSON import because repo-wide \`tsconfig.base.json\` lacks \`resolveJsonModule: true\`. Opt'd for minimum-diff over tsconfig change. Follow-up could switch to JSON import once \`resolveJsonModule\` is enabled repo-wide.

Closes part of #84.