### PR TITLE
fix: #84 items 12 + 15 — reserve async observer tool names + document direct env

### DIFF
--- a/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
@@ -1,9 +1,9 @@
 import { defineAgent, defineWorkflow } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { ErrorCode } from "../../errors.js";
 import type { McpToolResult } from "../../server.js";
 import { ASYNC_OBSERVER_TOOL_NAMES, createMcpServer } from "../../server.js";
-import { ErrorCode } from "../../errors.js";
 
 const agent = defineAgent({
   runner: "fake",
@@ -287,7 +287,12 @@ describe("async mode: reserved tool name guard (#84 item 12)", () => {
         tasks: { t: { agent: ag, input: { q: "hi" } } },
       });
       expect(() =>
-        createMcpServer({ workflow: wf, cliCeilings: {}, hitlStrategy: "auto", async: true }),
+        createMcpServer({
+          workflow: wf,
+          cliCeilings: {},
+          hitlStrategy: "auto",
+          async: true,
+        }),
       ).toThrow(/conflicts with a reserved async observer tool name/);
     },
   );
@@ -304,7 +309,12 @@ describe("async mode: reserved tool name guard (#84 item 12)", () => {
       tasks: { t: { agent: ag, input: { q: "hi" } } },
     });
     expect(() =>
-      createMcpServer({ workflow: wf, cliCeilings: {}, hitlStrategy: "auto", async: false }),
+      createMcpServer({
+        workflow: wf,
+        cliCeilings: {},
+        hitlStrategy: "auto",
+        async: false,
+      }),
     ).not.toThrow();
   });
 

--- a/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
@@ -2,7 +2,8 @@ import { defineAgent, defineWorkflow } from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import type { McpToolResult } from "../../server.js";
-import { createMcpServer } from "../../server.js";
+import { ASYNC_OBSERVER_TOOL_NAMES, createMcpServer } from "../../server.js";
+import { ErrorCode } from "../../errors.js";
 
 const agent = defineAgent({
   runner: "fake",
@@ -245,5 +246,76 @@ describe("async mode: ASYNC_MODE_DISABLED (#18)", () => {
     if (res.isError) {
       expect(res.structuredContent.errorCode).toBe("ASYNC_MODE_DISABLED");
     }
+  });
+});
+
+describe("async mode: reserved tool name guard (#84 item 12)", () => {
+  it("throws RESERVED_TOOL_NAME when workflow is named get_workflow_status in async mode", () => {
+    const reservedAgent = defineAgent({
+      runner: "fake",
+      input: z.object({ q: z.string() }),
+      output: z.object({ a: z.string() }),
+      prompt: () => "p",
+    });
+    const reservedWorkflow = defineWorkflow({
+      name: "get_workflow_status",
+      tasks: { t: { agent: reservedAgent, input: { q: "hi" } } },
+    });
+    expect(() =>
+      createMcpServer({
+        workflow: reservedWorkflow,
+        cliCeilings: {},
+        hitlStrategy: "auto",
+        async: true,
+      }),
+    ).toThrow(
+      /Workflow name "get_workflow_status" conflicts with a reserved async observer tool name/,
+    );
+  });
+
+  it.each(ASYNC_OBSERVER_TOOL_NAMES)(
+    "throws for each reserved observer name: %s",
+    (reservedName) => {
+      const ag = defineAgent({
+        runner: "fake",
+        input: z.object({ q: z.string() }),
+        output: z.object({ a: z.string() }),
+        prompt: () => "p",
+      });
+      const wf = defineWorkflow({
+        name: reservedName,
+        tasks: { t: { agent: ag, input: { q: "hi" } } },
+      });
+      expect(() =>
+        createMcpServer({ workflow: wf, cliCeilings: {}, hitlStrategy: "auto", async: true }),
+      ).toThrow(/conflicts with a reserved async observer tool name/);
+    },
+  );
+
+  it("does NOT throw when async is false, even with a reserved name", () => {
+    const ag = defineAgent({
+      runner: "fake",
+      input: z.object({ q: z.string() }),
+      output: z.object({ a: z.string() }),
+      prompt: () => "p",
+    });
+    const wf = defineWorkflow({
+      name: "get_workflow_status",
+      tasks: { t: { agent: ag, input: { q: "hi" } } },
+    });
+    expect(() =>
+      createMcpServer({ workflow: wf, cliCeilings: {}, hitlStrategy: "auto", async: false }),
+    ).not.toThrow();
+  });
+
+  it("does NOT throw for a normal workflow name in async mode", () => {
+    expect(() =>
+      createMcpServer({
+        workflow,
+        cliCeilings: {},
+        hitlStrategy: "auto",
+        async: true,
+      }),
+    ).not.toThrow();
   });
 });

--- a/agentflow/packages/mcp-server/src/errors.ts
+++ b/agentflow/packages/mcp-server/src/errors.ts
@@ -25,6 +25,7 @@ export const ErrorCode = {
   JOB_CANCELLED: "JOB_CANCELLED",
   INVALID_RUN_STATE: "INVALID_RUN_STATE",
   ASYNC_MODE_DISABLED: "ASYNC_MODE_DISABLED",
+  RESERVED_TOOL_NAME: "RESERVED_TOOL_NAME",
 } as const;
 
 export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -8,6 +8,17 @@ import {
   type McpToolErrorResult,
   formatErrorResult,
 } from "./errors.js";
+
+/**
+ * Tool names reserved by the async job observer layer.
+ * Workflow names must not collide with these — see `createMcpServer`.
+ */
+export const ASYNC_OBSERVER_TOOL_NAMES = [
+  "get_workflow_status",
+  "get_workflow_result",
+  "cancel_workflow",
+  "resume_workflow",
+] as const;
 import { type McpConnectionLike, buildMcpHooks } from "./hitl-bridge.js";
 import {
   type JobDispatchContext,
@@ -90,6 +101,23 @@ export interface McpServerHandle {
  * directly without the transport.
  */
 export function createMcpServer(opts: McpServerOptions): McpServerHandle {
+  // Guard: in async mode the observer tools own fixed names. If the workflow
+  // uses one of those names it would be unreachable (shadowed by observer
+  // dispatch) and listTools would surface duplicates.
+  if (opts.async === true) {
+    const reserved = new Set<string>(ASYNC_OBSERVER_TOOL_NAMES);
+    const wfName = opts.workflow.name;
+    const startName = `start_${wfName}`;
+    if (reserved.has(wfName) || reserved.has(startName)) {
+      throw new McpServerError(
+        ErrorCode.RESERVED_TOOL_NAME,
+        `Workflow name "${wfName}" conflicts with a reserved async observer tool name. ` +
+          `Reserved names: ${[...ASYNC_OBSERVER_TOOL_NAMES].join(", ")}`,
+        { workflowName: wfName, reserved: [...ASYNC_OBSERVER_TOOL_NAMES] },
+      );
+    }
+  }
+
   const resolved = resolveMcpConfig(opts.workflow.mcp);
   const stderr =
     opts.stderr ??

--- a/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
+++ b/agentflow/packages/runners/api/src/mcp-tool-adapter.ts
@@ -110,7 +110,8 @@ function buildToolDefinition(
         if (
           refineSchema === null ||
           typeof refineSchema !== "object" ||
-          typeof (refineSchema as { safeParse?: unknown }).safeParse !== "function"
+          typeof (refineSchema as { safeParse?: unknown }).safeParse !==
+            "function"
         ) {
           throw new McpToolArgInvalidError(
             toolName,

--- a/agentflow/packages/runners/api/src/types.ts
+++ b/agentflow/packages/runners/api/src/types.ts
@@ -21,6 +21,19 @@ export interface ToolDefinition {
 
 export type ToolRegistry = Record<string, ToolDefinition>;
 
+/**
+ * Configuration for ApiRunner.
+ *
+ * **Direct-caller env note:** When `ApiRunner.spawn` is called directly (outside
+ * the workflow executor), `${env:VAR}` placeholders in `mcpServers[].env` are
+ * passed VERBATIM to subprocess env — they are NOT expanded. The workflow
+ * executor handles expansion via `expandServerEnv` before calling `spawn`; if
+ * you bypass it, you must pre-expand placeholders yourself or the MCP server
+ * will receive literal strings like `${env:API_KEY}`.
+ *
+ * @see PR #82 — removed the second `${env:VAR}` expansion pass from
+ * `mcp-client.ts`; direct callers are now solely responsible for expansion.
+ */
 export interface ApiRunnerConfig {
   /** e.g. "https://api.openai.com/v1" — no trailing slash. */
   baseUrl: string;


### PR DESCRIPTION
Two small items from issue #84.

## Item 12 (P2) — Reserve async observer tool names

**Bug:** In async mode, observer dispatch runs before sync workflow dispatch. If a workflow is literally named \`get_workflow_status\`, \`get_workflow_result\`, \`resume_workflow\`, or \`cancel_workflow\`, its tool is unreachable and \`listTools\` shows duplicates.

**Fix (Option A):** Added \`ASYNC_OBSERVER_TOOL_NAMES\` export + startup guard in \`createMcpServer\` that throws \`McpServerError(RESERVED_TOOL_NAME, ...)\` when \`async: true\` and workflow name collides. Reserved names rejected early with a clear error.

7 new tests (reserved-name collision for each, sync-mode bypass, happy path).

## Item 15 (P2) — Document direct-caller env template behavior

**Bug:** PR #82 removed the second \`\${env:VAR}\` expansion pass in \`mcp-client.ts\`, so direct \`ApiRunner.spawn\` callers (bypassing executor) now get literal placeholders. Not documented.

**Fix:** Added JSDoc note on \`ApiRunnerConfig\` in \`packages/runners/api/src/types.ts\` explaining the behavior and required pre-expansion.

## Tests

- mcp-server: **86 → 93 passing** (+7)
- Typecheck: PASS

Closes part of #84.