### PR TITLE
fix: #87 forbid '__' in MCP server names + #89 stale /tmp/workdir refs

### DIFF
--- a/agentflow/examples/agent-uses-mcp/README.md
+++ b/agentflow/examples/agent-uses-mcp/README.md
@@ -49,7 +49,7 @@ AGENTFLOW_MOCK=1 bun run demo:api
 each runner that supports subprocess MCP servers.
 
 The server exposes `read_file` and `list_directory` tools scoped to
-`/tmp/workdir`. AgentFlow applies a `safePath()` Zod refinement on both tools'
+`.` (current working directory). AgentFlow applies a `safePath()` Zod refinement on both tools'
 `path` argument before the call is dispatched, blocking:
 
 - path traversal (`../`)
@@ -69,7 +69,7 @@ model — all others are filtered before reaching the prompt.
 | `tools: ["read_file", "list_directory"]` | Tool allowlist — any tool not listed is denied before it reaches the model |
 | `refine: { read_file: z.object({ path: safePath() }), ... }` | Per-argument Zod refinement run before each tool call; rejects traversal, absolute paths, env vars |
 | `sanitizeInput: true` (default) | Strips prompt-injection patterns from upstream agent outputs before interpolation |
-| Subprocess scoping | The filesystem server is started with `/tmp/workdir` as its root — it cannot serve files outside that directory |
+| Subprocess scoping | The filesystem server is started with `.` (current working directory) as its root — it cannot serve files outside that directory |
 
 ---
 

--- a/agentflow/examples/agent-uses-mcp/__mocks__/fetch-mock.ts
+++ b/agentflow/examples/agent-uses-mcp/__mocks__/fetch-mock.ts
@@ -17,7 +17,7 @@ export function mockFetch(
         message: {
           role: "assistant",
           content: JSON.stringify({
-            summary: "Found 3 files in /tmp/workdir via filesystem MCP.",
+            summary: "Found 3 files in .",
             fileCount: 3,
           }),
         },

--- a/agentflow/packages/core/src/__tests__/mcp-server-config.test.ts
+++ b/agentflow/packages/core/src/__tests__/mcp-server-config.test.ts
@@ -31,6 +31,25 @@ describe("McpServerConfigSchema", () => {
     ).toThrow();
   });
 
+  it("rejects names containing '__' (FQN delimiter)", () => {
+    const result = McpServerConfigSchema.safeParse({
+      name: "a__b",
+      command: "x",
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error)).toContain(
+      "MCP server name cannot contain '__' (reserved as FQN delimiter)",
+    );
+  });
+
+  it("accepts single-underscore names like 'github_enterprise'", () => {
+    const result = McpServerConfigSchema.safeParse({
+      name: "github_enterprise",
+      command: "npx",
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects unknown transport values", () => {
     expect(() =>
       McpServerConfigSchema.parse({

--- a/agentflow/packages/core/src/schemas.ts
+++ b/agentflow/packages/core/src/schemas.ts
@@ -250,6 +250,10 @@ export const McpServerConfigSchema = z
       .refine((v) => STATIC_IDENTIFIER_RE_SCHEMA.test(v), {
         message:
           "MCP server name must match /^[a-zA-Z0-9._-]+$/ (no path separators)",
+      })
+      .refine((v) => !v.includes("__"), {
+        message:
+          "MCP server name cannot contain '__' (reserved as FQN delimiter)",
       }),
     command: z.string().min(1, "command must not be empty"),
     args: z.array(z.string()).readonly().optional(),


### PR DESCRIPTION
Two small backlog cleanups.

## #87 — Forbid \`__\` in MCP server names

Server names with \`__\` (e.g., \`a__b\`) create parse ambiguity with the FQN format \`mcp__<server>__<tool>\`. Added a \`.refine()\` on \`McpServerConfigSchema.name\` rejecting any \`__\` substring.

2 new core tests: rejects \`a__b\` with clear error; still accepts single-underscore names like \`github_enterprise\`.

## #89 — Stale /tmp/workdir refs in agent-uses-mcp

- \`examples/agent-uses-mcp/README.md\` — 2 mentions of "\`/tmp/workdir\`" → "\`.\` (current working directory)"
- \`examples/agent-uses-mcp/__mocks__/fetch-mock.ts\` — \`"Found 3 files in /tmp/workdir..."\` → \`"Found 3 files in ."\`

Cosmetic alignment with PR #88.

## Checks

- Core: **158 → 160** tests passing (+2)
- Typecheck: PASS

Closes #87 #89.