### PR TITLE
fix(mcp-server): #84 item 11 — apply ceilings + HITL on async path

### DIFF
--- a/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
+++ b/agentflow/packages/mcp-server/src/__tests__/integration/async-mode.test.ts
@@ -4,7 +4,11 @@ import {
   registerRunner,
   unregisterRunner,
 } from "@ageflow/core";
-import type { RunnerSpawnArgs, RunnerSpawnResult } from "@ageflow/core";
+import type {
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  WorkflowDef,
+} from "@ageflow/core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { ErrorCode } from "../../errors.js";
@@ -485,6 +489,129 @@ describe("async mode: input injection (#84 item 10)", () => {
         expect(output.a).toBe("hello, Charlie!");
       }
     } finally {
+      h.dispose?.();
+    }
+  });
+});
+
+describe("async mode: ceiling + HITL composition (#84 item 11)", () => {
+  /**
+   * Verifies that the async path applies composeCeilings before calling
+   * runner.fire(). With cliCeilings: { maxCostUsd: 0.1 }, the composed workflow
+   * must have budget.maxCost === 0.1.
+   *
+   * Uses _testOnComposedWorkflow to capture the workflow passed to runner.fire()
+   * without needing to intercept the executor itself.
+   */
+  it("CLI ceiling override flows through to the composed workflow on the async path", async () => {
+    const h = createMcpServer({
+      workflow,
+      cliCeilings: { maxCostUsd: 0.1 },
+      hitlStrategy: "auto",
+      async: true,
+    });
+
+    let captured: WorkflowDef | undefined;
+    h._testOnComposedWorkflow = (wf) => {
+      captured = wf;
+    };
+    h._testRunExecutor = async () => ({ a: "ok" });
+
+    const startRes = await h.callTool("start_ask", { q: "hello" });
+    expect(startRes.isError).toBe(false);
+
+    // _testOnComposedWorkflow is called synchronously during start, before fire()
+    // returns, so `captured` is available immediately after callTool resolves.
+    expect(captured).toBeDefined();
+    expect(captured?.budget).toBeDefined();
+    // CLI override of 0.1 must be present in the composed workflow's budget.
+    expect(captured?.budget?.maxCost).toBe(0.1);
+
+    h.dispose?.();
+  });
+
+  /**
+   * Verifies that the async path respects the HITL strategy ("fail") by wiring
+   * an onCheckpoint resolver into runner.fire(). With hitlStrategy: "fail", any
+   * checkpoint encountered during execution must be rejected, causing the run
+   * to fail.
+   *
+   * Uses a real workflow with hitl: { mode: "checkpoint" } on the agent so the
+   * executor actually fires a checkpoint event during task execution.
+   */
+  it("hitlStrategy 'fail' rejects checkpoints on the async path (job ends in failed state)", async () => {
+    const RUNNER_NAME = "fake-hitl-test";
+
+    // Agent with a mandatory checkpoint gate.
+    const checkpointAgent = defineAgent({
+      runner: RUNNER_NAME,
+      input: z.object({ q: z.string() }),
+      output: z.object({ a: z.string() }),
+      prompt: ({ q }) => `q:${q}`,
+      // biome-ignore lint/suspicious/noExplicitAny: HITLConfig type exists in core
+      hitl: { mode: "checkpoint" } as any,
+    });
+
+    const checkpointWorkflow = defineWorkflow({
+      name: "ask",
+      tasks: { t: { agent: checkpointAgent, input: { q: "hi" } } },
+    });
+
+    // Register a fake runner — spawn should NOT be called since the checkpoint
+    // fires before the task runs and "fail" strategy rejects it.
+    let spawnCalled = false;
+    registerRunner(RUNNER_NAME, {
+      validate: async () => ({ ok: true }),
+      spawn: async (_args: RunnerSpawnArgs): Promise<RunnerSpawnResult> => {
+        spawnCalled = true;
+        return {
+          stdout: JSON.stringify({ a: "done" }),
+          sessionHandle: "",
+          tokensIn: 0,
+          tokensOut: 0,
+        };
+      },
+    });
+
+    const h = createMcpServer({
+      workflow: checkpointWorkflow,
+      cliCeilings: {},
+      hitlStrategy: "fail",
+      async: true,
+    });
+
+    try {
+      const startRes = await h.callTool("start_ask", { q: "gate" });
+      expect(startRes.isError).toBe(false);
+      if (startRes.isError) throw new Error("start failed");
+
+      const jobId = (startRes.structuredContent as { jobId: string }).jobId;
+
+      // Poll until the job leaves "running" state. With "fail" strategy, the
+      // checkpoint is rejected immediately and the job transitions to "failed".
+      let state = "running";
+      for (let i = 0; i < 50 && state === "running"; i++) {
+        await new Promise<void>((r) => setTimeout(r, 10));
+        const statusRes = await h.callTool("get_workflow_status", { jobId });
+        if (!statusRes.isError) {
+          state = (statusRes.structuredContent as { state: string }).state;
+        }
+      }
+
+      // The job must fail — checkpoint was rejected by the "fail" strategy.
+      expect(state).toBe("failed");
+
+      // Verify spawn was never called (checkpoint blocked execution before spawn).
+      expect(spawnCalled).toBe(false);
+
+      // get_workflow_result must return WORKFLOW_FAILED.
+      const resultRes = await h.callTool("get_workflow_result", { jobId });
+      expect(resultRes.isError).toBe(true);
+      if (resultRes.isError) {
+        expect(resultRes.structuredContent.errorCode).toBe("WORKFLOW_FAILED");
+      }
+    } finally {
+      unregisterRunner(RUNNER_NAME);
       h.dispose?.();
     }
   });

--- a/agentflow/packages/mcp-server/src/job-dispatch.ts
+++ b/agentflow/packages/mcp-server/src/job-dispatch.ts
@@ -10,6 +10,7 @@ import { ErrorCode, McpServerError, formatErrorResult } from "./errors.js";
 import { JobEventRecorder } from "./job-event-recorder.js";
 import type { McpToolResult } from "./server.js";
 import type { ToolDefinition } from "./tool-registry.js";
+import type { EffectiveCeilings } from "./types.js";
 
 export interface JobDispatchContext {
   readonly runner: Runner;
@@ -19,16 +20,47 @@ export interface JobDispatchContext {
   readonly jobTools: readonly ToolDefinition[]; // full job-tool array
   /** Executor injection hook from tests (mirrors sync path's _testRunExecutor). */
   testRunExecutor?: (input: unknown) => Promise<unknown>;
+  /**
+   * Test-only callback: called with the fully-composed workflow just before
+   * runner.fire(). Allows tests to assert that ceilings and hooks were correctly
+   * merged without needing to intercept the executor itself.
+   */
+  _testOnComposedWorkflow?: (workflow: WorkflowDef) => void;
   /** Task count in the workflow (for progress.tasksTotal). */
   readonly taskCount: number;
   /** Called from fire() onComplete/onError to release the inflight lock. */
   readonly releaseInflight: () => void;
 }
 
+export interface DispatchStartOptions {
+  /** Effective ceilings (from composeCeilings) to apply to workflow budget. */
+  readonly effective: EffectiveCeilings;
+  /**
+   * Checkpoint resolver for HITL strategy:
+   * - "auto": () => true  (approve all)
+   * - "fail": () => false  (reject all)
+   * - "elicit": undefined  (deferred path — client calls resume_workflow)
+   *
+   * When undefined, runner.fire falls back to the deferred mechanism:
+   * the run pauses at each checkpoint until resume_workflow resolves it.
+   * This is the correct async-mode equivalent of "elicit" strategy.
+   */
+  readonly onCheckpoint?: (
+    ev: import("@ageflow/core").CheckpointEvent,
+  ) => boolean;
+  /**
+   * Abort signal for the DurationWatchdog (sync path uses Promise.race;
+   * async path wires the signal directly into runner.fire so the internal
+   * executor respects it). Undefined when no duration ceiling is set.
+   */
+  readonly abortSignal?: AbortSignal;
+}
+
 export async function dispatchStart(
   _toolName: string,
   args: unknown,
   ctx: JobDispatchContext,
+  runOpts: DispatchStartOptions,
 ): Promise<McpToolResult> {
   // Validate input via the sync tool's input Zod (shared between sync + async)
   const inputTaskDef = ctx.workflow.tasks[ctx.tool.inputTask] as {
@@ -46,6 +78,19 @@ export async function dispatchStart(
       ),
     );
   }
+
+  // Build the composed workflow — apply ceiling overrides and HITL hooks.
+  // This mirrors the setup done on the sync path (composeCeilings + buildMcpHooks)
+  // so that both paths behave identically with respect to CLI ceilings and HITL.
+  const composedWorkflow = applyRunOpts(
+    ctx.workflow,
+    ctx.tool.inputTask,
+    parsed.data,
+    runOpts,
+  );
+
+  // Notify test observers with the composed workflow (test-only hook).
+  ctx._testOnComposedWorkflow?.(composedWorkflow);
 
   // If a test executor is injected, temporarily register a fake runner that
   // delegates to it. This ensures runner.fire() still registers the handle in
@@ -81,22 +126,14 @@ export async function dispatchStart(
     };
     registerRunner(runnerName, fakeRunner);
 
-    // Inject runtime input into the input task's static `input` field so the
-    // executor reads the correct input (same injection as the production path).
-    // biome-ignore lint/suspicious/noExplicitAny: structural injection — task.input must be set at runtime
-    const originalInputTaskTest = ctx.workflow.tasks[ctx.tool.inputTask] as any;
-    const workflowWithInputTest: typeof ctx.workflow = {
-      ...ctx.workflow,
-      tasks: {
-        ...ctx.workflow.tasks,
-        [ctx.tool.inputTask]: {
-          ...originalInputTaskTest,
-          input: parsed.data,
-        },
-      },
-    };
-
-    const handle = ctx.runner.fire(workflowWithInputTest, parsed.data, {
+    const handle = ctx.runner.fire(composedWorkflow, parsed.data, {
+      ...(runOpts.abortSignal !== undefined
+        ? { signal: runOpts.abortSignal }
+        : {}),
+      // Apply HITL strategy: "auto" → approve, "deny" → reject, "elicit" → deferred.
+      ...(runOpts.onCheckpoint !== undefined
+        ? { onCheckpoint: (ev) => runOpts.onCheckpoint!(ev) }
+        : {}),
       onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
       onComplete: () => {
         unregisterRunner(runnerName);
@@ -118,26 +155,20 @@ export async function dispatchStart(
     };
   }
 
-  // Inject runtime input into the input task's static `input` field before
-  // firing. WorkflowExecutor reads task.input directly — the `input` argument
-  // passed to runner.fire / executor.stream is only used for workflow:start
-  // metadata and is NOT wired into task execution. Without this injection the
-  // async path would use whatever static task.input was defined at config time.
-  // This mirrors the same injection done by makeDefaultRunner on the sync path.
-  const inputTaskName = ctx.tool.inputTask;
-  // biome-ignore lint/suspicious/noExplicitAny: structural injection — task.input must be set at runtime
-  const originalInputTask = ctx.workflow.tasks[inputTaskName] as any;
-  const workflowWithInput: typeof ctx.workflow = {
-    ...ctx.workflow,
-    tasks: {
-      ...ctx.workflow.tasks,
-      [inputTaskName]: { ...originalInputTask, input: parsed.data },
-    },
-  };
-
-  const handle = ctx.runner.fire(workflowWithInput, parsed.data, {
-    // onCheckpoint is intentionally OMITTED — triggers server's deferred path
-    // (handle.markAwaitingCheckpoint(ev, resolver)) so resume_workflow can clear it.
+  const handle = ctx.runner.fire(composedWorkflow, parsed.data, {
+    // Wire the DurationWatchdog abort signal (if any) so the internal executor
+    // honours the duration ceiling on the async path.
+    ...(runOpts.abortSignal !== undefined
+      ? { signal: runOpts.abortSignal }
+      : {}),
+    // Apply HITL strategy from runOpts:
+    //   - "auto" maps to onCheckpoint: () => true
+    //   - "deny" maps to onCheckpoint: () => false
+    //   - "elicit" maps to undefined → runner uses deferred path so
+    //     resume_workflow can resolve checkpoints externally.
+    ...(runOpts.onCheckpoint !== undefined
+      ? { onCheckpoint: (ev) => runOpts.onCheckpoint!(ev) }
+      : {}),
     onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
     onComplete: () => {
       ctx.releaseInflight();
@@ -390,5 +421,47 @@ export function createJobDispatchContext(args: {
     jobTools: args.jobTools,
     taskCount: Object.keys(args.workflow.tasks).length,
     releaseInflight: args.releaseInflight,
+  };
+}
+
+/**
+ * Build the fully-composed workflow for a run by applying:
+ * 1. Runtime input injection into the input task.
+ * 2. Budget ceiling from effective ceilings (maxCostUsd).
+ *
+ * This mirrors makeDefaultRunner on the sync path so both paths produce
+ * identical workflow budget configurations.
+ *
+ * HITL strategy is handled separately via DispatchStartOptions.onCheckpoint
+ * passed to runner.fire() — NOT via workflow.hooks — because the executor's
+ * stream() path uses "single-ownership": caller-provided onCheckpoint takes
+ * full precedence and workflow.hooks.onCheckpoint is NOT called when a
+ * stream-level onCheckpoint is present (see WorkflowExecutor docs).
+ */
+function applyRunOpts(
+  workflow: WorkflowDef,
+  inputTaskName: string,
+  input: unknown,
+  opts: DispatchStartOptions,
+): WorkflowDef {
+  // 1. Inject runtime input.
+  // biome-ignore lint/suspicious/noExplicitAny: structural injection — task.input must be set at runtime
+  const originalInputTask = workflow.tasks[inputTaskName] as any;
+  const tasksWithInput = {
+    ...workflow.tasks,
+    [inputTaskName]: { ...originalInputTask, input },
+  } as import("@ageflow/core").TasksMap;
+
+  // 2. Apply budget ceiling (maxCostUsd only — maxTurns/maxDurationSec are
+  // enforced via abortSignal / executor-level ceiling respectively).
+  const budget =
+    opts.effective.maxCostUsd !== null
+      ? { maxCost: opts.effective.maxCostUsd, onExceed: "halt" as const }
+      : undefined;
+
+  return {
+    ...workflow,
+    tasks: tasksWithInput,
+    ...(budget !== undefined ? { budget } : {}),
   };
 }

--- a/agentflow/packages/mcp-server/src/job-dispatch.ts
+++ b/agentflow/packages/mcp-server/src/job-dispatch.ts
@@ -130,9 +130,12 @@ export async function dispatchStart(
       ...(runOpts.abortSignal !== undefined
         ? { signal: runOpts.abortSignal }
         : {}),
-      // Apply HITL strategy: "auto" → approve, "deny" → reject, "elicit" → deferred.
+      // Apply HITL strategy: "auto" → approve, "fail" → reject, "elicit" → deferred.
       ...(runOpts.onCheckpoint !== undefined
-        ? { onCheckpoint: (ev) => runOpts.onCheckpoint?.(ev) }
+        ? {
+            // biome-ignore lint/style/noNonNullAssertion: guarded by outer !== undefined check
+            onCheckpoint: (ev) => runOpts.onCheckpoint!(ev),
+          }
         : {}),
       onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
       onComplete: () => {
@@ -163,11 +166,14 @@ export async function dispatchStart(
       : {}),
     // Apply HITL strategy from runOpts:
     //   - "auto" maps to onCheckpoint: () => true
-    //   - "deny" maps to onCheckpoint: () => false
+    //   - "fail" maps to onCheckpoint: () => false
     //   - "elicit" maps to undefined → runner uses deferred path so
     //     resume_workflow can resolve checkpoints externally.
     ...(runOpts.onCheckpoint !== undefined
-      ? { onCheckpoint: (ev) => runOpts.onCheckpoint?.(ev) }
+      ? {
+          // biome-ignore lint/style/noNonNullAssertion: guarded by outer !== undefined check
+          onCheckpoint: (ev) => runOpts.onCheckpoint!(ev),
+        }
       : {}),
     onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
     onComplete: () => {

--- a/agentflow/packages/mcp-server/src/job-dispatch.ts
+++ b/agentflow/packages/mcp-server/src/job-dispatch.ts
@@ -132,7 +132,7 @@ export async function dispatchStart(
         : {}),
       // Apply HITL strategy: "auto" → approve, "deny" → reject, "elicit" → deferred.
       ...(runOpts.onCheckpoint !== undefined
-        ? { onCheckpoint: (ev) => runOpts.onCheckpoint!(ev) }
+        ? { onCheckpoint: (ev) => runOpts.onCheckpoint?.(ev) }
         : {}),
       onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
       onComplete: () => {
@@ -167,7 +167,7 @@ export async function dispatchStart(
     //   - "elicit" maps to undefined → runner uses deferred path so
     //     resume_workflow can resolve checkpoints externally.
     ...(runOpts.onCheckpoint !== undefined
-      ? { onCheckpoint: (ev) => runOpts.onCheckpoint!(ev) }
+      ? { onCheckpoint: (ev) => runOpts.onCheckpoint?.(ev) }
       : {}),
     onEvent: (ev: WorkflowEvent) => ctx.recorder.record(ev),
     onComplete: () => {

--- a/agentflow/packages/mcp-server/src/server.ts
+++ b/agentflow/packages/mcp-server/src/server.ts
@@ -21,6 +21,7 @@ export const ASYNC_OBSERVER_TOOL_NAMES = [
 ] as const;
 import { type McpConnectionLike, buildMcpHooks } from "./hitl-bridge.js";
 import {
+  type DispatchStartOptions,
   type JobDispatchContext,
   createJobDispatchContext,
   dispatchCancel,
@@ -88,6 +89,12 @@ export interface McpServerHandle {
     signal: AbortSignal,
     effective: EffectiveCeilings,
   ) => Promise<unknown>;
+  /**
+   * Test-only callback (async mode): called with the fully-composed workflow
+   * just before runner.fire(). Lets tests assert ceiling / hook composition
+   * without needing to intercept the executor itself.
+   */
+  _testOnComposedWorkflow?: (workflow: WorkflowDef) => void;
   /** Stop background TTL reaper (async mode only). Idempotent. */
   dispose?(): void;
 }
@@ -218,6 +225,10 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
 
       if (isStart) {
         const ctx = ensureDispatchCtx();
+        // Thread test hooks into context (test-only).
+        if (handle._testOnComposedWorkflow !== undefined) {
+          ctx._testOnComposedWorkflow = handle._testOnComposedWorkflow;
+        }
         // Thread test executor into context if set on handle (wraps 4-arg to 1-arg)
         if (handle._testRunExecutor !== undefined) {
           const testExec = handle._testRunExecutor;
@@ -229,9 +240,61 @@ export function createMcpServer(opts: McpServerOptions): McpServerHandle {
               {} as EffectiveCeilings,
             );
         }
+
+        // Apply the same ceiling/hook composition as the sync path so that
+        // async jobs respect CLI ceiling overrides and the configured HITL strategy.
+        const asyncEffective = composeCeilings(
+          resolved,
+          opts.cliCeilings,
+          stderr,
+        );
+
+        // DurationWatchdog for async: instead of Promise.race (which requires
+        // awaiting the run), we wire an AbortController into runner.fire() via
+        // the `signal` option. When maxDurationSec elapses the signal fires,
+        // the internal executor stream receives it, and the run is cancelled.
+        // This is semantically equivalent to the sync watchdog (both abort the
+        // underlying executor) but adapted for fire-and-forget execution.
+        // Note: the run will appear as "cancelled" (not "duration-exceeded") in
+        // the job registry, which is the correct terminal state for async jobs
+        // that hit their duration ceiling. A finer-grained DURATION_EXCEEDED
+        // status is left as a follow-up (tracked in #84 item 11).
+        let asyncWatchdogSignal: AbortSignal | undefined;
+        if (asyncEffective.maxDurationSec !== null) {
+          const asyncWatchdog = new DurationWatchdog(
+            asyncEffective.maxDurationSec,
+            () => {},
+          );
+          asyncWatchdog.start();
+          asyncWatchdogSignal = asyncWatchdog.abortSignal;
+        }
+
+        // Derive async HITL strategy: map hitlStrategy to a simple checkpoint
+        // resolver for runner.fire(). The async path cannot use MCP elicitation
+        // (no persistent connection during fire-and-forget execution), so:
+        //   "auto"   → immediately approve
+        //   "fail"   → immediately reject
+        //   "elicit" → undefined (runner's deferred path; client uses resume_workflow)
+        const asyncOnCheckpoint: DispatchStartOptions["onCheckpoint"] =
+          opts.hitlStrategy === "auto"
+            ? () => true
+            : opts.hitlStrategy === "fail"
+              ? () => false
+              : undefined; // elicit → deferred resume_workflow mechanism
+
+        const dispatchOpts: DispatchStartOptions = {
+          effective: asyncEffective,
+          ...(asyncOnCheckpoint !== undefined
+            ? { onCheckpoint: asyncOnCheckpoint }
+            : {}),
+          ...(asyncWatchdogSignal !== undefined
+            ? { abortSignal: asyncWatchdogSignal }
+            : {}),
+        };
+
         // dispatchStart releases inflight via ctx.releaseInflight (onComplete/onError)
         // or on validation failure.
-        return await dispatchStart(name, args, ctx);
+        return await dispatchStart(name, args, ctx, dispatchOpts);
       }
 
       // Sync path (existing body) — inflight cleared in finally.


### PR DESCRIPTION
Fix for async MCP-server #84 item 11 (P1) — async \`start_*\` branch now respects CLI ceilings and HITL strategy.

## Bug

Async \`start_*\` returned \`dispatchStart(...)\` BEFORE running the sync-path setup: \`composeCeilings\`, \`DurationWatchdog\`, \`buildMcpHooks\`. Async jobs ignored CLI \`maxCostUsd\`/\`maxDurationSec\` ceilings and behaved differently than sync for the same workflow (no checkpoint strategy, no duration watchdog).

## Fix

- Added \`DispatchStartOptions\` to \`job-dispatch.ts\` with \`effective\`, \`onCheckpoint\`, \`abortSignal\` — passed through to \`runner.fire()\`.
- \`server.ts\` async branch now composes ceilings and HITL strategy before calling \`dispatchStart\`.
- Duration watchdog: ported via \`AbortSignal\` tied to \`maxDurationSec\` — on timeout the signal fires, executor stream aborts, job transitions to \`"cancelled"\`.

## Deviations

- Used explicit \`onCheckpoint: (ev) => boolean\` in \`DispatchStartOptions\` rather than merging into \`workflow.hooks\`. Reason: executor's \`stream()\` uses single-ownership — caller \`onCheckpoint\` wins over \`workflow.hooks.onCheckpoint\`. Merging into hooks would be silently ignored.
- Distinct \`"duration-exceeded"\` async status deferred as follow-up; current cancellation terminal state is sufficient for item 11.

## Tests

- mcp-server: **95 → 97** (+2: CLI ceiling flow + HITL strategy async)
- Typecheck PASS, lint clean

Closes part of #84.