### PR TITLE
fix(runner-api): #70 — reject mcpPool collision on differing spawn configs

### DIFF
--- a/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
+++ b/agentflow/packages/runners/api/src/__tests__/api-runner.mcp.test.ts
@@ -9,6 +9,7 @@ import type { Logger } from "@ageflow/core";
 import { spawnMockMcpServer } from "@ageflow/testing";
 import { describe, expect, it, vi } from "vitest";
 import { ApiRunner } from "../api-runner.js";
+import { McpPoolCollisionError } from "../errors.js";
 import type { McpClient } from "../mcp-client.js";
 import type { ChatCompletionResponse } from "../openai-types.js";
 
@@ -196,6 +197,180 @@ describe("ApiRunner logger config (issue #71)", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining("crashing on initialize"),
       );
+    },
+    { timeout: 5_000 },
+  );
+});
+
+// ─── Issue #70: mcpPool collision guard ──────────────────────────────────────
+
+describe("ApiRunner mcpPool collision guard (issue #70)", () => {
+  it(
+    "rejects second spawn with McpPoolCollisionError when same-named server has different command",
+    async () => {
+      const terminalResponse: ChatCompletionResponse = {
+        choices: [
+          {
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
+      };
+
+      const mcpClientMod = await import("../mcp-client.js");
+
+      // First call succeeds and returns a fake pooled client
+      const fakeClient: McpClient = {
+        config: {
+          name: "shared",
+          command: "/bin/a",
+          reusePerRunner: true,
+        },
+        async listTools() {
+          return [];
+        },
+        async callTool() {
+          return {};
+        },
+        async stop() {},
+      };
+
+      const startSpy = vi
+        .spyOn(mcpClientMod, "startMcpClients")
+        .mockResolvedValue([fakeClient]);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(terminalResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const runner = new ApiRunner({
+        baseUrl: "https://example.test/v1",
+        apiKey: "k",
+        defaultModel: "gpt-4o",
+        fetch: fetchMock as unknown as typeof fetch,
+      });
+
+      // First spawn registers "shared" with command "/bin/a"
+      await runner.spawn({
+        prompt: "first",
+        model: "gpt-4o",
+        mcpServers: [
+          { name: "shared", command: "/bin/a", reusePerRunner: true },
+        ],
+      });
+
+      // Second spawn uses same name but different command
+      await expect(
+        runner.spawn({
+          prompt: "second",
+          model: "gpt-4o",
+          mcpServers: [
+            { name: "shared", command: "/bin/b", reusePerRunner: true },
+          ],
+        }),
+      ).rejects.toThrow(McpPoolCollisionError);
+
+      // The error message must include the server name
+      await expect(
+        runner.spawn({
+          prompt: "second",
+          model: "gpt-4o",
+          mcpServers: [
+            { name: "shared", command: "/bin/b", reusePerRunner: true },
+          ],
+        }),
+      ).rejects.toThrow("shared");
+
+      startSpy.mockRestore();
+      await runner.shutdown();
+    },
+    { timeout: 5_000 },
+  );
+
+  it(
+    "reuses pooled client without error when spawn configs are identical",
+    async () => {
+      const terminalResponse: ChatCompletionResponse = {
+        choices: [
+          {
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
+      };
+
+      const mcpClientMod = await import("../mcp-client.js");
+
+      const fakeClient: McpClient = {
+        config: {
+          name: "reused",
+          command: "/bin/same",
+          args: ["--flag"],
+          reusePerRunner: true,
+        },
+        async listTools() {
+          return [];
+        },
+        async callTool() {
+          return {};
+        },
+        async stop() {},
+      };
+
+      const startSpy = vi
+        .spyOn(mcpClientMod, "startMcpClients")
+        .mockResolvedValue([fakeClient]);
+
+      const fetchMock = vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(terminalResponse), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      const runner = new ApiRunner({
+        baseUrl: "https://example.test/v1",
+        apiKey: "k",
+        defaultModel: "gpt-4o",
+        fetch: fetchMock as unknown as typeof fetch,
+      });
+
+      const config = {
+        name: "reused",
+        command: "/bin/same",
+        args: ["--flag"] as string[],
+        reusePerRunner: true as const,
+      };
+
+      // Both spawns use an identical config — second should reuse without error
+      await expect(
+        runner.spawn({
+          prompt: "first",
+          model: "gpt-4o",
+          mcpServers: [config],
+        }),
+      ).resolves.toBeDefined();
+
+      await expect(
+        runner.spawn({
+          prompt: "second",
+          model: "gpt-4o",
+          mcpServers: [config],
+        }),
+      ).resolves.toBeDefined();
+
+      // startMcpClients should have been called only once (pool reuse on second spawn)
+      expect(startSpy).toHaveBeenCalledTimes(1);
+
+      startSpy.mockRestore();
+      await runner.shutdown();
     },
     { timeout: 5_000 },
   );

--- a/agentflow/packages/runners/api/src/api-runner.ts
+++ b/agentflow/packages/runners/api/src/api-runner.ts
@@ -1,9 +1,11 @@
 import type {
   Logger,
+  McpServerConfig,
   Runner,
   RunnerSpawnArgs,
   RunnerSpawnResult,
 } from "@ageflow/core";
+import { McpPoolCollisionError } from "./errors.js";
 import type { McpClient } from "./mcp-client.js";
 import { shutdownAll, startMcpClients } from "./mcp-client.js";
 import { mcpToolsToRegistry } from "./mcp-tool-adapter.js";
@@ -12,6 +14,53 @@ import type { ChatMessage } from "./openai-types.js";
 import { InMemorySessionStore, type SessionStore } from "./session-store.js";
 import { runToolLoop } from "./tool-loop.js";
 import type { ApiRunnerConfig, ToolRegistry } from "./types.js";
+
+/**
+ * Returns true when two McpServerConfig objects would spawn an identical
+ * process. Compares all spawn-determining fields: command, args, env, cwd,
+ * and tools allowlist.
+ */
+function isSpawnEquivalent(a: McpServerConfig, b: McpServerConfig): boolean {
+  if (a.command !== b.command) return false;
+  if (a.cwd !== b.cwd) return false;
+
+  // args: both absent/empty counts as equal
+  const aArgs = a.args ?? [];
+  const bArgs = b.args ?? [];
+  if (aArgs.length !== bArgs.length) return false;
+  for (let i = 0; i < aArgs.length; i++) {
+    if (aArgs[i] !== bArgs[i]) return false;
+  }
+
+  // env: both absent/empty counts as equal
+  const aEnvEntries = Object.entries(a.env ?? {}).sort(([k1], [k2]) =>
+    k1 < k2 ? -1 : k1 > k2 ? 1 : 0,
+  );
+  const bEnvEntries = Object.entries(b.env ?? {}).sort(([k1], [k2]) =>
+    k1 < k2 ? -1 : k1 > k2 ? 1 : 0,
+  );
+  if (aEnvEntries.length !== bEnvEntries.length) return false;
+  for (let i = 0; i < aEnvEntries.length; i++) {
+    const ae = aEnvEntries[i];
+    const be = bEnvEntries[i];
+    if (ae === undefined || be === undefined) return false;
+    if (ae[0] !== be[0]) return false;
+    if (ae[1] !== be[1]) return false;
+  }
+
+  // tools allowlist
+  const aTools = a.tools ? [...a.tools].sort() : undefined;
+  const bTools = b.tools ? [...b.tools].sort() : undefined;
+  if ((aTools === undefined) !== (bTools === undefined)) return false;
+  if (aTools !== undefined && bTools !== undefined) {
+    if (aTools.length !== bTools.length) return false;
+    for (let i = 0; i < aTools.length; i++) {
+      if (aTools[i] !== bTools[i]) return false;
+    }
+  }
+
+  return true;
+}
 
 const DEFAULT_MAX_ROUNDS = 10;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -125,6 +174,8 @@ export class ApiRunner implements Runner {
               }
               pooled = started;
               this.mcpPool.set(s.name, pooled);
+            } else if (!isSpawnEquivalent(pooled.config, s)) {
+              throw new McpPoolCollisionError(s.name);
             }
             perSpawnClients.push(pooled);
           } else {

--- a/agentflow/packages/runners/api/src/errors.ts
+++ b/agentflow/packages/runners/api/src/errors.ts
@@ -1,5 +1,18 @@
 import { AgentFlowError } from "@ageflow/core";
 
+export class McpPoolCollisionError extends AgentFlowError {
+  readonly code = "mcp_pool_collision" as const;
+  constructor(
+    readonly serverName: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `MCP server pool collision: '${serverName}' already started with different command/args/env. Use a unique server name or ensure spawn args match.`,
+      options,
+    );
+  }
+}
+
 export class MaxToolRoundsError extends AgentFlowError {
   readonly code = "tool_loop_exceeded" as const;
   constructor(

--- a/agentflow/packages/runners/api/src/index.ts
+++ b/agentflow/packages/runners/api/src/index.ts
@@ -4,6 +4,7 @@ export {
   MaxToolRoundsError,
   ApiRequestError,
   ToolNotFoundError,
+  McpPoolCollisionError,
 } from "./errors.js";
 export type {
   ApiRunnerConfig,


### PR DESCRIPTION
## Bug (#70, P2)

\`api-runner.ts\` keyed the \`mcpPool\` by \`McpServerConfig.name\` alone. With \`reusePerRunner: true\`, two spawns with the SAME name but DIFFERENT \`command\`/\`args\`/\`env\`/\`cwd\`/\`tools\` silently reused the first client — agent calls routed to the wrong subprocess.

## Fix (Option 2 — explicit guard)

- \`isSpawnEquivalent(a, b)\` helper compares the 5 spawn-determining fields (\`command\`, \`args\`, \`env\`, \`cwd\`, \`tools\`).
- Before reusing a pooled client, compare cached config against incoming. If different, throw new \`McpPoolCollisionError\` (\`mcp_pool_collision\`) with a clear message naming the server.
- Identical configs still reuse correctly (the common path).

## Tests

- **Collision path**: second \`spawn()\` with same name but different command → rejects with \`McpPoolCollisionError\`
- **Compatible-reuse path**: identical configs → single \`startMcpClients\` call reused

Runner-api: **60 → 62** passing. Typecheck + lint clean.

Closes #70.