### PR TITLE
feat(core/executor): #24 Phase 1 — getSystemPromptPrefix hook + promptSent metric

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -469,6 +469,8 @@ export interface TaskMetrics {
   readonly retries: number;
   /** Estimated USD cost based on model and token counts. */
   readonly estimatedCost: number;
+  /** The full prompt as sent to the runner (including any injected prefixes). */
+  readonly promptSent?: string;
 }
 
 export interface WorkflowMetrics {
@@ -500,6 +502,14 @@ export interface WorkflowHooks<T extends TasksMap = TasksMap> {
     result: unknown,
     summary: WorkflowMetrics,
   ) => void;
+  /**
+   * Returns extra context to prepend to the agent's system prompt.
+   * Called before each task spawn. Learning hooks use this to inject skills.
+   * Generic — useful beyond learning (per-task instructions, env context).
+   */
+  readonly getSystemPromptPrefix?: (
+    taskName: keyof T & string,
+  ) => string | undefined;
 }
 
 // ─── MCP exposure config ─────────────────────────────────────────────────────

--- a/packages/executor/src/__tests__/node-runner.test.ts
+++ b/packages/executor/src/__tests__/node-runner.test.ts
@@ -409,4 +409,149 @@ describe("runNode", () => {
     expect(capturedSystemPrompt).toContain('"score"');
     expect(capturedSystemPrompt).toContain('"tags"');
   });
+
+  describe("getSystemPromptPrefix hook", () => {
+    it("prepends hook prefix to system prompt when hook returns a string", async () => {
+      let capturedSystemPrompt: string | undefined;
+
+      const runner: import("@ageflow/core").Runner = {
+        validate: vi.fn().mockResolvedValue({ ok: true }),
+        spawn: vi.fn(async (args: import("@ageflow/core").RunnerSpawnArgs) => {
+          capturedSystemPrompt = args.systemPrompt;
+          return makeSuccessResult({ result: "ok" });
+        }),
+      };
+
+      const hooks: import("@ageflow/core").WorkflowHooks = {
+        getSystemPromptPrefix: (_taskName) => "SKILL: always respond in JSON",
+      };
+
+      const task = { agent: simpleAgent };
+      await Promise.all([
+        runNode(
+          task,
+          { text: "hello" },
+          runner,
+          "prefix-task",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          hooks,
+        ),
+        vi.runAllTimersAsync(),
+      ]);
+
+      expect(capturedSystemPrompt).toBeDefined();
+      expect(capturedSystemPrompt).toContain("SKILL: always respond in JSON");
+      // Original schema prompt must still be present
+      expect(capturedSystemPrompt).toContain(
+        "You MUST respond with valid JSON",
+      );
+      // Prefix comes BEFORE the base system prompt
+      const prefixIndex = capturedSystemPrompt?.indexOf(
+        "SKILL: always respond in JSON",
+      );
+      const schemaIndex = capturedSystemPrompt?.indexOf(
+        "You MUST respond with valid JSON",
+      );
+      expect(prefixIndex).toBeLessThan(schemaIndex as number);
+    });
+
+    it("does not modify system prompt when hook returns undefined", async () => {
+      let capturedSystemPrompt: string | undefined;
+
+      const runner: import("@ageflow/core").Runner = {
+        validate: vi.fn().mockResolvedValue({ ok: true }),
+        spawn: vi.fn(async (args: import("@ageflow/core").RunnerSpawnArgs) => {
+          capturedSystemPrompt = args.systemPrompt;
+          return makeSuccessResult({ result: "ok" });
+        }),
+      };
+
+      const hooks: import("@ageflow/core").WorkflowHooks = {
+        getSystemPromptPrefix: (_taskName) => undefined,
+      };
+
+      const task = { agent: simpleAgent };
+      await Promise.all([
+        runNode(
+          task,
+          { text: "hello" },
+          runner,
+          "no-prefix-task",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          hooks,
+        ),
+        vi.runAllTimersAsync(),
+      ]);
+
+      expect(capturedSystemPrompt).toBeDefined();
+      // Should be exactly the base schema prompt — no extra prefix
+      expect(capturedSystemPrompt).not.toContain("SKILL:");
+      expect(capturedSystemPrompt).toContain(
+        "You MUST respond with valid JSON",
+      );
+    });
+
+    it("does not modify system prompt when no hooks are provided", async () => {
+      let capturedSystemPrompt: string | undefined;
+
+      const runner: import("@ageflow/core").Runner = {
+        validate: vi.fn().mockResolvedValue({ ok: true }),
+        spawn: vi.fn(async (args: import("@ageflow/core").RunnerSpawnArgs) => {
+          capturedSystemPrompt = args.systemPrompt;
+          return makeSuccessResult({ result: "ok" });
+        }),
+      };
+
+      const task = { agent: simpleAgent };
+      await Promise.all([
+        runNode(task, { text: "hello" }, runner, "no-hooks-task"),
+        vi.runAllTimersAsync(),
+      ]);
+
+      expect(capturedSystemPrompt).toBeDefined();
+      expect(capturedSystemPrompt).toContain(
+        "You MUST respond with valid JSON",
+      );
+    });
+
+    it("calls getSystemPromptPrefix with the correct taskName", async () => {
+      const prefixFn = vi.fn((_taskName: string) => "PREFIX");
+
+      const runner: import("@ageflow/core").Runner = {
+        validate: vi.fn().mockResolvedValue({ ok: true }),
+        spawn: vi.fn(async () => makeSuccessResult({ result: "ok" })),
+      };
+
+      const hooks: import("@ageflow/core").WorkflowHooks = {
+        getSystemPromptPrefix: prefixFn,
+      };
+
+      const task = { agent: simpleAgent };
+      await Promise.all([
+        runNode(
+          task,
+          { text: "hello" },
+          runner,
+          "my-named-task",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          hooks,
+        ),
+        vi.runAllTimersAsync(),
+      ]);
+
+      expect(prefixFn).toHaveBeenCalledWith("my-named-task");
+    });
+  });
 });

--- a/packages/executor/src/__tests__/workflow-executor.test.ts
+++ b/packages/executor/src/__tests__/workflow-executor.test.ts
@@ -354,4 +354,81 @@ describe("WorkflowExecutor", () => {
     expect(result.metrics.totalTokensIn).toBe(20); // 2 tasks × 10 tokens each
     expect(result.metrics.totalTokensOut).toBe(40); // 2 tasks × 20 tokens each
   });
+
+  describe("promptSent in TaskMetrics", () => {
+    it("onTaskComplete receives promptSent containing the user prompt", async () => {
+      const onTaskComplete = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-prompt-sent",
+        tasks: {
+          taskA: { agent: agentA, input: { value: "hello-world" } },
+        },
+        hooks: { onTaskComplete },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      expect(onTaskComplete).toHaveBeenCalledTimes(1);
+      const [, , metrics] = onTaskComplete.mock.calls[0] as [
+        string,
+        unknown,
+        import("@ageflow/core").TaskMetrics,
+      ];
+      expect(metrics.promptSent).toBeDefined();
+      expect(typeof metrics.promptSent).toBe("string");
+      // The prompt template is `Process: ${value}`, so "hello-world" must appear
+      expect(metrics.promptSent).toContain("hello-world");
+    });
+
+    it("promptSent includes the system prompt content", async () => {
+      const onTaskComplete = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-prompt-sent-system",
+        tasks: {
+          taskA: { agent: agentA, input: { value: "test" } },
+        },
+        hooks: { onTaskComplete },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      const [, , metrics] = onTaskComplete.mock.calls[0] as [
+        string,
+        unknown,
+        import("@ageflow/core").TaskMetrics,
+      ];
+      // System prompt contains JSON schema instructions
+      expect(metrics.promptSent).toContain("You MUST respond with valid JSON");
+    });
+
+    it("promptSent includes getSystemPromptPrefix content when hook is set", async () => {
+      const onTaskComplete = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-prompt-sent-prefix",
+        tasks: {
+          taskA: { agent: agentA, input: { value: "test" } },
+        },
+        hooks: {
+          onTaskComplete,
+          getSystemPromptPrefix: (_taskName) =>
+            "LEARNING SKILL: be extra helpful",
+        },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      const [, , metrics] = onTaskComplete.mock.calls[0] as [
+        string,
+        unknown,
+        import("@ageflow/core").TaskMetrics,
+      ];
+      expect(metrics.promptSent).toContain("LEARNING SKILL: be extra helpful");
+    });
+  });
 });

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -10,6 +10,7 @@ import type {
   McpServerConfig,
   Runner,
   TaskDef,
+  WorkflowHooks,
 } from "@ageflow/core";
 import type { ZodType } from "zod";
 import { OutputValidationError } from "./errors.js";
@@ -25,6 +26,8 @@ export interface NodeRunResult<O> {
   latencyMs: number;
   retries: number;
   sessionHandle: string;
+  /** The full prompt as sent to the runner (systemPrompt + user prompt). */
+  promptSent: string;
 }
 
 // ─── Input sanitization ───────────────────────────────────────────────────────
@@ -108,6 +111,8 @@ export async function runNode<
   filteredTools?: readonly string[],
   onRetry?: (attempt: number, reason: string) => void,
   workflowMcpServers?: readonly McpServerConfig[],
+  // biome-ignore lint/suspicious/noExplicitAny: hooks generic T not available here
+  hooks?: WorkflowHooks<any>,
 ): Promise<
   NodeRunResult<
     import("zod").infer<
@@ -131,10 +136,15 @@ export async function runNode<
 
       // Build spawn args — only include optional properties when defined
       // (exactOptionalPropertyTypes requires we not pass explicit undefined)
+      const baseSystemPrompt = buildOutputSchemaPrompt(resolvedDef.output);
+      const prefix = hooks?.getSystemPromptPrefix?.(taskName);
+      const systemPrompt = prefix
+        ? `${prefix}\n\n${baseSystemPrompt}`
+        : baseSystemPrompt;
       const spawnArgs: import("@ageflow/core").RunnerSpawnArgs = {
         prompt,
         taskName,
-        systemPrompt: buildOutputSchemaPrompt(resolvedDef.output),
+        systemPrompt,
       };
       if (resolvedDef.model !== undefined) {
         spawnArgs.model = resolvedDef.model;
@@ -193,6 +203,7 @@ export async function runNode<
         latencyMs,
         retries: attempt,
         sessionHandle: spawnResult.sessionHandle,
+        promptSent: `${systemPrompt}\n\n${prompt}`,
       };
     } catch (err) {
       // HITL conflict — never retry. Runners emit "unknown" as the task name

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -365,6 +365,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                 filteredTools,
                 undefined,
                 this.workflow.mcpServers,
+                hooks,
               );
 
               const latencyMs = Date.now() - taskStart;
@@ -419,6 +420,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                 latencyMs,
                 retries: result.retries,
                 estimatedCost,
+                promptSent: result.promptSent,
               };
 
               // Fire onTaskComplete hook
@@ -624,6 +626,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                   });
                 },
                 this.workflow.mcpServers,
+                hooks,
               );
 
               const latencyMs = Date.now() - taskStart;
@@ -686,6 +689,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                 latencyMs,
                 retries: result.retries,
                 estimatedCost,
+                promptSent: result.promptSent,
               };
 
               // Fire onTaskComplete hook


### PR DESCRIPTION
Phase 1 of @ageflow/learning implementation plan.

## Changes

### @ageflow/core
- \`WorkflowHooks.getSystemPromptPrefix\` — generic hook for injecting extra context into agent system prompts. First consumer: learning skill injection. Also useful for per-task instructions, env context.
- \`TaskMetrics.promptSent\` — optional field capturing the full prompt as sent to the runner (system + user), enabling trace collection.

### @ageflow/executor
- \`node-runner.ts\` — calls \`hooks.getSystemPromptPrefix(taskName)\` and prepends result to systemPrompt
- \`workflow-executor.ts\` — populates \`promptSent\` in TaskMetrics passed to \`onTaskComplete\`

## Tests

- executor: **163 → 170** (+7 — 4 prefix injection + 3 promptSent metric)
- Typecheck + lint clean

Part of #24.