### PR TITLE
feat(learning): #24 Phase 2 — types, Zod schemas, store interfaces

### DIFF
--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ageflow/learning",
+  "version": "0.3.0",
+  "description": "Self-evolving skill layer for ageflow — trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
+  "type": "module",
+  "private": false,
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@ageflow/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@ageflow/executor": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@ageflow/executor": { "optional": true }
+  },
+  "devDependencies": {
+    "@ageflow/executor": "workspace:*",
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0",
+    "zod": "^3.23.0"
+  },
+  "license": "MIT"
+}

--- a/packages/learning/src/__tests__/types.test.ts
+++ b/packages/learning/src/__tests__/types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  ExecutionTraceSchema,
+  FeedbackSchema,
+  SkillRecordSchema,
+  TaskTraceSchema,
+} from "../types.js";
+
+describe("FeedbackSchema", () => {
+  it("accepts valid feedback", () => {
+    const result = FeedbackSchema.safeParse({
+      rating: "negative",
+      comment: "PR rejected",
+      source: "human",
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid rating", () => {
+    const result = FeedbackSchema.safeParse({
+      rating: "terrible",
+      source: "human",
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("SkillRecordSchema", () => {
+  it("accepts valid skill record", () => {
+    const result = SkillRecordSchema.safeParse({
+      id: crypto.randomUUID(),
+      name: "analyze-root-cause-v1",
+      description: "Improved root cause analysis",
+      content: "# Skill\nAlways check adjacent modules...",
+      targetAgent: "analyze",
+      version: 1,
+      parentId: undefined,
+      status: "active",
+      score: 0.8,
+      runCount: 5,
+      bestInLineage: true,
+      createdAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects score > 1", () => {
+    const result = SkillRecordSchema.safeParse({
+      id: crypto.randomUUID(),
+      name: "test",
+      description: "test",
+      content: "test",
+      targetAgent: "test",
+      version: 0,
+      status: "active",
+      score: 1.5,
+      runCount: 0,
+      bestInLineage: false,
+      createdAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ExecutionTraceSchema", () => {
+  it("accepts valid trace with empty feedback", () => {
+    const result = ExecutionTraceSchema.safeParse({
+      id: crypto.randomUUID(),
+      workflowName: "bug-fix",
+      runAt: new Date().toISOString(),
+      success: true,
+      totalDurationMs: 5000,
+      taskTraces: [],
+      workflowInput: { file: "main.ts" },
+      workflowOutput: { fixed: true },
+      feedback: [],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/learning/src/index.ts
+++ b/packages/learning/src/index.ts
@@ -1,2 +1,24 @@
-// @ageflow/learning — Self-evolving skill layer
-// Public API exported below as types/interfaces are added.
+// Types
+export type {
+  ExecutionTrace,
+  Feedback,
+  LearningConfig,
+  LearningThresholds,
+  ReflectEvery,
+  ScoredSkill,
+  SkillRecord,
+  TaskTrace,
+  TraceFilter,
+} from "./types.js";
+
+export {
+  DEFAULT_CONFIG,
+  DEFAULT_THRESHOLDS,
+  ExecutionTraceSchema,
+  FeedbackSchema,
+  SkillRecordSchema,
+  TaskTraceSchema,
+} from "./types.js";
+
+// Interfaces
+export type { SkillStore, TraceStore } from "./interfaces.js";

--- a/packages/learning/src/index.ts
+++ b/packages/learning/src/index.ts
@@ -1,0 +1,2 @@
+// @ageflow/learning — Self-evolving skill layer
+// Public API exported below as types/interfaces are added.

--- a/packages/learning/src/interfaces.ts
+++ b/packages/learning/src/interfaces.ts
@@ -1,0 +1,34 @@
+import type {
+  ExecutionTrace,
+  Feedback,
+  ScoredSkill,
+  SkillRecord,
+  TraceFilter,
+} from "./types.js";
+
+/** Persistent storage for learned skills. */
+export interface SkillStore {
+  save(skill: SkillRecord): Promise<void>;
+  get(id: string): Promise<SkillRecord | null>;
+  getByTarget(
+    targetAgent: string,
+    targetWorkflow?: string,
+  ): Promise<SkillRecord[]>;
+  getActiveForTask(
+    taskName: string,
+    workflowName?: string,
+  ): Promise<SkillRecord | null>;
+  getBestInLineage(skillId: string): Promise<SkillRecord | null>;
+  search(query: string, limit: number): Promise<ScoredSkill[]>;
+  list(): Promise<SkillRecord[]>;
+  retire(id: string): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+/** Persistent storage for workflow execution traces + feedback. */
+export interface TraceStore {
+  saveTrace(trace: ExecutionTrace): Promise<void>;
+  getTrace(id: string): Promise<ExecutionTrace | null>;
+  getTraces(filter: TraceFilter): Promise<ExecutionTrace[]>;
+  addFeedback(traceId: string, feedback: Feedback): Promise<void>;
+}

--- a/packages/learning/src/types.ts
+++ b/packages/learning/src/types.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+
+// ─── Feedback ─────────────────────────────────────────────────────────────────
+
+export const FeedbackSchema = z.object({
+  rating: z.enum(["positive", "negative", "mixed"]),
+  comment: z.string().optional(),
+  source: z.enum(["human", "ci", "monitoring"]),
+  timestamp: z.string().datetime(),
+});
+
+export type Feedback = z.infer<typeof FeedbackSchema>;
+
+// ─── TaskTrace ────────────────────────────────────────────────────────────────
+
+export const TaskTraceSchema = z.object({
+  taskName: z.string(),
+  agentRunner: z.string(),
+  prompt: z.string(),
+  output: z.string(),
+  parsedOutput: z.unknown(),
+  success: z.boolean(),
+  skillsApplied: z.array(z.string()),
+  tokensIn: z.number(),
+  tokensOut: z.number(),
+  durationMs: z.number(),
+  retryCount: z.number(),
+});
+
+export type TaskTrace = z.infer<typeof TaskTraceSchema>;
+
+// ─── ExecutionTrace ───────────────────────────────────────────────────────────
+
+export const ExecutionTraceSchema = z.object({
+  id: z.string().uuid(),
+  workflowName: z.string(),
+  runAt: z.string().datetime(),
+  success: z.boolean(),
+  totalDurationMs: z.number(),
+  taskTraces: z.array(TaskTraceSchema),
+  workflowInput: z.unknown(),
+  workflowOutput: z.unknown(),
+  feedback: z.array(FeedbackSchema),
+});
+
+export type ExecutionTrace = z.infer<typeof ExecutionTraceSchema>;
+
+// ─── SkillRecord ──────────────────────────────────────────────────────────────
+
+export const SkillRecordSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  content: z.string(),
+  targetAgent: z.string(),
+  targetWorkflow: z.string().optional(),
+  version: z.number().int().nonnegative(),
+  parentId: z.string().uuid().optional(),
+  status: z.enum(["active", "retired"]),
+  score: z.number().min(0).max(1),
+  runCount: z.number().int().nonnegative(),
+  bestInLineage: z.boolean(),
+  createdAt: z.string().datetime(),
+});
+
+export type SkillRecord = z.infer<typeof SkillRecordSchema>;
+
+// ─── Query types ──────────────────────────────────────────────────────────────
+
+export interface ScoredSkill {
+  readonly skill: SkillRecord;
+  /** Retrieval relevance score (0-1), NOT quality score. */
+  readonly relevance: number;
+}
+
+export interface TraceFilter {
+  readonly workflowName?: string;
+  readonly since?: string;
+  readonly limit?: number;
+  readonly hasFeedback?: boolean;
+}
+
+// ─── Learning config ──────────────────────────────────────────────────────────
+
+export interface LearningThresholds {
+  /** Score below which reflection triggers skill rewrite. Default: 0.7 */
+  readonly reflectionThreshold: number;
+  /** Score drop from best-in-lineage that triggers rollback. Default: 0.15 */
+  readonly rollbackMargin: number;
+  /** Minimum runs before rollback decision. Default: 3 */
+  readonly minRunsBeforeRollback: number;
+  /** EMA smoothing factor. Default: 0.3 */
+  readonly emaAlpha: number;
+  /** EMA alpha when delayed feedback contradicts immediate. Default: 0.5 */
+  readonly feedbackAlpha: number;
+}
+
+export const DEFAULT_THRESHOLDS: LearningThresholds = {
+  reflectionThreshold: 0.7,
+  rollbackMargin: 0.15,
+  minRunsBeforeRollback: 3,
+  emaAlpha: 0.3,
+  feedbackAlpha: 0.5,
+};
+
+export type ReflectEvery = "always" | "on-failure" | "on-feedback" | number;
+
+export interface LearningConfig {
+  readonly strategy: "autonomous" | "hitl";
+  readonly reflectEvery: ReflectEvery;
+  readonly thresholds: LearningThresholds;
+}
+
+export const DEFAULT_CONFIG: LearningConfig = {
+  strategy: "autonomous",
+  reflectEvery: "always",
+  thresholds: DEFAULT_THRESHOLDS,
+};

--- a/packages/learning/tsconfig.json
+++ b/packages/learning/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "dist", "node_modules"]
+}


### PR DESCRIPTION
Scaffolds \`@ageflow/learning\` package with types, Zod schemas, and store interfaces.

## New package: \`@ageflow/learning\`

- \`SkillRecord\` + \`SkillRecordSchema\` — learned skills with lineage tracking
- \`ExecutionTrace\` + \`TaskTrace\` — workflow execution traces for reflection
- \`Feedback\` — delayed feedback accumulation (positive/negative/mixed)
- \`LearningConfig\` + \`LearningThresholds\` — EMA scoring parameters
- \`SkillStore\` interface — pluggable skill persistence
- \`TraceStore\` interface — pluggable trace persistence

5 Zod schema tests. Typecheck + lint clean.

Part of #24.