### PR TITLE
feat(learning-sqlite): #24 Phase 3 — SQLite store implementation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -124,7 +124,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -136,7 +136,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "zod-to-json-schema": "^3.23.0",
@@ -147,9 +147,40 @@
         "zod": "^3.23.0",
       },
     },
+    "packages/learning": {
+      "name": "@ageflow/learning",
+      "version": "0.3.0",
+      "dependencies": {
+        "@ageflow/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@ageflow/executor": "workspace:*",
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.23.0",
+      },
+      "peerDependencies": {
+        "@ageflow/executor": "workspace:*",
+      },
+      "optionalPeers": [
+        "@ageflow/executor",
+      ],
+    },
+    "packages/learning-sqlite": {
+      "name": "@ageflow/learning-sqlite",
+      "version": "0.3.0",
+      "dependencies": {
+        "@ageflow/learning": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "packages/mcp-server": {
       "name": "@ageflow/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
@@ -166,7 +197,7 @@
     },
     "packages/runners/api": {
       "name": "@ageflow/runner-api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -180,7 +211,7 @@
     },
     "packages/runners/claude": {
       "name": "@ageflow/runner-claude",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -192,7 +223,7 @@
     },
     "packages/runners/codex": {
       "name": "@ageflow/runner-codex",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -204,7 +235,7 @@
     },
     "packages/server": {
       "name": "@ageflow/server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
@@ -217,7 +248,7 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ageflow/core": "workspace:*",
         "@ageflow/executor": "workspace:*",
@@ -251,6 +282,10 @@
     "@ageflow/example-mcp-server": ["@ageflow/example-mcp-server@workspace:examples/mcp-server"],
 
     "@ageflow/executor": ["@ageflow/executor@workspace:packages/executor"],
+
+    "@ageflow/learning": ["@ageflow/learning@workspace:packages/learning"],
+
+    "@ageflow/learning-sqlite": ["@ageflow/learning-sqlite@workspace:packages/learning-sqlite"],
 
     "@ageflow/mcp-server": ["@ageflow/mcp-server@workspace:packages/mcp-server"],
 

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ageflow/learning-sqlite",
+  "version": "0.3.0",
+  "description": "SQLite + sqlite-vec storage for @ageflow/learning",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
+  "type": "module",
+  "private": false,
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "bun --bun x vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@ageflow/learning": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "@types/node": "^22.0.0",
+    "vitest": "^2.1.0"
+  },
+  "license": "MIT"
+}

--- a/packages/learning-sqlite/src/__tests__/store.test.ts
+++ b/packages/learning-sqlite/src/__tests__/store.test.ts
@@ -1,0 +1,337 @@
+import { Database } from "bun:sqlite";
+import type { ExecutionTrace, Feedback, SkillRecord } from "@ageflow/learning";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MIGRATIONS } from "../migrations.js";
+import { SqliteLearningStore } from "../sqlite-learning-store.js";
+import { SqliteSkillStore } from "../sqlite-skill-store.js";
+import { SqliteTraceStore } from "../sqlite-trace-store.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkill(overrides: Partial<SkillRecord> = {}): SkillRecord {
+  return {
+    id: crypto.randomUUID(),
+    name: "test-skill",
+    description: "A test skill",
+    content: "# Skill\nDo the thing well.",
+    targetAgent: "analyze",
+    version: 0,
+    status: "active",
+    score: 0.5,
+    runCount: 0,
+    bestInLineage: true,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeTrace(overrides: Partial<ExecutionTrace> = {}): ExecutionTrace {
+  return {
+    id: crypto.randomUUID(),
+    workflowName: "bug-fix",
+    runAt: new Date().toISOString(),
+    success: true,
+    totalDurationMs: 5000,
+    taskTraces: [],
+    workflowInput: { file: "main.ts" },
+    workflowOutput: { fixed: true },
+    feedback: [],
+    ...overrides,
+  };
+}
+
+function makeFeedback(overrides: Partial<Feedback> = {}): Feedback {
+  return {
+    rating: "positive",
+    comment: "Looks good",
+    source: "human",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ─── SqliteSkillStore tests ───────────────────────────────────────────────────
+
+describe("SqliteSkillStore", () => {
+  let db: Database;
+  let store: SqliteSkillStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    for (const sql of MIGRATIONS) db.run(sql);
+    store = new SqliteSkillStore(db);
+  });
+
+  afterEach(() => db.close());
+
+  it("save + get round-trips a skill", async () => {
+    const skill = makeSkill();
+    await store.save(skill);
+    const loaded = await store.get(skill.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.name).toBe(skill.name);
+    expect(loaded?.content).toBe(skill.content);
+    expect(loaded?.targetAgent).toBe(skill.targetAgent);
+    expect(loaded?.status).toBe(skill.status);
+    expect(loaded?.score).toBe(skill.score);
+    expect(loaded?.runCount).toBe(skill.runCount);
+    expect(loaded?.bestInLineage).toBe(skill.bestInLineage);
+  });
+
+  it("get returns null for missing id", async () => {
+    const result = await store.get(crypto.randomUUID());
+    expect(result).toBeNull();
+  });
+
+  it("getActiveForTask returns the active skill for a task", async () => {
+    const s1 = makeSkill({ targetAgent: "fix", status: "active" });
+    const s2 = makeSkill({ targetAgent: "fix", status: "retired" });
+    await store.save(s1);
+    await store.save(s2);
+    const active = await store.getActiveForTask("fix");
+    expect(active).not.toBeNull();
+    expect(active?.id).toBe(s1.id);
+  });
+
+  it("getActiveForTask returns null when no active skills", async () => {
+    const s1 = makeSkill({ targetAgent: "fix", status: "retired" });
+    await store.save(s1);
+    const active = await store.getActiveForTask("fix");
+    expect(active).toBeNull();
+  });
+
+  it("getByTarget returns all skills for an agent", async () => {
+    const s1 = makeSkill({ targetAgent: "agent-a" });
+    const s2 = makeSkill({ targetAgent: "agent-a", status: "retired" });
+    const s3 = makeSkill({ targetAgent: "agent-b" });
+    await store.save(s1);
+    await store.save(s2);
+    await store.save(s3);
+    const results = await store.getByTarget("agent-a");
+    expect(results.length).toBe(2);
+  });
+
+  it("retire sets status to retired", async () => {
+    const skill = makeSkill();
+    await store.save(skill);
+    await store.retire(skill.id);
+    const loaded = await store.get(skill.id);
+    expect(loaded?.status).toBe("retired");
+  });
+
+  it("delete removes the skill", async () => {
+    const skill = makeSkill();
+    await store.save(skill);
+    await store.delete(skill.id);
+    const loaded = await store.get(skill.id);
+    expect(loaded).toBeNull();
+  });
+
+  it("list returns all skills", async () => {
+    await store.save(makeSkill());
+    await store.save(makeSkill());
+    const all = await store.list();
+    expect(all.length).toBe(2);
+  });
+
+  it("search finds skills by keyword (FTS5 fallback)", async () => {
+    const skill = makeSkill({
+      description: "root cause analysis for TypeScript",
+    });
+    await store.save(skill);
+    const results = await store.search("root cause", 10);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.skill.id).toBe(skill.id);
+  });
+
+  it("search returns empty array when no match", async () => {
+    await store.save(makeSkill({ description: "unrelated topic" }));
+    const results = await store.search("xyzzy-not-found", 10);
+    expect(results.length).toBe(0);
+  });
+
+  it("getBestInLineage returns highest-scoring version", async () => {
+    const v1 = makeSkill({ version: 0, score: 0.6, bestInLineage: false });
+    const v2 = makeSkill({
+      version: 1,
+      score: 0.9,
+      parentId: v1.id,
+      bestInLineage: true,
+    });
+    const v3 = makeSkill({
+      version: 2,
+      score: 0.4,
+      parentId: v2.id,
+      bestInLineage: false,
+    });
+    await store.save(v1);
+    await store.save(v2);
+    await store.save(v3);
+    const best = await store.getBestInLineage(v3.id);
+    expect(best).not.toBeNull();
+    expect(best?.id).toBe(v2.id);
+  });
+
+  it("getBestInLineage returns the skill itself when it has no parent", async () => {
+    const skill = makeSkill({ score: 0.8, bestInLineage: true });
+    await store.save(skill);
+    const best = await store.getBestInLineage(skill.id);
+    expect(best).not.toBeNull();
+    expect(best?.id).toBe(skill.id);
+  });
+});
+
+// ─── SqliteTraceStore tests ───────────────────────────────────────────────────
+
+describe("SqliteTraceStore", () => {
+  let db: Database;
+  let store: SqliteTraceStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    for (const sql of MIGRATIONS) db.run(sql);
+    store = new SqliteTraceStore(db);
+  });
+
+  afterEach(() => db.close());
+
+  it("save + get round-trips a trace", async () => {
+    const trace = makeTrace();
+    await store.saveTrace(trace);
+    const loaded = await store.getTrace(trace.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.workflowName).toBe(trace.workflowName);
+    expect(loaded?.success).toBe(trace.success);
+    expect(loaded?.totalDurationMs).toBe(trace.totalDurationMs);
+    expect(loaded?.feedback).toEqual([]);
+    expect(loaded?.taskTraces).toEqual([]);
+  });
+
+  it("getTrace returns null for missing id", async () => {
+    const result = await store.getTrace(crypto.randomUUID());
+    expect(result).toBeNull();
+  });
+
+  it("addFeedback appends to existing trace", async () => {
+    const trace = makeTrace();
+    await store.saveTrace(trace);
+    const fb = makeFeedback();
+    await store.addFeedback(trace.id, fb);
+    const loaded = await store.getTrace(trace.id);
+    expect(loaded?.feedback.length).toBe(1);
+    expect(loaded?.feedback[0]?.rating).toBe("positive");
+  });
+
+  it("addFeedback appends multiple feedbacks", async () => {
+    const trace = makeTrace();
+    await store.saveTrace(trace);
+    await store.addFeedback(trace.id, makeFeedback({ rating: "positive" }));
+    await store.addFeedback(
+      trace.id,
+      makeFeedback({ rating: "negative", comment: "actually bad" }),
+    );
+    const loaded = await store.getTrace(trace.id);
+    expect(loaded?.feedback.length).toBe(2);
+  });
+
+  it("getTraces filters by workflowName", async () => {
+    await store.saveTrace(makeTrace({ workflowName: "workflow-a" }));
+    await store.saveTrace(makeTrace({ workflowName: "workflow-b" }));
+    const results = await store.getTraces({ workflowName: "workflow-a" });
+    expect(results.length).toBe(1);
+    expect(results[0]?.workflowName).toBe("workflow-a");
+  });
+
+  it("getTraces filters by hasFeedback=true", async () => {
+    const withFeedback = makeTrace();
+    const noFeedback = makeTrace();
+    await store.saveTrace(withFeedback);
+    await store.saveTrace(noFeedback);
+    await store.addFeedback(withFeedback.id, makeFeedback());
+    const results = await store.getTraces({ hasFeedback: true });
+    expect(results.length).toBe(1);
+    expect(results[0]?.id).toBe(withFeedback.id);
+  });
+
+  it("getTraces filters by hasFeedback=false", async () => {
+    const withFeedback = makeTrace();
+    const noFeedback = makeTrace();
+    await store.saveTrace(withFeedback);
+    await store.saveTrace(noFeedback);
+    await store.addFeedback(withFeedback.id, makeFeedback());
+    const results = await store.getTraces({ hasFeedback: false });
+    expect(results.length).toBe(1);
+    expect(results[0]?.id).toBe(noFeedback.id);
+  });
+
+  it("getTraces filters by since", async () => {
+    const old = makeTrace({ runAt: "2020-01-01T00:00:00.000Z" });
+    const recent = makeTrace({ runAt: new Date().toISOString() });
+    await store.saveTrace(old);
+    await store.saveTrace(recent);
+    const results = await store.getTraces({
+      since: "2024-01-01T00:00:00.000Z",
+    });
+    expect(results.length).toBe(1);
+    expect(results[0]?.id).toBe(recent.id);
+  });
+
+  it("getTraces respects limit", async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.saveTrace(makeTrace());
+    }
+    const results = await store.getTraces({ limit: 3 });
+    expect(results.length).toBe(3);
+  });
+
+  it("getTraces with no filter returns all", async () => {
+    await store.saveTrace(makeTrace());
+    await store.saveTrace(makeTrace());
+    const results = await store.getTraces({});
+    expect(results.length).toBe(2);
+  });
+});
+
+// ─── SqliteLearningStore tests ────────────────────────────────────────────────
+
+describe("SqliteLearningStore", () => {
+  let store: SqliteLearningStore;
+
+  beforeEach(() => {
+    store = new SqliteLearningStore(new Database(":memory:"));
+  });
+
+  it("implements SkillStore: save + get", async () => {
+    const skill = makeSkill();
+    await store.save(skill);
+    const loaded = await store.get(skill.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.id).toBe(skill.id);
+  });
+
+  it("implements TraceStore: saveTrace + getTrace", async () => {
+    const trace = makeTrace();
+    await store.saveTrace(trace);
+    const loaded = await store.getTrace(trace.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.id).toBe(trace.id);
+  });
+
+  it("implements both interfaces on same database", async () => {
+    const skill = makeSkill();
+    const trace = makeTrace();
+    await store.save(skill);
+    await store.saveTrace(trace);
+    const [s, t] = await Promise.all([
+      store.get(skill.id),
+      store.getTrace(trace.id),
+    ]);
+    expect(s?.id).toBe(skill.id);
+    expect(t?.id).toBe(trace.id);
+  });
+
+  it("accepts a file path string", () => {
+    // SqliteLearningStore should construct itself without throwing
+    expect(() => new SqliteLearningStore(":memory:")).not.toThrow();
+  });
+});

--- a/packages/learning-sqlite/src/index.ts
+++ b/packages/learning-sqlite/src/index.ts
@@ -1,0 +1,5 @@
+// @ageflow/learning-sqlite — SQLite-backed stores for @ageflow/learning
+export { MIGRATIONS } from "./migrations.js";
+export { SqliteSkillStore } from "./sqlite-skill-store.js";
+export { SqliteTraceStore } from "./sqlite-trace-store.js";
+export { SqliteLearningStore } from "./sqlite-learning-store.js";

--- a/packages/learning-sqlite/src/migrations.ts
+++ b/packages/learning-sqlite/src/migrations.ts
@@ -1,0 +1,46 @@
+/** SQL statements to initialize the learning database schema. */
+export const MIGRATIONS = [
+  // Skills table
+  `CREATE TABLE IF NOT EXISTS skills (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    content TEXT NOT NULL,
+    target_agent TEXT NOT NULL,
+    target_workflow TEXT,
+    version INTEGER NOT NULL DEFAULT 0,
+    parent_id TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'retired')),
+    score REAL NOT NULL DEFAULT 0.5,
+    run_count INTEGER NOT NULL DEFAULT 0,
+    best_in_lineage INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (parent_id) REFERENCES skills(id)
+  )`,
+
+  // Index for task+workflow lookup
+  `CREATE INDEX IF NOT EXISTS idx_skills_target
+   ON skills(target_agent, target_workflow, status)`,
+
+  // FTS5 for keyword search fallback (stored content — simpler than external content table)
+  `CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
+    skill_id UNINDEXED, name, description
+  )`,
+
+  // Traces table
+  `CREATE TABLE IF NOT EXISTS traces (
+    id TEXT PRIMARY KEY,
+    workflow_name TEXT NOT NULL,
+    run_at TEXT NOT NULL,
+    success INTEGER NOT NULL,
+    total_duration_ms INTEGER NOT NULL,
+    task_traces TEXT NOT NULL,
+    workflow_input TEXT,
+    workflow_output TEXT,
+    feedback TEXT NOT NULL DEFAULT '[]'
+  )`,
+
+  // Index for workflow lookup
+  `CREATE INDEX IF NOT EXISTS idx_traces_workflow
+   ON traces(workflow_name, run_at DESC)`,
+] as const;

--- a/packages/learning-sqlite/src/sqlite-learning-store.ts
+++ b/packages/learning-sqlite/src/sqlite-learning-store.ts
@@ -1,0 +1,91 @@
+import { Database } from "bun:sqlite";
+import type {
+  ExecutionTrace,
+  Feedback,
+  ScoredSkill,
+  SkillRecord,
+  SkillStore,
+  TraceFilter,
+  TraceStore,
+} from "@ageflow/learning";
+import { MIGRATIONS } from "./migrations.js";
+import { SqliteSkillStore } from "./sqlite-skill-store.js";
+import { SqliteTraceStore } from "./sqlite-trace-store.js";
+
+/**
+ * Convenience wrapper — single SQLite database backing both stores.
+ * Implements SkillStore & TraceStore.
+ */
+export class SqliteLearningStore implements SkillStore, TraceStore {
+  private readonly skillStore: SqliteSkillStore;
+  private readonly traceStore: SqliteTraceStore;
+
+  constructor(pathOrDb: string | Database) {
+    const db = typeof pathOrDb === "string" ? new Database(pathOrDb) : pathOrDb;
+    for (const sql of MIGRATIONS) db.run(sql);
+    this.skillStore = new SqliteSkillStore(db);
+    this.traceStore = new SqliteTraceStore(db);
+  }
+
+  // ─── SkillStore delegation ─────────────────────────────────────────────────
+
+  save(skill: SkillRecord): Promise<void> {
+    return this.skillStore.save(skill);
+  }
+
+  get(id: string): Promise<SkillRecord | null> {
+    return this.skillStore.get(id);
+  }
+
+  getByTarget(
+    targetAgent: string,
+    targetWorkflow?: string,
+  ): Promise<SkillRecord[]> {
+    return this.skillStore.getByTarget(targetAgent, targetWorkflow);
+  }
+
+  getActiveForTask(
+    taskName: string,
+    workflowName?: string,
+  ): Promise<SkillRecord | null> {
+    return this.skillStore.getActiveForTask(taskName, workflowName);
+  }
+
+  getBestInLineage(skillId: string): Promise<SkillRecord | null> {
+    return this.skillStore.getBestInLineage(skillId);
+  }
+
+  search(query: string, limit: number): Promise<ScoredSkill[]> {
+    return this.skillStore.search(query, limit);
+  }
+
+  list(): Promise<SkillRecord[]> {
+    return this.skillStore.list();
+  }
+
+  retire(id: string): Promise<void> {
+    return this.skillStore.retire(id);
+  }
+
+  delete(id: string): Promise<void> {
+    return this.skillStore.delete(id);
+  }
+
+  // ─── TraceStore delegation ─────────────────────────────────────────────────
+
+  saveTrace(trace: ExecutionTrace): Promise<void> {
+    return this.traceStore.saveTrace(trace);
+  }
+
+  getTrace(id: string): Promise<ExecutionTrace | null> {
+    return this.traceStore.getTrace(id);
+  }
+
+  getTraces(filter: TraceFilter): Promise<ExecutionTrace[]> {
+    return this.traceStore.getTraces(filter);
+  }
+
+  addFeedback(traceId: string, feedback: Feedback): Promise<void> {
+    return this.traceStore.addFeedback(traceId, feedback);
+  }
+}

--- a/packages/learning-sqlite/src/sqlite-skill-store.ts
+++ b/packages/learning-sqlite/src/sqlite-skill-store.ts
@@ -1,0 +1,245 @@
+import type { Database } from "bun:sqlite";
+import type { ScoredSkill, SkillRecord, SkillStore } from "@ageflow/learning";
+
+// ─── Row type from SQLite ─────────────────────────────────────────────────────
+
+interface SkillRow {
+  id: string;
+  name: string;
+  description: string;
+  content: string;
+  target_agent: string;
+  target_workflow: string | null;
+  version: number;
+  parent_id: string | null;
+  status: "active" | "retired";
+  score: number;
+  run_count: number;
+  best_in_lineage: number;
+  created_at: string;
+}
+
+// ─── Mapping ──────────────────────────────────────────────────────────────────
+
+function rowToRecord(row: SkillRow): SkillRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    content: row.content,
+    targetAgent: row.target_agent,
+    targetWorkflow: row.target_workflow ?? undefined,
+    version: row.version,
+    parentId: row.parent_id ?? undefined,
+    status: row.status,
+    score: row.score,
+    runCount: row.run_count,
+    bestInLineage: row.best_in_lineage === 1,
+    createdAt: row.created_at,
+  };
+}
+
+// ─── SqliteSkillStore ─────────────────────────────────────────────────────────
+
+export class SqliteSkillStore implements SkillStore {
+  constructor(private readonly db: Database) {}
+
+  async save(skill: SkillRecord): Promise<void> {
+    // Insert or replace in skills table
+    this.db
+      .query(
+        `INSERT OR REPLACE INTO skills
+           (id, name, description, content, target_agent, target_workflow,
+            version, parent_id, status, score, run_count, best_in_lineage, created_at)
+         VALUES
+           ($id, $name, $description, $content, $targetAgent, $targetWorkflow,
+            $version, $parentId, $status, $score, $runCount, $bestInLineage, $createdAt)`,
+      )
+      .run({
+        $id: skill.id,
+        $name: skill.name,
+        $description: skill.description,
+        $content: skill.content,
+        $targetAgent: skill.targetAgent,
+        $targetWorkflow: skill.targetWorkflow ?? null,
+        $version: skill.version,
+        $parentId: skill.parentId ?? null,
+        $status: skill.status,
+        $score: skill.score,
+        $runCount: skill.runCount,
+        $bestInLineage: skill.bestInLineage ? 1 : 0,
+        $createdAt: skill.createdAt,
+      });
+
+    // Sync FTS5: remove old entry if exists, insert fresh
+    this.db
+      .query("DELETE FROM skills_fts WHERE skill_id = $id")
+      .run({ $id: skill.id });
+    this.db
+      .query(
+        `INSERT INTO skills_fts(skill_id, name, description)
+         VALUES ($id, $name, $description)`,
+      )
+      .run({
+        $id: skill.id,
+        $name: skill.name,
+        $description: skill.description,
+      });
+  }
+
+  async get(id: string): Promise<SkillRecord | null> {
+    const row = this.db
+      .query<SkillRow, { $id: string }>("SELECT * FROM skills WHERE id = $id")
+      .get({ $id: id });
+    return row ? rowToRecord(row) : null;
+  }
+
+  async getByTarget(
+    targetAgent: string,
+    targetWorkflow?: string,
+  ): Promise<SkillRecord[]> {
+    let rows: SkillRow[];
+    if (targetWorkflow !== undefined) {
+      rows = this.db
+        .query<SkillRow, { $agent: string; $workflow: string }>(
+          `SELECT * FROM skills
+           WHERE target_agent = $agent AND target_workflow = $workflow
+           ORDER BY score DESC`,
+        )
+        .all({ $agent: targetAgent, $workflow: targetWorkflow });
+    } else {
+      rows = this.db
+        .query<SkillRow, { $agent: string }>(
+          `SELECT * FROM skills
+           WHERE target_agent = $agent
+           ORDER BY score DESC`,
+        )
+        .all({ $agent: targetAgent });
+    }
+    return rows.map(rowToRecord);
+  }
+
+  async getActiveForTask(
+    taskName: string,
+    workflowName?: string,
+  ): Promise<SkillRecord | null> {
+    let row: SkillRow | null;
+    if (workflowName !== undefined) {
+      row = this.db
+        .query<SkillRow, { $agent: string; $workflow: string }>(
+          `SELECT * FROM skills
+           WHERE target_agent = $agent
+             AND target_workflow = $workflow
+             AND status = 'active'
+           ORDER BY score DESC
+           LIMIT 1`,
+        )
+        .get({ $agent: taskName, $workflow: workflowName });
+    } else {
+      row = this.db
+        .query<SkillRow, { $agent: string }>(
+          `SELECT * FROM skills
+           WHERE target_agent = $agent AND status = 'active'
+           ORDER BY score DESC
+           LIMIT 1`,
+        )
+        .get({ $agent: taskName });
+    }
+    return row ? rowToRecord(row) : null;
+  }
+
+  async getBestInLineage(skillId: string): Promise<SkillRecord | null> {
+    // Traverse parent chain to collect all skill ids in the lineage
+    const ids: string[] = [];
+    let currentId: string | null = skillId;
+
+    while (currentId !== null) {
+      ids.push(currentId);
+      const parentRow = this.db
+        .query<{ parent_id: string | null }, { $id: string }>(
+          "SELECT parent_id FROM skills WHERE id = $id",
+        )
+        .get({ $id: currentId });
+      currentId = parentRow?.parent_id ?? null;
+    }
+
+    if (ids.length === 0) return null;
+
+    // Among all collected ids, find the one with max score
+    const placeholders = ids.map((_, i) => `$id${i}`).join(", ");
+    const params: Record<string, string> = {};
+    for (let i = 0; i < ids.length; i++) {
+      params[`$id${i}`] = ids[i] as string;
+    }
+
+    const row = this.db
+      .query<SkillRow, Record<string, string>>(
+        `SELECT * FROM skills WHERE id IN (${placeholders}) ORDER BY score DESC LIMIT 1`,
+      )
+      .get(params);
+
+    return row ? rowToRecord(row) : null;
+  }
+
+  async search(query: string, limit: number): Promise<ScoredSkill[]> {
+    interface FtsRow {
+      skill_id: string;
+      rank: number;
+    }
+
+    // Wrap the query in double-quotes to treat it as a phrase literal,
+    // avoiding FTS5 keyword conflicts (NOT, AND, OR, etc.)
+    const safeQuery = `"${query.replace(/"/g, '""')}"`;
+
+    const ftsRows = this.db
+      .query<FtsRow, { $query: string; $limit: number }>(
+        `SELECT skill_id, rank
+         FROM skills_fts
+         WHERE skills_fts MATCH $query
+         ORDER BY rank
+         LIMIT $limit`,
+      )
+      .all({ $query: safeQuery, $limit: limit });
+
+    const results: ScoredSkill[] = [];
+    for (const ftsRow of ftsRows) {
+      const skillRow = this.db
+        .query<SkillRow, { $id: string }>("SELECT * FROM skills WHERE id = $id")
+        .get({ $id: ftsRow.skill_id });
+      if (skillRow) {
+        results.push({
+          skill: rowToRecord(skillRow),
+          // FTS5 rank is negative; normalize to [0,1] relevance heuristic
+          relevance: Math.max(0, Math.min(1, 1 / (1 + Math.abs(ftsRow.rank)))),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  async list(): Promise<SkillRecord[]> {
+    const rows = this.db
+      .query<SkillRow, never[]>("SELECT * FROM skills ORDER BY created_at DESC")
+      .all();
+    return rows.map(rowToRecord);
+  }
+
+  async retire(id: string): Promise<void> {
+    this.db
+      .query<null, { $id: string }>(
+        `UPDATE skills SET status = 'retired' WHERE id = $id`,
+      )
+      .run({ $id: id });
+  }
+
+  async delete(id: string): Promise<void> {
+    // Clean up FTS5 first
+    this.db
+      .query("DELETE FROM skills_fts WHERE skill_id = $id")
+      .run({ $id: id });
+    this.db
+      .query<null, { $id: string }>("DELETE FROM skills WHERE id = $id")
+      .run({ $id: id });
+  }
+}

--- a/packages/learning-sqlite/src/sqlite-trace-store.ts
+++ b/packages/learning-sqlite/src/sqlite-trace-store.ts
@@ -1,0 +1,140 @@
+import type { Database } from "bun:sqlite";
+import type {
+  ExecutionTrace,
+  Feedback,
+  TraceFilter,
+  TraceStore,
+} from "@ageflow/learning";
+
+// ─── Row type from SQLite ─────────────────────────────────────────────────────
+
+interface TraceRow {
+  id: string;
+  workflow_name: string;
+  run_at: string;
+  success: number;
+  total_duration_ms: number;
+  task_traces: string;
+  workflow_input: string | null;
+  workflow_output: string | null;
+  feedback: string;
+}
+
+// ─── Mapping ──────────────────────────────────────────────────────────────────
+
+function rowToTrace(row: TraceRow): ExecutionTrace {
+  return {
+    id: row.id,
+    workflowName: row.workflow_name,
+    runAt: row.run_at,
+    success: row.success === 1,
+    totalDurationMs: row.total_duration_ms,
+    taskTraces: JSON.parse(row.task_traces) as ExecutionTrace["taskTraces"],
+    workflowInput:
+      row.workflow_input !== null
+        ? (JSON.parse(row.workflow_input) as unknown)
+        : undefined,
+    workflowOutput:
+      row.workflow_output !== null
+        ? (JSON.parse(row.workflow_output) as unknown)
+        : undefined,
+    feedback: JSON.parse(row.feedback) as Feedback[],
+  };
+}
+
+// ─── SqliteTraceStore ─────────────────────────────────────────────────────────
+
+export class SqliteTraceStore implements TraceStore {
+  constructor(private readonly db: Database) {}
+
+  async saveTrace(trace: ExecutionTrace): Promise<void> {
+    this.db
+      .query(
+        `INSERT OR REPLACE INTO traces
+           (id, workflow_name, run_at, success, total_duration_ms,
+            task_traces, workflow_input, workflow_output, feedback)
+         VALUES
+           ($id, $workflowName, $runAt, $success, $totalDurationMs,
+            $taskTraces, $workflowInput, $workflowOutput, $feedback)`,
+      )
+      .run({
+        $id: trace.id,
+        $workflowName: trace.workflowName,
+        $runAt: trace.runAt,
+        $success: trace.success ? 1 : 0,
+        $totalDurationMs: trace.totalDurationMs,
+        $taskTraces: JSON.stringify(trace.taskTraces),
+        $workflowInput:
+          trace.workflowInput !== undefined
+            ? JSON.stringify(trace.workflowInput)
+            : null,
+        $workflowOutput:
+          trace.workflowOutput !== undefined
+            ? JSON.stringify(trace.workflowOutput)
+            : null,
+        $feedback: JSON.stringify(trace.feedback),
+      });
+  }
+
+  async getTrace(id: string): Promise<ExecutionTrace | null> {
+    const row = this.db
+      .query<TraceRow, { $id: string }>("SELECT * FROM traces WHERE id = $id")
+      .get({ $id: id });
+    return row ? rowToTrace(row) : null;
+  }
+
+  async getTraces(filter: TraceFilter): Promise<ExecutionTrace[]> {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (filter.workflowName !== undefined) {
+      conditions.push("workflow_name = $workflowName");
+      params.$workflowName = filter.workflowName;
+    }
+
+    if (filter.since !== undefined) {
+      conditions.push("run_at >= $since");
+      params.$since = filter.since;
+    }
+
+    if (filter.hasFeedback === true) {
+      conditions.push("feedback != '[]'");
+    } else if (filter.hasFeedback === false) {
+      conditions.push("feedback = '[]'");
+    }
+
+    const where =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limitClause =
+      filter.limit !== undefined ? `LIMIT ${filter.limit}` : "";
+
+    const rows = this.db
+      .prepare<TraceRow, Record<string, string | number | null | boolean>>(
+        `SELECT * FROM traces ${where} ORDER BY run_at DESC ${limitClause}`,
+      )
+      .all(params as Record<string, string | number | null | boolean>);
+
+    return rows.map(rowToTrace);
+  }
+
+  async addFeedback(traceId: string, feedback: Feedback): Promise<void> {
+    const row = this.db
+      .query<{ feedback: string }, { $id: string }>(
+        "SELECT feedback FROM traces WHERE id = $id",
+      )
+      .get({ $id: traceId });
+
+    if (!row) {
+      throw new Error(`Trace not found: ${traceId}`);
+    }
+
+    const existing = JSON.parse(row.feedback) as Feedback[];
+    existing.push(feedback);
+
+    this.db
+      .query<null, { $feedback: string; $id: string }>(
+        "UPDATE traces SET feedback = $feedback WHERE id = $id",
+      )
+      .run({ $feedback: JSON.stringify(existing), $id: traceId });
+  }
+}

--- a/packages/learning-sqlite/tsconfig.json
+++ b/packages/learning-sqlite/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "dist", "node_modules"]
+}

--- a/packages/learning-sqlite/vitest.config.ts
+++ b/packages/learning-sqlite/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
New package \`@ageflow/learning-sqlite\` — SQLite + FTS5 storage for the learning system.

## What

- \`SqliteSkillStore\` — SkillStore interface via bun:sqlite (save, get, search via FTS5, lineage traversal, retire)
- \`SqliteTraceStore\` — TraceStore interface (traces with JSON-serialized taskTraces + feedback accumulation)
- \`SqliteLearningStore\` — convenience class implementing both interfaces on a single Database
- Schema migrations with skills table, FTS5 index, traces table

## Tests

26 tests covering CRUD, FTS5 search, lineage (getBestInLineage), feedback append, trace filtering.

Part of #24.