### PR TITLE
feat(learning): #24 Phases 4+5 — createLearningHooks + EMA scoring

### DIFF
--- a/packages/learning/src/__tests__/hooks.test.ts
+++ b/packages/learning/src/__tests__/hooks.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLearningHooks } from "../hooks.js";
+import type { SkillStore, TraceStore } from "../interfaces.js";
+import type {
+  ExecutionTrace,
+  Feedback,
+  ScoredSkill,
+  SkillRecord,
+  TraceFilter,
+} from "../types.js";
+
+// ─── In-memory mock stores ────────────────────────────────────────────────────
+
+function makeSkillRecord(overrides: Partial<SkillRecord> = {}): SkillRecord {
+  return {
+    id: crypto.randomUUID(),
+    name: "test-skill",
+    description: "A test skill",
+    content: "Always check adjacent modules first.",
+    targetAgent: "analyze",
+    targetWorkflow: "bug-fix",
+    version: 1,
+    status: "active",
+    score: 0.8,
+    runCount: 5,
+    bestInLineage: true,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeSkillStore(activeSkill: SkillRecord | null = null): SkillStore {
+  const records = new Map<string, SkillRecord>();
+  if (activeSkill) records.set(activeSkill.id, activeSkill);
+  return {
+    save: vi.fn(async (skill: SkillRecord) => {
+      records.set(skill.id, skill);
+    }),
+    get: vi.fn(async (id: string) => records.get(id) ?? null),
+    getByTarget: vi.fn(async () => [...records.values()]),
+    getActiveForTask: vi.fn(async () => activeSkill),
+    getBestInLineage: vi.fn(async () => null),
+    search: vi.fn(async (): Promise<ScoredSkill[]> => []),
+    list: vi.fn(async () => [...records.values()]),
+    retire: vi.fn(async () => {}),
+    delete: vi.fn(async (id: string) => {
+      records.delete(id);
+    }),
+  };
+}
+
+function makeTraceStore(): TraceStore & { traces: ExecutionTrace[] } {
+  const traces: ExecutionTrace[] = [];
+  return {
+    traces,
+    saveTrace: vi.fn(async (trace: ExecutionTrace) => {
+      traces.push(trace);
+    }),
+    getTrace: vi.fn(
+      async (id: string) => traces.find((t) => t.id === id) ?? null,
+    ),
+    getTraces: vi.fn(async (_filter: TraceFilter) => traces),
+    addFeedback: vi.fn(async (_traceId: string, _feedback: Feedback) => {}),
+  };
+}
+
+const makeMetrics = () => ({
+  totalLatencyMs: 1000,
+  totalTokensIn: 100,
+  totalTokensOut: 50,
+  totalEstimatedCost: 0.01,
+  taskCount: 1,
+});
+
+const makeTaskMetrics = () => ({
+  tokensIn: 100,
+  tokensOut: 50,
+  latencyMs: 500,
+  retries: 0,
+  estimatedCost: 0.005,
+  promptSent: "test prompt",
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("createLearningHooks", () => {
+  it("returns a valid WorkflowHooks object with expected hook properties", () => {
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore: makeTraceStore(),
+      workflowName: "test-workflow",
+    });
+
+    expect(hooks).toBeDefined();
+    expect(typeof hooks.onTaskStart).toBe("function");
+    expect(typeof hooks.getSystemPromptPrefix).toBe("function");
+    expect(typeof hooks.onTaskComplete).toBe("function");
+    expect(typeof hooks.onTaskError).toBe("function");
+    expect(typeof hooks.onWorkflowComplete).toBe("function");
+  });
+
+  it("getSystemPromptPrefix returns skill content when active skill exists", async () => {
+    const skill = makeSkillRecord({ content: "Use structured output always." });
+    const skillStore = makeSkillStore(skill);
+    const hooks = createLearningHooks({
+      skillStore,
+      traceStore: makeTraceStore(),
+      workflowName: "bug-fix",
+    });
+
+    // Trigger cache population
+    hooks.onTaskStart?.("analyze");
+    await vi.waitFor(() => {
+      const result = hooks.getSystemPromptPrefix?.("analyze");
+      expect(result).toBe("Use structured output always.");
+    });
+  });
+
+  it("getSystemPromptPrefix returns undefined when no skill exists", async () => {
+    const skillStore = makeSkillStore(null);
+    const hooks = createLearningHooks({
+      skillStore,
+      traceStore: makeTraceStore(),
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze");
+    await vi.waitFor(() => {
+      const result = hooks.getSystemPromptPrefix?.("analyze");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it("onWorkflowComplete saves ExecutionTrace to traceStore", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze");
+    hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+    expect(traceStore.traces).toHaveLength(1);
+    const trace = traceStore.traces[0];
+    expect(trace.workflowName).toBe("bug-fix");
+    expect(trace.success).toBe(true);
+    expect(trace.taskTraces).toHaveLength(1);
+    expect(trace.workflowOutput).toEqual({ fixed: true });
+  });
+
+  it("TaskTrace includes skillsApplied when a skill was active", async () => {
+    const skill = makeSkillRecord({ content: "Always verify." });
+    const skillStore = makeSkillStore(skill);
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore,
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    // Pre-populate cache
+    hooks.onTaskStart?.("analyze");
+    await vi.waitFor(() => {
+      return hooks.getSystemPromptPrefix?.("analyze") !== undefined;
+    });
+
+    hooks.onTaskComplete?.("analyze", "output text", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].skillsApplied).toContain("analyze");
+  });
+
+  it("TaskTrace does not include skillsApplied when no skill was active", async () => {
+    const skillStore = makeSkillStore(null);
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore,
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze");
+    await vi.waitFor(() => {
+      const result = hooks.getSystemPromptPrefix?.("analyze");
+      return result === undefined;
+    });
+
+    hooks.onTaskComplete?.("analyze", "output", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].skillsApplied).toHaveLength(0);
+  });
+
+  it("multiple runs reset task traces correctly", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    // Run 1
+    hooks.onTaskStart?.("taskA");
+    hooks.onTaskComplete?.("taskA", "out1", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    // Run 2
+    hooks.onTaskStart?.("taskB");
+    hooks.onTaskComplete?.("taskB", "out2", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    // Each trace should only have one task from that run
+    expect(traceStore.traces).toHaveLength(2);
+    expect(traceStore.traces[0].taskTraces).toHaveLength(1);
+    expect(traceStore.traces[0].taskTraces[0].taskName).toBe("taskA");
+    expect(traceStore.traces[1].taskTraces).toHaveLength(1);
+    expect(traceStore.traces[1].taskTraces[0].taskName).toBe("taskB");
+  });
+
+  it("onTaskError records failed TaskTrace", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze");
+    hooks.onTaskError?.("analyze", new Error("timeout"), 2);
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].success).toBe(false);
+    expect(trace.taskTraces[0].output).toBe("timeout");
+    expect(trace.taskTraces[0].retryCount).toBe(2);
+  });
+});

--- a/packages/learning/src/__tests__/scoring.test.ts
+++ b/packages/learning/src/__tests__/scoring.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { shouldRollback, updateScore } from "../scoring.js";
+import { DEFAULT_THRESHOLDS } from "../types.js";
+
+describe("updateScore", () => {
+  it("applies EMA with default alpha 0.3", () => {
+    // new = 0.3 * 1.0 + 0.7 * 0.5 = 0.3 + 0.35 = 0.65
+    const result = updateScore(0.5, 1.0, false, DEFAULT_THRESHOLDS);
+    expect(result).toBeCloseTo(0.65, 10);
+  });
+
+  it("uses higher alpha 0.5 for delayed feedback", () => {
+    // new = 0.5 * 1.0 + 0.5 * 0.5 = 0.5 + 0.25 = 0.75
+    const result = updateScore(0.5, 1.0, true, DEFAULT_THRESHOLDS);
+    expect(result).toBeCloseTo(0.75, 10);
+  });
+
+  it("clamps result to 0 when EMA would go below 0", () => {
+    // new = 0.3 * 0 + 0.7 * 0 = 0 — stays at 0
+    const result = updateScore(0, 0, false, DEFAULT_THRESHOLDS);
+    expect(result).toBe(0);
+  });
+
+  it("clamps result to 1 when EMA would exceed 1", () => {
+    // new = 0.3 * 1 + 0.7 * 1 = 1 — stays at 1
+    const result = updateScore(1, 1, false, DEFAULT_THRESHOLDS);
+    expect(result).toBe(1);
+  });
+
+  it("clamps to [0, 1] even with edge signals", () => {
+    // Force a scenario: currentScore=0, signal=0 -> 0 (min clamp path)
+    // currentScore=1, signal=1 -> 1 (max clamp path)
+    expect(updateScore(0, 0, true, DEFAULT_THRESHOLDS)).toBe(0);
+    expect(updateScore(1, 1, true, DEFAULT_THRESHOLDS)).toBe(1);
+  });
+});
+
+describe("shouldRollback", () => {
+  it("returns false when runCount < minRunsBeforeRollback (3)", () => {
+    // minRunsBeforeRollback = 3, runCount = 2 → false
+    const result = shouldRollback(0.3, 0.9, 2, DEFAULT_THRESHOLDS);
+    expect(result).toBe(false);
+  });
+
+  it("returns false when score is within rollback margin (0.15)", () => {
+    // bestScore=0.8, currentScore=0.7, diff=0.1 < margin=0.15 → false
+    const result = shouldRollback(0.7, 0.8, 5, DEFAULT_THRESHOLDS);
+    expect(result).toBe(false);
+  });
+
+  it("returns false when score equals best minus margin exactly", () => {
+    // bestScore=0.8, currentScore=0.65, diff=0.15 — not strictly below → false
+    const result = shouldRollback(0.65, 0.8, 5, DEFAULT_THRESHOLDS);
+    expect(result).toBe(false);
+  });
+
+  it("returns true when score drops below best minus margin", () => {
+    // bestScore=0.8, currentScore=0.6, diff=0.2 > margin=0.15 → true
+    const result = shouldRollback(0.6, 0.8, 5, DEFAULT_THRESHOLDS);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when runCount equals minRunsBeforeRollback - 1", () => {
+    const result = shouldRollback(0.1, 0.9, 2, DEFAULT_THRESHOLDS);
+    expect(result).toBe(false);
+  });
+
+  it("returns true with runCount exactly at minRunsBeforeRollback and bad score", () => {
+    // runCount=3 >= 3, score=0.5, best=0.8, diff=0.3 > 0.15 → true
+    const result = shouldRollback(0.5, 0.8, 3, DEFAULT_THRESHOLDS);
+    expect(result).toBe(true);
+  });
+});

--- a/packages/learning/src/hooks.ts
+++ b/packages/learning/src/hooks.ts
@@ -1,0 +1,124 @@
+import type { WorkflowHooks } from "@ageflow/core";
+import type { SkillStore, TraceStore } from "./interfaces.js";
+import type { ExecutionTrace, LearningConfig, TaskTrace } from "./types.js";
+import { DEFAULT_CONFIG } from "./types.js";
+
+export interface CreateLearningHooksOptions {
+  readonly skillStore: SkillStore;
+  readonly traceStore: TraceStore;
+  readonly workflowName: string;
+  readonly config?: Partial<LearningConfig>;
+}
+
+export function createLearningHooks(
+  opts: CreateLearningHooksOptions,
+): WorkflowHooks {
+  const _config = { ...DEFAULT_CONFIG, ...opts.config }; // reserved for Phase 6
+  const { skillStore, traceStore, workflowName } = opts;
+
+  // Per-run state (reset on each workflow execution)
+  let taskTraces: TaskTrace[] = [];
+  let runStartTime = Date.now();
+  let runCount = 0;
+  let isFirstTaskOfRun = true;
+
+  // Cache active skills per task (populated async on onTaskStart)
+  // Maps taskName -> skill content string or null (null = no skill found)
+  const skillCache = new Map<string, string | null>();
+
+  return {
+    onTaskStart(taskName) {
+      if (isFirstTaskOfRun) {
+        // Reset state for the new run
+        taskTraces = [];
+        runStartTime = Date.now();
+        skillCache.clear();
+        isFirstTaskOfRun = false;
+      }
+
+      // Async pre-populate cache — fire and don't await (sync hook)
+      // The cache will be ready by the time getSystemPromptPrefix is called
+      // if there's any async gap (e.g. executor awaits before spawn).
+      // We store a promise so repeated calls don't double-fetch.
+      if (!skillCache.has(taskName)) {
+        // Mark as in-flight with undefined to prevent double calls
+        skillStore
+          .getActiveForTask(taskName, workflowName)
+          .then((skill) => {
+            skillCache.set(taskName, skill?.content ?? null);
+          })
+          .catch(() => {
+            skillCache.set(taskName, null);
+          });
+      }
+    },
+
+    getSystemPromptPrefix(taskName) {
+      // Return cached value (sync). May be undefined if cache not yet populated.
+      const cached = skillCache.get(taskName);
+      if (cached === null) return undefined; // explicitly no skill
+      return cached ?? undefined; // undefined if not yet cached
+    },
+
+    onTaskComplete(taskName, output, metrics) {
+      const appliedSkills: string[] = [];
+      const cachedSkill = skillCache.get(taskName);
+      if (cachedSkill) appliedSkills.push(taskName);
+
+      taskTraces.push({
+        taskName,
+        agentRunner: "",
+        prompt: metrics.promptSent ?? "",
+        output: typeof output === "string" ? output : JSON.stringify(output),
+        parsedOutput: output,
+        success: true,
+        skillsApplied: appliedSkills,
+        tokensIn: metrics.tokensIn,
+        tokensOut: metrics.tokensOut,
+        durationMs: metrics.latencyMs,
+        retryCount: metrics.retries,
+      });
+
+      // Mark next onTaskStart as still part of this run
+      // (isFirstTaskOfRun stays false until onWorkflowComplete resets it)
+    },
+
+    onTaskError(taskName, error, attempt) {
+      taskTraces.push({
+        taskName,
+        agentRunner: "",
+        prompt: "",
+        output: error.message,
+        parsedOutput: null,
+        success: false,
+        skillsApplied: [],
+        tokensIn: 0,
+        tokensOut: 0,
+        durationMs: 0,
+        retryCount: attempt,
+      });
+    },
+
+    async onWorkflowComplete(result, summary) {
+      runCount++;
+      const trace: ExecutionTrace = {
+        id: crypto.randomUUID(),
+        workflowName,
+        runAt: new Date().toISOString(),
+        success: summary.taskCount > 0 && taskTraces.every((t) => t.success),
+        totalDurationMs: Date.now() - runStartTime,
+        taskTraces,
+        workflowInput: null,
+        workflowOutput: result,
+        feedback: [],
+      };
+
+      await traceStore.saveTrace(trace);
+
+      // Reset for next run
+      isFirstTaskOfRun = true;
+
+      // TODO Phase 6: trigger reflectionWorkflow here based on config.reflectEvery
+    },
+  };
+}

--- a/packages/learning/src/index.ts
+++ b/packages/learning/src/index.ts
@@ -22,3 +22,10 @@ export {
 
 // Interfaces
 export type { SkillStore, TraceStore } from "./interfaces.js";
+
+// Scoring
+export { shouldRollback, updateScore } from "./scoring.js";
+
+// Hooks
+export { createLearningHooks } from "./hooks.js";
+export type { CreateLearningHooksOptions } from "./hooks.js";

--- a/packages/learning/src/scoring.ts
+++ b/packages/learning/src/scoring.ts
@@ -1,0 +1,26 @@
+import type { LearningThresholds } from "./types.js";
+
+/** EMA score update. Signal is 0-1. Returns clamped [0,1]. */
+export function updateScore(
+  currentScore: number,
+  signal: number,
+  isDelayedFeedback: boolean,
+  thresholds: LearningThresholds,
+): number {
+  const alpha = isDelayedFeedback
+    ? thresholds.feedbackAlpha
+    : thresholds.emaAlpha;
+  const raw = alpha * signal + (1 - alpha) * currentScore;
+  return Math.max(0, Math.min(1, raw));
+}
+
+/** Should we rollback to a better version? */
+export function shouldRollback(
+  currentScore: number,
+  bestScore: number,
+  runCount: number,
+  thresholds: LearningThresholds,
+): boolean {
+  if (runCount < thresholds.minRunsBeforeRollback) return false;
+  return currentScore < bestScore - thresholds.rollbackMargin;
+}


### PR DESCRIPTION
Core learning logic: hooks that collect traces + inject skills, plus scoring math.

## createLearningHooks (Phase 4)

- \`getSystemPromptPrefix\` — returns cached skill content for active skills
- \`onTaskStart\` — triggers async skill cache pre-population
- \`onTaskComplete\` — builds TaskTrace with metrics + skillsApplied
- \`onTaskError\` — records error traces
- \`onWorkflowComplete\` — assembles ExecutionTrace, saves to traceStore

## EMA Scoring (Phase 5)

- \`updateScore()\` — Exponential Moving Average with configurable alpha (0.3 default, 0.5 for delayed feedback)
- \`shouldRollback()\` — triggers rollback when score drops below best-in-lineage minus margin (0.15), only after minimum runs (3)

## Tests

- learning package: 5 (types) + 11 (scoring) + 8 (hooks) = **24 passing**
- Typecheck + lint clean

Part of #24.