### PR TITLE
chore: #104 — clean up stale biome-ignore suppressions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -301,9 +301,9 @@ export interface ResolvedAgentDef<
 
 // ─── Task map types ───────────────────────────────────────────────────────────
 
-// biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
 export type TasksMap = Record<
   string,
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
   TaskDef<AgentDef<any, any, any>, readonly string[]> | LoopDef<TasksMap>
 >;
 
@@ -346,7 +346,7 @@ export type InputOf<A> = A extends { input: infer I extends ZodType }
 export type RunnerOfTask<
   T extends TasksMap,
   K extends keyof T,
-> = T[K] extends TaskDef<infer A, readonly string[]> ? RunnerOf<A> : never; // biome-ignore lint/suspicious/noExplicitAny: structural infer
+> = T[K] extends TaskDef<infer A, readonly string[]> ? RunnerOf<A> : never;
 
 /**
  * Extract the direct dependsOn keys of task K in workflow T.
@@ -368,7 +368,6 @@ export type DependsOnOf<
  * Loop outputs are typed as unknown (v1 known limitation).
  */
 export type CtxFor<T extends TasksMap, K extends keyof T> = {
-  // biome-ignore lint/suspicious/noExplicitAny: structural infer
   readonly [P in DependsOnOf<T, K>]: T[P] extends TaskDef<
     infer A,
     readonly string[]

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/preflight.test.ts
+++ b/packages/executor/src/__tests__/preflight.test.ts
@@ -154,15 +154,15 @@ describe("runPreflight — DAG validation", () => {
     const workflow = defineWorkflow({
       name: "test",
       tasks: {
-        // biome-ignore lint/suspicious/noExplicitAny: intentional cycle for testing
         a: {
           agent: claudeAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: intentional cycle for testing
           dependsOn: ["b"] as any,
           input: { text: "a" },
         },
-        // biome-ignore lint/suspicious/noExplicitAny: intentional cycle for testing
         b: {
           agent: claudeAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: intentional cycle for testing
           dependsOn: ["a"] as any,
           input: { text: "b" },
         },
@@ -180,9 +180,9 @@ describe("runPreflight — DAG validation", () => {
     const workflow = defineWorkflow({
       name: "test",
       tasks: {
-        // biome-ignore lint/suspicious/noExplicitAny: intentional unresolved dep for testing
         a: {
           agent: claudeAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: intentional unresolved dep for testing
           dependsOn: ["nonexistent"] as any,
           input: { text: "a" },
         },
@@ -277,7 +277,6 @@ describe("runPreflight — cross-provider session warning", () => {
     const sess = sessionToken("shared-ctx", "claude");
 
     // Force codex agent to use the same session token (bypassing phantom brand at runtime)
-    // biome-ignore lint/suspicious/noExplicitAny: intentional cross-provider for testing
     const workflow = defineWorkflow({
       name: "test",
       tasks: {

--- a/packages/executor/src/output-parser.ts
+++ b/packages/executor/src/output-parser.ts
@@ -60,6 +60,5 @@ export function parseAgentOutput<O extends ZodType>(
     throw new OutputValidationError(taskName, result.error.message);
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: inferred from generic O
   return result.data as import("zod").infer<O>;
 }

--- a/packages/mcp-server/src/__tests__/hitl-bridge.test.ts
+++ b/packages/mcp-server/src/__tests__/hitl-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ErrorCode, McpServerError } from "../errors.js";
 import { buildMcpHooks } from "../hitl-bridge.js";
 
+// biome-ignore lint/suspicious/noExplicitAny: test helper accepts arbitrary mock response shapes
 const mkConn = (supportsElicit: boolean, elicitResponse?: any) => ({
   supports: (cap: string) => cap === "elicitation" && supportsElicit,
   elicit: vi

--- a/packages/mcp-server/src/__tests__/integration/server.test.ts
+++ b/packages/mcp-server/src/__tests__/integration/server.test.ts
@@ -38,6 +38,7 @@ describe("createMcpServer (integration)", () => {
     });
     const result = await server.callTool("greet", { name: 123 });
     expect(result.isError).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: accessing untyped structuredContent in test assertion
     expect((result.structuredContent as any).errorCode).toBe(
       "INPUT_VALIDATION_FAILED",
     );
@@ -51,11 +52,13 @@ describe("createMcpServer (integration)", () => {
     });
     // Mock executor to hang so we can test concurrency
     const hangPromise = new Promise(() => {});
+    // biome-ignore lint/suspicious/noExplicitAny: accessing internal test hook on server instance
     (server as any)._testRunExecutor = () => hangPromise;
 
     server.callTool("greet", { name: "a" }); // no await
     const result = await server.callTool("greet", { name: "b" });
     expect(result.isError).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: accessing untyped structuredContent in test assertion
     expect((result.structuredContent as any).errorCode).toBe("BUSY");
   });
 
@@ -81,6 +84,7 @@ describe("createMcpServer (integration)", () => {
 
       const result = await server.callTool("hang", { name: "x" });
       expect(result.isError).toBe(true);
+      // biome-ignore lint/suspicious/noExplicitAny: accessing untyped structuredContent in test assertion
       expect((result.structuredContent as any).errorCode).toBe(
         "DURATION_EXCEEDED",
       );
@@ -104,6 +108,7 @@ describe("createMcpServer (integration)", () => {
         tasks: {
           ...args.workflow.tasks,
           greet: {
+            // biome-ignore lint/suspicious/noExplicitAny: spreading typed task config via untyped access for test injection
             ...(args.workflow.tasks as any).greet,
             input: args.input,
           },
@@ -125,6 +130,7 @@ describe("createMcpServer (integration)", () => {
 
     const result = await server.callTool("greet", { name: "Alice" });
     expect(result.isError).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: accessing untyped structuredContent in test assertion
     expect((result.structuredContent as any).greeting).toBe("hello, Alice!");
   });
 });

--- a/packages/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-registry.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ErrorCode, McpServerError } from "../errors.js";
 import { buildToolDefinition } from "../tool-registry.js";
 
+// biome-ignore lint/suspicious/noExplicitAny: test helper accepts arbitrary mcp config shapes
 const mkWorkflow = (mcp?: any): WorkflowDef =>
   ({
     name: "test-flow",
@@ -17,8 +18,10 @@ const mkWorkflow = (mcp?: any): WorkflowDef =>
           output: z.object({ y: z.number() }),
           prompt: () => "",
         },
+        // biome-ignore lint/suspicious/noExplicitAny: casting partial task config for test fixture
       } as any,
     },
+    // biome-ignore lint/suspicious/noExplicitAny: casting partial workflow config for test fixture
   }) as any;
 
 describe("buildToolDefinition", () => {


### PR DESCRIPTION
Achieves **0 lint warnings** (was 24).

- Repositioned 8 stale \`biome-ignore\` comments to correct lines (types.ts, preflight.test.ts, output-parser.ts)
- Added 10 proper suppressions on test \`as any\` casts (mcp-server tests)
- Removed 36 macOS duplicate backup files that biome was scanning
- Patch bump: \`@ageflow/core\` + \`@ageflow/executor\` → 0.3.1

Lint: **0 warnings** (was 24). Typecheck + tests clean.

Closes #104.