### PR TITLE
fix(cli): #114 + #115 — learn export createdAt + unique filenames

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -145,7 +145,7 @@ export function registerLearnCommand(program: Command): void {
 
         let count = 0;
         for (const s of skills) {
-          const filename = `${s.name.replace(/[^a-zA-Z0-9_-]/g, "-")}.skill.md`;
+          const filename = `${s.name.replace(/[^a-zA-Z0-9_-]/g, "-")}-v${s.version}-${s.id.slice(0, 8)}.skill.md`;
           const filePath = path.join(outDir, filename);
           const frontmatter = [
             "---",
@@ -161,6 +161,7 @@ export function registerLearnCommand(program: Command): void {
             `score: ${s.score}`,
             `runCount: ${s.runCount}`,
             `bestInLineage: ${s.bestInLineage}`,
+            `createdAt: ${s.createdAt}`,
             "---",
             "",
           ].join("\n");


### PR DESCRIPTION
Two export round-trip bugs from PR #112 inline review.

- **#114 (P1)**: Export now includes \`createdAt\` in skill frontmatter. Import round-trip works.
- **#115 (P2)**: Filenames now include version + short id: \`analyze-v3-abc12345.skill.md\`. No overwrites for same-name lineage versions.

Patch bump: \`@ageflow/cli\` 0.3.0 → 0.3.1.

Closes #114, #115.