### PR TITLE
test(runner-api): #105 — real-API integration test (skip by default)

### DIFF
--- a/packages/runners/api/package.json
+++ b/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/api",
   "type": "module",

--- a/packages/runners/api/src/__tests__/integration.real-api.test.ts
+++ b/packages/runners/api/src/__tests__/integration.real-api.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { ApiRunner } from "../api-runner.js";
+
+const RUN_INTEGRATION = process.env.AGEFLOW_INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+describeIntegration("real OpenAI API integration", () => {
+  it("sends a prompt and receives a valid response", async () => {
+    const runner = new ApiRunner({
+      baseUrl: process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+      // biome-ignore lint/style/noNonNullAssertion: OPENAI_API_KEY is required when AGEFLOW_INTEGRATION=1
+      apiKey: process.env.OPENAI_API_KEY!,
+      defaultModel: "gpt-4o-mini",
+    });
+
+    const result = await runner.spawn({
+      prompt: "Reply with exactly the word 'hello' and nothing else.",
+      model: "gpt-4o-mini",
+    });
+
+    expect(result.stdout.toLowerCase()).toContain("hello");
+    expect(result.tokensIn).toBeGreaterThan(0);
+    expect(result.tokensOut).toBeGreaterThan(0);
+  }, 30_000); // 30s timeout for real API
+});

--- a/packages/runners/api/src/__tests__/integration.test.ts
+++ b/packages/runners/api/src/__tests__/integration.test.ts
@@ -5,6 +5,8 @@ const url = process.env.AGENTFLOW_TEST_API_URL;
 const key = process.env.AGENTFLOW_TEST_API_KEY;
 const model = process.env.AGENTFLOW_TEST_API_MODEL ?? "gpt-4o-mini";
 
+// To run: set AGENTFLOW_TEST_API_URL, AGENTFLOW_TEST_API_KEY (and optionally AGENTFLOW_TEST_API_MODEL).
+// For the opt-in real OpenAI integration test, use AGEFLOW_INTEGRATION=1 instead (see integration.real-api.test.ts).
 const maybe = url && key ? describe : describe.skip;
 
 maybe("ApiRunner (live)", () => {

--- a/packages/runners/api/src/types.ts
+++ b/packages/runners/api/src/types.ts
@@ -8,7 +8,7 @@ export type { Logger };
  * Package version — keep in sync with package.json.
  * Used as the MCP Client `version` in the protocol handshake.
  */
-export const RUNNER_VERSION = "0.3.0" as const;
+export const RUNNER_VERSION = "0.3.1" as const;
 
 export interface ToolDefinition {
   /** Human-readable description surfaced to the model. */


### PR DESCRIPTION
Opt-in integration test gated on \`AGEFLOW_INTEGRATION=1\`.

- New \`integration.real-api.test.ts\` — sends a prompt to OpenAI, asserts valid response + token counts
- Skipped by default in CI — run locally with \`AGEFLOW_INTEGRATION=1 bun run test\`
- Existing integration.test.ts skip message updated to reference the env var
- Patch bump: \`@ageflow/runner-api\` 0.3.0 → 0.3.1 + RUNNER_VERSION synced

Closes #105.