### PR TITLE
fix: #120 P0 — replace workspace:* with ^0.3.2 in published deps + bump all to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "prepublish:check": "! grep -r 'workspace:' packages/*/package.json packages/runners/*/package.json"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",
@@ -22,11 +22,11 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
-    "@ageflow/executor": "workspace:*",
-    "@ageflow/learning": "workspace:*",
-    "@ageflow/learning-sqlite": "workspace:*",
-    "@ageflow/mcp-server": "workspace:*",
+    "@ageflow/core": "^0.3.2",
+    "@ageflow/executor": "^0.3.2",
+    "@ageflow/learning": "^0.3.2",
+    "@ageflow/learning-sqlite": "^0.3.2",
+    "@ageflow/mcp-server": "^0.3.2",
     "chalk": "^5.3.0",
     "ora": "^8.0.0",
     "boxen": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
+    "@ageflow/core": "^0.3.2",
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning-sqlite",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "SQLite + sqlite-vec storage for @ageflow/learning",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
   "type": "module",
@@ -16,7 +16,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/learning": "workspace:*"
+    "@ageflow/learning": "^0.3.2"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Self-evolving skill layer for ageflow — trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",
@@ -16,10 +16,10 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*"
+    "@ageflow/core": "^0.3.2"
   },
   "peerDependencies": {
-    "@ageflow/executor": "workspace:*"
+    "@ageflow/executor": "^0.3.2"
   },
   "peerDependenciesMeta": {
     "@ageflow/executor": { "optional": true }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Expose ageflow workflows as MCP tools (stdio transport, progress streaming, HITL via elicitation).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/mcp-server",
   "type": "module",
@@ -16,9 +16,9 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
-    "@ageflow/executor": "workspace:*",
-    "@ageflow/server": "workspace:*",
+    "@ageflow/core": "^0.3.2",
+    "@ageflow/executor": "^0.3.2",
+    "@ageflow/server": "^0.3.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod-to-json-schema": "^3.23.0"
   },

--- a/packages/runners/api/package.json
+++ b/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/api",
   "type": "module",
@@ -17,7 +17,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
+    "@ageflow/core": "^0.3.2",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/runners/api/src/types.ts
+++ b/packages/runners/api/src/types.ts
@@ -8,7 +8,7 @@ export type { Logger };
  * Package version — keep in sync with package.json.
  * Used as the MCP Client `version` in the protocol handshake.
  */
-export const RUNNER_VERSION = "0.3.1" as const;
+export const RUNNER_VERSION = "0.3.2" as const;
 
 export interface ToolDefinition {
   /** Human-readable description surfaced to the model. */

--- a/packages/runners/claude/package.json
+++ b/packages/runners/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-claude",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Claude CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/claude",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*"
+    "@ageflow/core": "^0.3.2"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/runners/codex/package.json
+++ b/packages/runners/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-codex",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "OpenAI Codex CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/codex",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*"
+    "@ageflow/core": "^0.3.2"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/server",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Embeddable execution surface for ageflow workflows: stream, fire-and-forget, async HITL, cancellation.",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/server",
   "type": "module",
@@ -17,8 +17,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
-    "@ageflow/executor": "workspace:*"
+    "@ageflow/core": "^0.3.2",
+    "@ageflow/executor": "^0.3.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/testing",
   "type": "module",
@@ -19,8 +19,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "workspace:*",
-    "@ageflow/executor": "workspace:*",
+    "@ageflow/core": "^0.3.2",
+    "@ageflow/executor": "^0.3.2",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**P0 blocker**: all published @ageflow/* packages at 0.3.0 have \`"@ageflow/core": "workspace:*"\` in dependencies. Consumers can't install.

## Fix

- Replaced ALL \`workspace:*\` in dependencies/peerDependencies with \`^0.3.2\`
- Bumped ALL 11 packages to 0.3.2
- Added \`prepublish:check\` script to root for future validation
- \`devDependencies\` still use \`workspace:*\` (not published to npm — correct)

**After merge: republish all 11 packages at 0.3.2.**

Closes part of #120 (item 1 of 7).