### PR TITLE
feat(core/executor): #126 — TaskDef.skipIf for conditional task execution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   TaskMcpOverride,
   TaskMetrics,
   TaskRetryEvent,
+  TaskSkipEvent,
   TasksMap,
   TaskStartEvent,
   ToolCallRecord,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -438,6 +438,15 @@ export interface TaskDef<
   readonly mustUse?: readonly string[];
   /** Override which resolved MCP servers are available for this specific task. */
   readonly mcpOverride?: TaskMcpOverride;
+  /**
+   * Conditional skip predicate. When defined and returns `true` at runtime,
+   * the executor skips this task entirely (sets output to `undefined`).
+   * Downstream tasks still run; they receive `undefined` for this task's output.
+   * Budget is NOT charged for skipped tasks.
+   *
+   * Errors thrown from `skipIf` surface as task errors (onTaskError is fired).
+   */
+  readonly skipIf?: (ctx: BoundCtx<D>) => boolean;
 }
 
 // ─── Loop definition ──────────────────────────────────────────────────────────
@@ -492,6 +501,8 @@ export interface WorkflowHooks<T extends TasksMap = TasksMap> {
     error: Error,
     attempt: number,
   ) => void;
+  /** Called when a task is skipped due to its `skipIf` predicate returning `true`. */
+  readonly onTaskSkip?: (taskName: keyof T & string, reason: "skipIf") => void;
   /**
    * Called when a checkpoint HITL gate is reached.
    * Use this to send Telegram/Slack notifications before proceeding.
@@ -616,6 +627,12 @@ export interface TaskRetryEvent extends EventBase {
   readonly reason: string;
 }
 
+export interface TaskSkipEvent extends EventBase {
+  readonly type: "task:skip";
+  readonly taskName: string;
+  readonly reason: "skipIf";
+}
+
 export interface CheckpointEvent extends EventBase {
   readonly type: "checkpoint";
   readonly taskName: string;
@@ -651,6 +668,7 @@ export type WorkflowEvent =
   | TaskCompleteEvent
   | TaskErrorEvent
   | TaskRetryEvent
+  | TaskSkipEvent
   | CheckpointEvent
   | BudgetWarningEvent
   | WorkflowCompleteEvent

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/preflight.test.ts
+++ b/packages/executor/src/__tests__/preflight.test.ts
@@ -500,3 +500,81 @@ describe("runPreflight — MCP config validation", () => {
     ).toBe(true);
   });
 });
+
+// ─── warnAllDepsSkippable ──────────────────────────────────────────────────────
+
+describe("runPreflight — warnAllDepsSkippable", () => {
+  it("warns when ALL deps of a task have skipIf defined", async () => {
+    const workflow = defineWorkflow({
+      name: "test-all-deps-skippable",
+      tasks: {
+        a: {
+          agent: claudeAgent,
+          input: { text: "hello" },
+          skipIf: () => false,
+        },
+        b: {
+          agent: claudeAgent,
+          dependsOn: ["a"] as const,
+          input: { text: "world" },
+          // b depends on a, and a has skipIf → all deps of b are skippable
+        },
+      },
+    });
+
+    const result = await runPreflight(workflow, { whichFn: alwaysFoundWhich });
+    expect(result.warnings.some((w) => w.includes("all dependencies"))).toBe(
+      true,
+    );
+    expect(result.warnings.some((w) => w.includes('"b"'))).toBe(true);
+  });
+
+  it("does NOT warn when only some deps have skipIf defined", async () => {
+    const workflow = defineWorkflow({
+      name: "test-partial-deps-skippable",
+      tasks: {
+        a: {
+          agent: claudeAgent,
+          input: { text: "hello" },
+          skipIf: () => false,
+        },
+        c: {
+          agent: claudeAgent,
+          input: { text: "hello" },
+          // no skipIf on c
+        },
+        b: {
+          agent: claudeAgent,
+          dependsOn: ["a", "c"] as const,
+          input: { text: "world" },
+          // only a has skipIf, c does not → partial — no warning
+        },
+      },
+    });
+
+    const result = await runPreflight(workflow, { whichFn: alwaysFoundWhich });
+    const skippableWarnings = result.warnings.filter((w) =>
+      w.includes("all dependencies"),
+    );
+    expect(skippableWarnings).toHaveLength(0);
+  });
+
+  it("does NOT warn when task has no deps", async () => {
+    const workflow = defineWorkflow({
+      name: "test-no-deps",
+      tasks: {
+        a: {
+          agent: claudeAgent,
+          input: { text: "hello" },
+          // No dependsOn — no deps to be skippable
+        },
+      },
+    });
+
+    const result = await runPreflight(workflow, { whichFn: alwaysFoundWhich });
+    const skippableWarnings = result.warnings.filter((w) =>
+      w.includes("all dependencies"),
+    );
+    expect(skippableWarnings).toHaveLength(0);
+  });
+});

--- a/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -411,6 +411,89 @@ describe("P2-1: task:error attempt count", () => {
   });
 });
 
+describe("TaskDef.skipIf (stream path)", () => {
+  it("emits task:skip event when skipIf returns true", async () => {
+    const wfSkip = defineWorkflow({
+      name: "skip-demo",
+      tasks: {
+        a: {
+          agent,
+          input: {},
+          skipIf: () => true,
+        },
+        b: { agent, input: {}, dependsOn: ["a"] as const },
+      },
+    });
+
+    const executor = new WorkflowExecutor(wfSkip);
+    const events: WorkflowEvent[] = [];
+    for await (const ev of executor.stream({})) {
+      events.push(ev);
+    }
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("task:skip");
+    // task:start must NOT be emitted for the skipped task
+    const taskStartNames = events
+      .filter((e) => e.type === "task:start")
+      .map((e) => (e as { taskName: string }).taskName);
+    expect(taskStartNames).not.toContain("a");
+    // downstream task b still ran
+    expect(taskStartNames).toContain("b");
+  });
+
+  it("task:skip event has correct shape", async () => {
+    const wfSkip = defineWorkflow({
+      name: "skip-shape",
+      tasks: {
+        a: {
+          agent,
+          input: {},
+          skipIf: () => true,
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(wfSkip);
+    const events: WorkflowEvent[] = [];
+    for await (const ev of executor.stream({})) {
+      events.push(ev);
+    }
+
+    const skipEv = events.find((e) => e.type === "task:skip");
+    expect(skipEv).toBeDefined();
+    if (skipEv?.type === "task:skip") {
+      expect(skipEv.taskName).toBe("a");
+      expect(skipEv.reason).toBe("skipIf");
+      expect(typeof skipEv.runId).toBe("string");
+      expect(typeof skipEv.workflowName).toBe("string");
+      expect(typeof skipEv.timestamp).toBe("number");
+    }
+  });
+
+  it("does NOT emit task:skip when skipIf returns false", async () => {
+    const wfNoSkip = defineWorkflow({
+      name: "no-skip",
+      tasks: {
+        a: {
+          agent,
+          input: {},
+          skipIf: () => false,
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(wfNoSkip);
+    const events: WorkflowEvent[] = [];
+    for await (const ev of executor.stream({})) {
+      events.push(ev);
+    }
+
+    expect(events.some((e) => e.type === "task:skip")).toBe(false);
+    expect(events.some((e) => e.type === "task:complete")).toBe(true);
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/packages/executor/src/__tests__/workflow-executor.test.ts
+++ b/packages/executor/src/__tests__/workflow-executor.test.ts
@@ -355,6 +355,223 @@ describe("WorkflowExecutor", () => {
     expect(result.metrics.totalTokensOut).toBe(40); // 2 tasks × 20 tokens each
   });
 
+  // ─── TaskDef.skipIf ─────────────────────────────────────────────────────────
+
+  describe("TaskDef.skipIf", () => {
+    it("skips a task when skipIf returns true and downstream reads undefined output", async () => {
+      let taskBRan = false;
+      const mockRunner = makeMockRunner(async (args) => {
+        if (args.prompt.includes("Process")) {
+          return makeSuccessResult({ result: "from-A" });
+        }
+        taskBRan = true;
+        return makeSuccessResult({ final: "from-B" });
+      });
+      registerRunner("mock-wf", mockRunner);
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-basic",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => true,
+          },
+          taskB: {
+            agent: agentB,
+            dependsOn: ["taskA"],
+            input: (_ctx) => ({ upstream: "no-upstream" }),
+          },
+        },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      const result = await executor.run();
+
+      // taskA was skipped — its output is undefined
+      expect(result.outputs.taskA).toBeUndefined();
+      // taskB still ran (skipped tasks don't block downstream)
+      expect(taskBRan).toBe(true);
+    });
+
+    it("does not skip when skipIf returns false", async () => {
+      let taskARan = false;
+      const mockRunner = makeMockRunner(async (args) => {
+        if (args.prompt.includes("Process")) {
+          taskARan = true;
+          return makeSuccessResult({ result: "from-A" });
+        }
+        return makeSuccessResult({ final: "from-B" });
+      });
+      registerRunner("mock-wf", mockRunner);
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-false",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => false,
+          },
+        },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      const result = await executor.run();
+
+      expect(taskARan).toBe(true);
+      expect(result.outputs.taskA).toEqual({ result: "from-A" });
+    });
+
+    it("passes ctx to skipIf predicate", async () => {
+      let capturedCtx: unknown;
+      const mockRunner = makeMockRunner(async (args) => {
+        if (args.prompt.includes("Process")) {
+          return makeSuccessResult({ result: "from-A" });
+        }
+        return makeSuccessResult({ final: "from-B" });
+      });
+      registerRunner("mock-wf", mockRunner);
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-ctx",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+          },
+          taskB: {
+            agent: agentB,
+            dependsOn: ["taskA"],
+            input: (_ctx) => ({ upstream: "no-upstream" }),
+            skipIf: (ctx) => {
+              capturedCtx = ctx;
+              return false;
+            },
+          },
+        },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      // ctx should contain taskA's output since taskB depends on it
+      expect(capturedCtx).toBeDefined();
+      expect((capturedCtx as Record<string, unknown>).taskA).toBeDefined();
+    });
+
+    it("fires onTaskSkip hook when task is skipped", async () => {
+      const onTaskSkip = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-hook",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => true,
+          },
+        },
+        hooks: { onTaskSkip },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      expect(onTaskSkip).toHaveBeenCalledOnce();
+      expect(onTaskSkip).toHaveBeenCalledWith("taskA", "skipIf");
+    });
+
+    it("does NOT fire onTaskSkip hook when task is NOT skipped", async () => {
+      const onTaskSkip = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-hook-not-fired",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => false,
+          },
+        },
+        hooks: { onTaskSkip },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      expect(onTaskSkip).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call onTaskStart or onTaskComplete for skipped tasks", async () => {
+      const onTaskStart = vi.fn();
+      const onTaskComplete = vi.fn();
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-no-hooks",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => true,
+          },
+        },
+        hooks: { onTaskStart, onTaskComplete },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await executor.run();
+
+      expect(onTaskStart).not.toHaveBeenCalled();
+      expect(onTaskComplete).not.toHaveBeenCalled();
+    });
+
+    it("does NOT charge budget for skipped tasks", async () => {
+      const budgetTracker = new BudgetTracker();
+      const costBefore = budgetTracker.total;
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-budget",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => true,
+          },
+        },
+      });
+
+      const executor = new WorkflowExecutor(workflow, { budgetTracker });
+      await executor.run();
+
+      // Budget should not have increased (no task ran)
+      expect(budgetTracker.total).toBe(costBefore);
+    });
+
+    it("skipIf throws — fires onTaskError and rethrows", async () => {
+      const onTaskError = vi.fn();
+      const boom = new Error("skipIf exploded");
+
+      const workflow = defineWorkflow({
+        name: "test-skipif-throws",
+        tasks: {
+          taskA: {
+            agent: agentA,
+            input: { value: "test" },
+            skipIf: () => {
+              throw boom;
+            },
+          },
+        },
+        hooks: { onTaskError },
+      });
+
+      const executor = new WorkflowExecutor(workflow);
+      await expect(executor.run()).rejects.toThrow("skipIf exploded");
+      expect(onTaskError).toHaveBeenCalledWith("taskA", boom, 0);
+    });
+  });
+
   describe("promptSent in TaskMetrics", () => {
     it("onTaskComplete receives promptSent containing the user prompt", async () => {
       const onTaskComplete = vi.fn();

--- a/packages/executor/src/preflight.ts
+++ b/packages/executor/src/preflight.ts
@@ -324,6 +324,36 @@ function validateMcpConfigs(
   }
 }
 
+function warnAllDepsSkippable(tasks: TasksMap, warnings: string[]): void {
+  for (const [taskName, task] of Object.entries(tasks)) {
+    if (task === undefined || "kind" in task) {
+      // LoopDef — recurse into inner tasks
+      if (task !== undefined && "kind" in task && task.kind === "loop") {
+        warnAllDepsSkippable(task.tasks as TasksMap, warnings);
+      }
+      continue;
+    }
+
+    const deps = task.dependsOn;
+    if (deps === undefined || deps.length === 0) {
+      continue;
+    }
+
+    // Check whether ALL declared deps have skipIf defined
+    const allSkippable = deps.every((depName) => {
+      const depTask = tasks[depName];
+      if (depTask === undefined || "kind" in depTask) return false;
+      return depTask.skipIf !== undefined;
+    });
+
+    if (allSkippable) {
+      warnings.push(
+        `Task "${taskName}": all dependencies (${deps.map((d) => `"${d}"`).join(", ")}) have \`skipIf\` defined — "${taskName}" may receive undefined inputs at runtime`,
+      );
+    }
+  }
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 export async function runPreflight(
@@ -355,6 +385,9 @@ export async function runPreflight(
 
   // 7. Validate MCP server configs (duplicates, unknown overrides, missing env vars)
   validateMcpConfigs(workflow, errors, warnings);
+
+  // 8. Warn when ALL deps of a task have skipIf defined
+  warnAllDepsSkippable(tasks, warnings);
 
   return { errors, warnings };
 }

--- a/packages/executor/src/types-internal.ts
+++ b/packages/executor/src/types-internal.ts
@@ -19,5 +19,5 @@ export type RunBatchesFn = (
  */
 export interface CtxEntry {
   output: unknown;
-  _source: "agent" | "loop";
+  _source: "agent" | "loop" | "skipped";
 }

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -305,6 +305,26 @@ export class WorkflowExecutor<T extends TasksMap> {
             // This is a TaskDef<AgentDef<...>>
             // biome-ignore lint/suspicious/noExplicitAny: structural constraint
             const task = taskDef as TaskDef<AgentDef<any, any, any>>;
+
+            // Evaluate skipIf predicate before any runner/HITL/budget work
+            if (task.skipIf !== undefined) {
+              let shouldSkip: boolean;
+              try {
+                shouldSkip = (
+                  task.skipIf as (ctx: Record<string, CtxEntry>) => boolean
+                )(ctx);
+              } catch (err) {
+                const e = err instanceof Error ? err : new Error(String(err));
+                hooks?.onTaskError?.(taskName as keyof T & string, e, 0);
+                throw e;
+              }
+              if (shouldSkip) {
+                ctx[taskName] = { output: undefined, _source: "skipped" };
+                hooks?.onTaskSkip?.(taskName as keyof T & string, "skipIf");
+                continue;
+              }
+            }
+
             const runnerName: string = task.agent.runner;
 
             // Get runner from registry
@@ -521,6 +541,35 @@ export class WorkflowExecutor<T extends TasksMap> {
             // This is a TaskDef<AgentDef<...>>
             // biome-ignore lint/suspicious/noExplicitAny: structural constraint
             const task = taskDef as TaskDef<AgentDef<any, any, any>>;
+
+            // Evaluate skipIf predicate before any runner/HITL/budget work
+            if (task.skipIf !== undefined) {
+              let shouldSkip: boolean;
+              try {
+                shouldSkip = (
+                  task.skipIf as (ctx: Record<string, CtxEntry>) => boolean
+                )(ctx);
+              } catch (err) {
+                const e = err instanceof Error ? err : new Error(String(err));
+                hooks?.onTaskError?.(taskName as keyof T & string, e, 0);
+                throw e;
+              }
+              if (shouldSkip) {
+                ctx[taskName] = { output: undefined, _source: "skipped" };
+                hooks?.onTaskSkip?.(taskName as keyof T & string, "skipIf");
+                // Emit task:skip event
+                push({
+                  type: "task:skip",
+                  runId,
+                  workflowName,
+                  timestamp: Date.now(),
+                  taskName,
+                  reason: "skipIf",
+                });
+                continue;
+              }
+            }
+
             const runnerName: string = task.agent.runner;
 
             // Get runner from registry


### PR DESCRIPTION
Runtime-conditional task execution via \`skipIf\` predicate. Central pattern for multi-agent templates with standing roles.

## API

\`\`\`ts
{ agent: securityEng, skipIf: (ctx) => !ctx.\$input.standing.includes("security") }
\`\`\`

## What

- \`TaskDef.skipIf?: (ctx: BoundCtx<D>) => boolean\` — sync predicate, returns true = skip
- \`TaskSkipEvent\` — new event in \`WorkflowEvent\` union
- \`WorkflowHooks.onTaskSkip\` — observability hook
- Skipped tasks write \`{ output: undefined, _source: "skipped" }\` to ctx — downstream tasks branch explicitly
- No cascade — explicit over implicit
- Pre-flight warning when all deps of a task have skipIf
- skipIf throws → task error (no silent swallow)

## Tests

14 new tests: basic skip, downstream ctx, throws, budget not charged, stream events, preflight warnings.

## Version bump

\`@ageflow/core\` + \`@ageflow/executor\`: 0.3.2 → **0.4.0** (minor — new feature)

Closes #126.