### PR TITLE
fix: #136+#137 — require @ageflow/core ^0.4.2 in cli+server

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ageflow/cli",
   "version": "0.4.0",
-  "description": "CLI for ageflow — agentwf run / validate / dry-run / init",
+  "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",
   "private": false,
@@ -14,7 +14,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
@@ -22,7 +24,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.3.2",
+    "@ageflow/core": "^0.4.2",
     "@ageflow/executor": "^0.3.2",
     "@ageflow/learning": "^0.3.2",
     "@ageflow/learning-sqlite": "^0.3.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,9 +7,14 @@
   "private": false,
   "sideEffects": false,
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
@@ -17,7 +22,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.3.2",
+    "@ageflow/core": "^0.4.2",
     "@ageflow/executor": "^0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
CLI and server import shutdownAllRunners from core@0.4.2 but deps allowed older core. Fixed to ^0.4.2. Closes #136 #137.