### PR TITLE
fix(core/executor): #130+#131+#133+#138 — executor bug batch

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/__tests__/builders.test.ts
+++ b/packages/core/src/__tests__/builders.test.ts
@@ -420,4 +420,27 @@ describe("shutdownAllRunners", () => {
   it("resolves immediately when no runners are registered", async () => {
     await expect(shutdownAllRunners()).resolves.toBeUndefined();
   });
+
+  it("#138: swallows sync throw from shutdown() — does not propagate", async () => {
+    // If shutdown() throws synchronously (not returning a rejected promise),
+    // the async wrapper converts the sync throw to a rejected promise so
+    // Promise.allSettled can catch it. The overall call must still resolve.
+    const syncThrowShutdown = vi.fn(() => {
+      throw new Error("sync shutdown crash");
+    });
+
+    registerRunner(RUNNER_A, {
+      validate: async () => ({ ok: true }),
+      spawn: async () => ({
+        stdout: "{}",
+        sessionHandle: "",
+        tokensIn: 0,
+        tokensOut: 0,
+      }),
+      shutdown: syncThrowShutdown,
+    });
+
+    await expect(shutdownAllRunners()).resolves.toBeUndefined();
+    expect(syncThrowShutdown).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -247,7 +247,7 @@ export function unregisterRunner(name: string): void {
 export async function shutdownAllRunners(): Promise<void> {
   const runners = getRunners();
   const results = await Promise.allSettled(
-    [...runners.values()].map((r) => r.shutdown?.()),
+    [...runners.values()].map(async (r) => r.shutdown?.()),
   );
   for (const r of results) {
     if (r.status === "rejected") {

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",
@@ -44,3 +44,4 @@
   ],
   "license": "MIT"
 }
+

--- a/packages/executor/src/__tests__/budget-tracker.test.ts
+++ b/packages/executor/src/__tests__/budget-tracker.test.ts
@@ -245,5 +245,22 @@ describe("BudgetTracker", () => {
         ),
       ).resolves.toBeUndefined();
     });
+
+    it("#133: fires callback only once — subsequent calls after first crossing are no-ops", async () => {
+      // onExceeded must fire exactly once, even if fireOnExceeded is called
+      // after every task once the threshold is crossed.
+      const tracker = new BudgetTracker();
+      tracker.addCost("claude-sonnet-4-6", 1_000_000, 1_000_000); // $18.00 — over limit
+
+      const onExceeded = vi.fn();
+      const config = { maxCost: 5.0, onExceed: "warn" as const, onExceeded };
+
+      await tracker.fireOnExceeded(config, "task-1", "wf");
+      await tracker.fireOnExceeded(config, "task-2", "wf");
+      await tracker.fireOnExceeded(config, "task-3", "wf");
+
+      // Must have fired exactly once despite three calls after threshold
+      expect(onExceeded).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/executor/src/__tests__/workflow-executor.stream.test.ts
+++ b/packages/executor/src/__tests__/workflow-executor.stream.test.ts
@@ -494,6 +494,110 @@ describe("TaskDef.skipIf (stream path)", () => {
   });
 });
 
+describe("#130: skipIf throw emits task:error in stream", () => {
+  it("emits task:error when skipIf throws — not just fires hook", async () => {
+    const wfSkipThrow = defineWorkflow({
+      name: "skip-throw",
+      tasks: {
+        a: {
+          agent,
+          input: {},
+          skipIf: () => {
+            throw new Error("skipIf predicate crash");
+          },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(wfSkipThrow);
+    const events: WorkflowEvent[] = [];
+    try {
+      for await (const ev of executor.stream({})) {
+        events.push(ev);
+      }
+    } catch {
+      // expected — executor rethrows after emitting workflow:error
+    }
+
+    // task:error must be present (Bug #130: was missing before fix)
+    const taskErr = events.find((e) => e.type === "task:error");
+    expect(taskErr).toBeDefined();
+    if (taskErr?.type === "task:error") {
+      expect(taskErr.taskName).toBe("a");
+      expect(taskErr.terminal).toBe(true);
+      expect(taskErr.attempt).toBe(0);
+      expect(taskErr.error.message).toBe("skipIf predicate crash");
+    }
+    // workflow:error must follow
+    expect(events[events.length - 1]?.type).toBe("workflow:error");
+  });
+});
+
+describe("#131: onTaskError receives attempt count, not latencyMs", () => {
+  it("passes attempt=1 to onTaskError for a single non-retryable failure", async () => {
+    const errorArgs: Array<[string, Error, number]> = [];
+    const wfErr = defineWorkflow({
+      name: "err-hook",
+      tasks: {
+        a: { agent, input: {} },
+      },
+      hooks: {
+        onTaskError: (taskName, error, attempt) => {
+          errorArgs.push([taskName, error, attempt]);
+        },
+      },
+    });
+
+    // Override runner to fail once (non-retryable via 0 max retries)
+    const failRunner: Runner = {
+      validate: async () => ({ ok: true }),
+      spawn: async () => {
+        throw new Error("task failure");
+      },
+    };
+    registerRunner("fail131", failRunner);
+    try {
+      const agentFail = defineAgent({
+        runner: "fail131",
+        input: z.object({}),
+        output: z.object({ x: z.string() }),
+        prompt: () => "p",
+        // max:1 means 1 attempt total — attempt 0 runs, fails, attempts.length === 1
+        retry: { max: 1, on: ["subprocess_error"], backoff: "fixed" },
+      });
+      const wfFail = defineWorkflow({
+        name: "fail131-wf",
+        tasks: { t: { agent: agentFail, input: {} } },
+        hooks: {
+          onTaskError: (taskName, error, attempt) => {
+            errorArgs.push([taskName, error, attempt]);
+          },
+        },
+      });
+      const ex = new WorkflowExecutor(wfFail);
+      try {
+        for await (const _ev of ex.stream({})) {
+          // drain
+        }
+      } catch {
+        // expected
+      }
+      // attempt must be a small integer (1), NOT a large latency value (e.g. 50+)
+      expect(errorArgs).toHaveLength(1);
+      const firstCall = errorArgs[0];
+      expect(firstCall).toBeDefined();
+      const attempt = firstCall?.[2];
+      // A latencyMs value would be >> 10 in almost every scenario;
+      // attempt count is always 1 for a single-attempt failure with max:0.
+      expect(attempt).toBe(1);
+      // Sanity: must not look like a latency value
+      expect(attempt).toBeLessThan(10);
+    } finally {
+      unregisterRunner("fail131");
+    }
+  });
+});
+
 describe("run() is a drain over stream()", () => {
   it("produces the same WorkflowResult as draining stream()", async () => {
     const executor = new WorkflowExecutor(wf);

--- a/packages/executor/src/budget-tracker.ts
+++ b/packages/executor/src/budget-tracker.ts
@@ -18,6 +18,7 @@ const MODEL_PRICES: Record<
 
 export class BudgetTracker {
   private totalCost = 0;
+  private _exceededNotified = false;
 
   costFor(model: string, tokensIn: number, tokensOut: number): number {
     const prices =
@@ -68,6 +69,8 @@ export class BudgetTracker {
   ): Promise<void> {
     if (!config.onExceeded) return;
     if (!this.exceeded(config)) return;
+    if (this._exceededNotified) return;
+    this._exceededNotified = true;
 
     const info: BudgetExceededInfo = {
       currentCostUsd: this.totalCost,

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -461,11 +461,12 @@ export class WorkflowExecutor<T extends TasksMap> {
             } catch (err) {
               // Fire onTaskError hook
               if (err instanceof Error) {
-                const latencyMs = Date.now() - taskStart;
+                const attemptCount =
+                  err instanceof NodeMaxRetriesError ? err.attempts.length : 1;
                 hooks?.onTaskError?.(
                   taskName as keyof T & string,
                   err,
-                  latencyMs,
+                  attemptCount,
                 );
               }
               throw err;
@@ -561,6 +562,20 @@ export class WorkflowExecutor<T extends TasksMap> {
               } catch (err) {
                 const e = err instanceof Error ? err : new Error(String(err));
                 hooks?.onTaskError?.(taskName as keyof T & string, e, 0);
+                push({
+                  type: "task:error",
+                  runId,
+                  workflowName,
+                  timestamp: Date.now(),
+                  taskName,
+                  error: {
+                    name: e.name,
+                    message: e.message,
+                    ...(e.stack !== undefined ? { stack: e.stack } : {}),
+                  },
+                  attempt: 0,
+                  terminal: true,
+                });
                 throw e;
               }
               if (shouldSkip) {
@@ -776,13 +791,15 @@ export class WorkflowExecutor<T extends TasksMap> {
               });
             } catch (err) {
               const e = err instanceof Error ? err : new Error(String(err));
-              // Fire onTaskError hook
-              const latencyMs = Date.now() - taskStart;
-              hooks?.onTaskError?.(taskName as keyof T & string, e, latencyMs);
-
               // Derive actual attempt count from NodeMaxRetriesError when available
               const attemptCount =
                 err instanceof NodeMaxRetriesError ? err.attempts.length : 1;
+              // Fire onTaskError hook
+              hooks?.onTaskError?.(
+                taskName as keyof T & string,
+                e,
+                attemptCount,
+              );
 
               // Emit task:error event (terminal: true — retries exhausted or non-retryable)
               push({


### PR DESCRIPTION
4 small fixes:
- **#138**: \`shutdownAllRunners\` — wrap in async to guard sync throws
- **#133**: \`onExceeded\` fires only on first budget crossing (added \`_exceededNotified\` flag)
- **#131**: \`onTaskError\` hook — pass \`attempt\` not \`latencyMs\` (pre-existing bug)
- **#130**: skipIf throw in stream path — push \`task:error\` event before rethrowing

4 new tests. Patch: core 0.4.3, executor 0.4.2.

Closes #130 #131 #133 #138.