### PR TITLE
feat: #91 — @ageflow/runner-anthropic (native Anthropic Messages API)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,14 +103,16 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
       "dependencies": {
-        "@ageflow/core": "workspace:*",
-        "@ageflow/executor": "workspace:*",
-        "@ageflow/mcp-server": "workspace:*",
+        "@ageflow/core": "^0.4.2",
+        "@ageflow/executor": "^0.3.2",
+        "@ageflow/learning": "^0.3.2",
+        "@ageflow/learning-sqlite": "^0.3.2",
+        "@ageflow/mcp-server": "^0.3.2",
         "boxen": "^8.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -124,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.3.0",
+      "version": "0.4.3",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -136,9 +138,9 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.3.0",
+      "version": "0.4.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.3.2",
         "zod-to-json-schema": "^3.23.0",
       },
       "devDependencies": {
@@ -149,9 +151,9 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.3.2",
       },
       "devDependencies": {
         "@ageflow/executor": "workspace:*",
@@ -161,7 +163,7 @@
         "zod": "^3.23.0",
       },
       "peerDependencies": {
-        "@ageflow/executor": "workspace:*",
+        "@ageflow/executor": "^0.3.2",
       },
       "optionalPeers": [
         "@ageflow/executor",
@@ -169,9 +171,9 @@
     },
     "packages/learning-sqlite": {
       "name": "@ageflow/learning-sqlite",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@ageflow/learning": "workspace:*",
+        "@ageflow/learning": "^0.3.2",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -181,11 +183,11 @@
     },
     "packages/mcp-server": {
       "name": "@ageflow/mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
-        "@ageflow/executor": "workspace:*",
-        "@ageflow/server": "workspace:*",
+        "@ageflow/core": "^0.3.2",
+        "@ageflow/executor": "^0.3.2",
+        "@ageflow/server": "^0.3.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "zod-to-json-schema": "^3.23.0",
       },
@@ -196,11 +198,24 @@
         "zod": "^3.23.0",
       },
     },
+    "packages/runners/anthropic": {
+      "name": "@ageflow/runner-anthropic",
+      "version": "0.4.0",
+      "dependencies": {
+        "@ageflow/core": "^0.4.0",
+        "@ageflow/runner-api": "^0.3.2",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.23.0",
+      },
+    },
     "packages/runners/api": {
       "name": "@ageflow/runner-api",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.3.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {
@@ -212,9 +227,9 @@
     },
     "packages/runners/claude": {
       "name": "@ageflow/runner-claude",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.3.2",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -224,9 +239,9 @@
     },
     "packages/runners/codex": {
       "name": "@ageflow/runner-codex",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.3.2",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -236,10 +251,10 @@
     },
     "packages/server": {
       "name": "@ageflow/server",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
-        "@ageflow/executor": "workspace:*",
+        "@ageflow/core": "^0.4.2",
+        "@ageflow/executor": "^0.3.2",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -249,10 +264,10 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
-        "@ageflow/executor": "workspace:*",
+        "@ageflow/core": "^0.3.2",
+        "@ageflow/executor": "^0.3.2",
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {
@@ -289,6 +304,8 @@
     "@ageflow/learning-sqlite": ["@ageflow/learning-sqlite@workspace:packages/learning-sqlite"],
 
     "@ageflow/mcp-server": ["@ageflow/mcp-server@workspace:packages/mcp-server"],
+
+    "@ageflow/runner-anthropic": ["@ageflow/runner-anthropic@workspace:packages/runners/anthropic"],
 
     "@ageflow/runner-api": ["@ageflow/runner-api@workspace:packages/runners/api"],
 
@@ -754,9 +771,47 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@ageflow/cli/@ageflow/executor": ["@ageflow/executor@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2", "zod-to-json-schema": "^3.23.0" } }, "sha512-Av8dCZuVcz5IsxPEM+SWsmYIQCC6hx5v8BpYQCdNv4GgyoaN6qU5Vb81S2W0ebIv5oSu+FpAoAAXUQWMF3ag3w=="],
+
+    "@ageflow/cli/@ageflow/learning": ["@ageflow/learning@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2" }, "peerDependencies": { "@ageflow/executor": "^0.3.2" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-TvtkwRsGEN7+8brX1XQWcg8pkyPqmxaxIRAkMbTs8/sYhtK76aWfdO+Mok3Gfj7fOQMUrY3bJ2t9OoRxW638mQ=="],
+
+    "@ageflow/cli/@ageflow/learning-sqlite": ["@ageflow/learning-sqlite@0.3.2", "", { "dependencies": { "@ageflow/learning": "^0.3.2" } }, "sha512-evd02MVCVf4ZRCCtGUOZoc92904DSQPd+KLaoPS9LQT9fguFR1hXxd3XqgPaL/YsTKjzWCAx6zHBWsp/7fQBig=="],
+
+    "@ageflow/executor/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/learning/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/learning-sqlite/@ageflow/learning": ["@ageflow/learning@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2" }, "peerDependencies": { "@ageflow/executor": "^0.3.2" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-TvtkwRsGEN7+8brX1XQWcg8pkyPqmxaxIRAkMbTs8/sYhtK76aWfdO+Mok3Gfj7fOQMUrY3bJ2t9OoRxW638mQ=="],
+
+    "@ageflow/mcp-server/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/mcp-server/@ageflow/executor": ["@ageflow/executor@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2", "zod-to-json-schema": "^3.23.0" } }, "sha512-Av8dCZuVcz5IsxPEM+SWsmYIQCC6hx5v8BpYQCdNv4GgyoaN6qU5Vb81S2W0ebIv5oSu+FpAoAAXUQWMF3ag3w=="],
+
+    "@ageflow/mcp-server/@ageflow/server": ["@ageflow/server@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2", "@ageflow/executor": "^0.3.2" } }, "sha512-5v02sObQk1Wt3D8laz0MvZa3MKl6bNKzybfv57lK789rnhc4K3SvtHPT2sxi4zTzutuNIlp2SCfi9N8yKb5KAg=="],
+
+    "@ageflow/runner-api/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/runner-claude/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/runner-codex/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/server/@ageflow/executor": ["@ageflow/executor@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2", "zod-to-json-schema": "^3.23.0" } }, "sha512-Av8dCZuVcz5IsxPEM+SWsmYIQCC6hx5v8BpYQCdNv4GgyoaN6qU5Vb81S2W0ebIv5oSu+FpAoAAXUQWMF3ag3w=="],
+
+    "@ageflow/testing/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/testing/@ageflow/executor": ["@ageflow/executor@0.3.2", "", { "dependencies": { "@ageflow/core": "^0.3.2", "zod-to-json-schema": "^3.23.0" } }, "sha512-Av8dCZuVcz5IsxPEM+SWsmYIQCC6hx5v8BpYQCdNv4GgyoaN6qU5Vb81S2W0ebIv5oSu+FpAoAAXUQWMF3ag3w=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "@ageflow/cli/@ageflow/executor/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/cli/@ageflow/learning/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/learning-sqlite/@ageflow/learning/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
+
+    "@ageflow/server/@ageflow/executor/@ageflow/core": ["@ageflow/core@0.3.2", "", { "peerDependencies": { "zod": ">=3.23.0 <4.0.0" } }, "sha512-Uk5HlnB2FCL9c9+z3+RdkROaogzPcmHiH01L6P7iVAZ2AEWz9wgOa0GLGVPa14IppNhjji+aTAnwW/KisnRZuA=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/packages/runners/anthropic/package.json
+++ b/packages/runners/anthropic/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ageflow/runner-anthropic",
+  "version": "0.4.0",
+  "description": "Native Anthropic Messages API runner for ageflow (/v1/messages)",
+  "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/anthropic",
+  "type": "module",
+  "private": false,
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist"],
+  "scripts": { "build": "tsc", "typecheck": "tsc --noEmit", "test": "vitest run", "lint": "biome check src/" },
+  "dependencies": {
+    "@ageflow/core": "^0.4.0",
+    "@ageflow/runner-api": "^0.3.2"
+  },
+  "devDependencies": { "@types/node": "^22.0.0", "vitest": "^2.1.0", "zod": "^3.23.0" },
+  "license": "MIT"
+}

--- a/packages/runners/anthropic/src/__tests__/anthropic-runner.test.ts
+++ b/packages/runners/anthropic/src/__tests__/anthropic-runner.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicRunner } from "../anthropic-runner.js";
+import type { AnthropicResponse } from "../anthropic-types.js";
+import { ToolNotFoundError } from "../errors.js";
+import { InMemoryAnthropicSessionStore } from "../session-store.js";
+
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const endTurnResponse: AnthropicResponse = {
+  id: "msg_1",
+  type: "message",
+  role: "assistant",
+  content: [{ type: "text", text: "hello world" }],
+  model: "claude-3-5-sonnet-20241022",
+  stop_reason: "end_turn",
+  stop_sequence: null,
+  usage: { input_tokens: 4, output_tokens: 3 },
+};
+
+describe("AnthropicRunner.spawn", () => {
+  it("performs a single completion and returns stdout + token counts", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "test-key",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await runner.spawn({
+      prompt: "say hi",
+      model: "claude-3-5-sonnet-20241022",
+      sessionHandle: undefined,
+    });
+
+    expect(res.stdout).toBe("hello world");
+    expect(res.tokensIn).toBe(4);
+    expect(res.tokensOut).toBe(3);
+    expect(res.sessionHandle.length).toBeGreaterThan(0);
+    expect(res.toolCalls).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses defaultModel when args.model is not set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-haiku-20240307",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await runner.spawn({ prompt: "x" });
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe("claude-3-haiku-20240307");
+  });
+
+  it("throws when no model configured", async () => {
+    const fetchMock = vi.fn();
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(runner.spawn({ prompt: "x" })).rejects.toThrow(
+      /model not set/,
+    );
+  });
+
+  it("persists history to the session store under sessionHandle", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      sessionStore: store,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const first = await runner.spawn({ prompt: "p1" });
+    const history = await store.get(first.sessionHandle);
+    expect(history?.length).toBeGreaterThanOrEqual(2); // user + assistant
+  });
+
+  it("resumes when sessionHandle is provided", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    await store.set("existing", [
+      { role: "user", content: "earlier" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "earlier reply" }],
+      },
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      sessionStore: store,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const res = await runner.spawn({
+      prompt: "next",
+      sessionHandle: "existing",
+    });
+    expect(res.sessionHandle).toBe("existing");
+
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string }>;
+    };
+    // earlier user + earlier assistant + next user = 3
+    expect(body.messages.length).toBe(3);
+    expect(
+      (body.messages[2] as { role: string; content: string }).content,
+    ).toBe("next");
+  });
+
+  it("puts systemPrompt in system field, not in messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await runner.spawn({ prompt: "hi", systemPrompt: "be concise" });
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.system).toBe("be concise");
+    const hasSystemMsg = (body.messages as Array<{ role: string }>).some(
+      (m) => m.role === "system",
+    );
+    expect(hasSystemMsg).toBe(false);
+  });
+
+  it("filters tool registry by args.tools allowlist", async () => {
+    const toolUseResponse: AnthropicResponse = {
+      id: "msg_t",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_c",
+          name: "c",
+          input: {},
+        },
+      ],
+      model: "claude-3-5-sonnet-20241022",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 5, output_tokens: 5 },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(toolUseResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      fetch: fetchMock as unknown as typeof fetch,
+      tools: {
+        a: { description: "a", parameters: {}, execute: async () => "a" },
+        b: { description: "b", parameters: {}, execute: async () => "b" },
+        c: { description: "c", parameters: {}, execute: async () => "c" },
+      },
+    });
+
+    // Only allow tools "a" and "b" — model tries to call "c" → ToolNotFoundError
+    await expect(
+      runner.spawn({ prompt: "use c", tools: ["a", "b"] }),
+    ).rejects.toThrow(ToolNotFoundError);
+  });
+});
+
+describe("AnthropicRunner.validate", () => {
+  it("returns ok:true when API responds 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResp(endTurnResponse));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      defaultModel: "claude-3-5-sonnet-20241022",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(true);
+    expect(res.version).toBe("claude-3-5-sonnet-20241022");
+  });
+
+  it("returns ok:false on 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+    const runner = new AnthropicRunner({
+      apiKey: "bad",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("401");
+  });
+
+  it("returns ok:false when fetch throws", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const runner = new AnthropicRunner({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const res = await runner.validate();
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("ECONNREFUSED");
+  });
+});
+
+describe("AnthropicRunner.shutdown", () => {
+  it("resolves without error when no MCP clients are pooled", async () => {
+    const runner = new AnthropicRunner({ apiKey: "k" });
+    await expect(runner.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/packages/runners/anthropic/src/__tests__/exports.test.ts
+++ b/packages/runners/anthropic/src/__tests__/exports.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  AnthropicRequestError,
+  AnthropicRunner,
+  InMemoryAnthropicSessionStore,
+  MaxToolRoundsError,
+  McpPoolCollisionError,
+  ToolNotFoundError,
+} from "../index.js";
+import type {
+  AnthropicMessage,
+  AnthropicRequest,
+  AnthropicResponse,
+  AnthropicRunnerConfig,
+  AnthropicSessionStore,
+  AnthropicToolSchema,
+  ContentBlock,
+  TextBlock,
+  ThinkingBlock,
+  ThinkingConfig,
+  ToolResultBlock,
+  ToolUseBlock,
+} from "../index.js";
+
+describe("barrel exports", () => {
+  it("AnthropicRunner is exported and instantiable", () => {
+    const runner = new AnthropicRunner({ apiKey: "k" });
+    expect(runner).toBeInstanceOf(AnthropicRunner);
+  });
+
+  it("InMemoryAnthropicSessionStore is exported and instantiable", () => {
+    const store = new InMemoryAnthropicSessionStore();
+    expect(store).toBeInstanceOf(InMemoryAnthropicSessionStore);
+  });
+
+  it("AnthropicRequestError is exported and instantiable", () => {
+    const err = new AnthropicRequestError(400, "bad request");
+    expect(err).toBeInstanceOf(AnthropicRequestError);
+    expect(err.status).toBe(400);
+    expect(err.body).toBe("bad request");
+    expect(err.code).toBe("anthropic_request_failed");
+  });
+
+  it("MaxToolRoundsError is re-exported", () => {
+    const err = new MaxToolRoundsError(10);
+    expect(err).toBeInstanceOf(MaxToolRoundsError);
+    expect(err.code).toBe("tool_loop_exceeded");
+  });
+
+  it("ToolNotFoundError is re-exported", () => {
+    const err = new ToolNotFoundError("my_tool");
+    expect(err).toBeInstanceOf(ToolNotFoundError);
+    expect(err.code).toBe("tool_not_found");
+  });
+
+  it("McpPoolCollisionError is re-exported", () => {
+    const err = new McpPoolCollisionError("my-server");
+    expect(err).toBeInstanceOf(McpPoolCollisionError);
+    expect(err.code).toBe("mcp_pool_collision");
+  });
+
+  it("type-level: AnthropicMessage can be used as annotation", () => {
+    const msg: AnthropicMessage = { role: "user", content: "hello" };
+    expect(msg.role).toBe("user");
+  });
+
+  it("type-level: ContentBlock, TextBlock, ToolUseBlock, ToolResultBlock, ThinkingBlock compile", () => {
+    const text: TextBlock = { type: "text", text: "hi" };
+    const toolUse: ToolUseBlock = {
+      type: "tool_use",
+      id: "id1",
+      name: "tool",
+      input: {},
+    };
+    const thinking: ThinkingBlock = {
+      type: "thinking",
+      thinking: "thoughts",
+    };
+    expect(text.type).toBe("text");
+    expect(toolUse.type).toBe("tool_use");
+    expect(thinking.type).toBe("thinking");
+  });
+
+  it("type-level: AnthropicToolSchema compiles", () => {
+    const schema: AnthropicToolSchema = {
+      name: "foo",
+      description: "bar",
+      input_schema: { type: "object" },
+    };
+    expect(schema.name).toBe("foo");
+  });
+
+  it("type-level: ThinkingConfig compiles", () => {
+    const cfg: ThinkingConfig = { type: "enabled", budget_tokens: 5000 };
+    expect(cfg.type).toBe("enabled");
+  });
+
+  // Compile-time checks: these just need to import without error
+  it("all type-only imports resolve (AnthropicRunnerConfig, AnthropicSessionStore, etc.)", () => {
+    // If these types weren't exported the import at the top would fail to compile
+    const _config: AnthropicRunnerConfig = { apiKey: "k" };
+    const _store: AnthropicSessionStore = new InMemoryAnthropicSessionStore();
+    expect(_config.apiKey).toBe("k");
+    expect(_store).toBeTruthy();
+  });
+});

--- a/packages/runners/anthropic/src/__tests__/message-builder.test.ts
+++ b/packages/runners/anthropic/src/__tests__/message-builder.test.ts
@@ -1,0 +1,97 @@
+import type { ToolRegistry } from "@ageflow/runner-api";
+import { describe, expect, it } from "vitest";
+import type { AnthropicMessage } from "../anthropic-types.js";
+import {
+  buildAnthropicMessages,
+  toolsToAnthropicSchemas,
+} from "../message-builder.js";
+
+describe("buildAnthropicMessages", () => {
+  it("builds a single user message when no history", () => {
+    const msgs = buildAnthropicMessages({
+      prompt: "hello",
+      history: undefined,
+    });
+    expect(msgs).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("appends prompt to existing history", () => {
+    const history: AnthropicMessage[] = [
+      { role: "user", content: "prior" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "prior reply" }],
+      },
+    ];
+    const msgs = buildAnthropicMessages({ prompt: "next", history });
+    expect(msgs.length).toBe(3);
+    expect(msgs[2]).toEqual({ role: "user", content: "next" });
+  });
+
+  it("does NOT embed system prompt in messages (system goes in request field)", () => {
+    // System prompt is handled by the caller — NOT inserted into messages[].
+    const msgs = buildAnthropicMessages({
+      prompt: "hi",
+      history: undefined,
+    });
+    const hasSystemMsg = msgs.some(
+      (m) =>
+        m.role === "user" &&
+        typeof m.content === "string" &&
+        m.content.startsWith("SYSTEM:"),
+    );
+    expect(hasSystemMsg).toBe(false);
+    expect(msgs).toEqual([{ role: "user", content: "hi" }]);
+  });
+});
+
+describe("toolsToAnthropicSchemas", () => {
+  const registry: ToolRegistry = {
+    echo: {
+      description: "echoes input",
+      parameters: {
+        type: "object",
+        properties: { s: { type: "string" } },
+        required: ["s"],
+      },
+      execute: async ({ s }) => s,
+    },
+    noop: {
+      description: "does nothing",
+      parameters: {},
+      execute: async () => null,
+    },
+  };
+
+  it("returns undefined when names is empty", () => {
+    expect(toolsToAnthropicSchemas(registry, [])).toBeUndefined();
+  });
+
+  it("returns undefined when names is undefined", () => {
+    expect(toolsToAnthropicSchemas(registry, undefined)).toBeUndefined();
+  });
+
+  it("converts named tools to Anthropic tool schema format", () => {
+    const schemas = toolsToAnthropicSchemas(registry, ["echo"]);
+    expect(schemas).toHaveLength(1);
+    const schema = schemas?.[0];
+    expect(schema?.name).toBe("echo");
+    expect(schema?.description).toBe("echoes input");
+    expect(schema?.input_schema.type).toBe("object");
+  });
+
+  it("ignores unknown tool names", () => {
+    const schemas = toolsToAnthropicSchemas(registry, ["echo", "unknown"]);
+    expect(schemas).toHaveLength(1);
+    expect(schemas?.[0]?.name).toBe("echo");
+  });
+
+  it("returns undefined when all names are unknown", () => {
+    expect(toolsToAnthropicSchemas(registry, ["unknown"])).toBeUndefined();
+  });
+
+  it("tool schema has input_schema with type: object", () => {
+    const schemas = toolsToAnthropicSchemas(registry, ["noop"]);
+    expect(schemas?.[0]?.input_schema).toMatchObject({ type: "object" });
+  });
+});

--- a/packages/runners/anthropic/src/__tests__/session-store.test.ts
+++ b/packages/runners/anthropic/src/__tests__/session-store.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { AnthropicMessage } from "../anthropic-types.js";
+import { InMemoryAnthropicSessionStore } from "../session-store.js";
+
+const msg1: AnthropicMessage = { role: "user", content: "hello" };
+const msg2: AnthropicMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: "world" }],
+};
+
+describe("InMemoryAnthropicSessionStore", () => {
+  it("returns undefined for a missing handle", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    expect(await store.get("missing")).toBeUndefined();
+  });
+
+  it("stores and retrieves messages", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    await store.set("h1", [msg1, msg2]);
+    const got = await store.get("h1");
+    expect(got).toEqual([msg1, msg2]);
+  });
+
+  it("returns deep-cloned copies (mutation guard)", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    const msgs: AnthropicMessage[] = [msg1];
+    await store.set("h2", msgs);
+    const copy = await store.get("h2");
+    // Mutating the copy must not affect stored data
+    (copy as AnthropicMessage[]).push(msg2);
+    const stored = await store.get("h2");
+    expect(stored?.length).toBe(1);
+  });
+
+  it("deletes a session", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    await store.set("h3", [msg1]);
+    await store.delete("h3");
+    expect(await store.get("h3")).toBeUndefined();
+  });
+
+  it("delete is a no-op for non-existent handle", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    await expect(store.delete("nonexistent")).resolves.toBeUndefined();
+  });
+
+  it("overwrites existing session on set", async () => {
+    const store = new InMemoryAnthropicSessionStore();
+    await store.set("h4", [msg1]);
+    await store.set("h4", [msg2]);
+    const got = await store.get("h4");
+    expect(got).toEqual([msg2]);
+  });
+});

--- a/packages/runners/anthropic/src/__tests__/tool-loop.test.ts
+++ b/packages/runners/anthropic/src/__tests__/tool-loop.test.ts
@@ -1,0 +1,315 @@
+import type { ToolRegistry } from "@ageflow/runner-api";
+import { describe, expect, it, vi } from "vitest";
+import type { AnthropicResponse } from "../anthropic-types.js";
+import { MaxToolRoundsError, ToolNotFoundError } from "../errors.js";
+import { runAnthropicToolLoop } from "../tool-loop.js";
+
+function makeResponse(body: AnthropicResponse): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const endTurnResponse: AnthropicResponse = {
+  id: "msg_1",
+  type: "message",
+  role: "assistant",
+  content: [{ type: "text", text: "done" }],
+  model: "claude-3-5-sonnet-20241022",
+  stop_reason: "end_turn",
+  stop_sequence: null,
+  usage: { input_tokens: 5, output_tokens: 3 },
+};
+
+describe("runAnthropicToolLoop", () => {
+  it("returns assistant text on end_turn", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(endTurnResponse));
+    const res = await runAnthropicToolLoop({
+      apiKey: "test-key",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-5-sonnet-20241022",
+      messages: [{ role: "user", content: "hi" }],
+      system: undefined,
+      tools: undefined,
+      registry: {},
+      maxRounds: 10,
+      maxTokens: 8192,
+      requestTimeout: 5000,
+    });
+    expect(res.finalText).toBe("done");
+    expect(res.tokensIn).toBe(5);
+    expect(res.tokensOut).toBe(3);
+    expect(res.toolCalls).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends x-api-key and anthropic-version headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(endTurnResponse));
+    await runAnthropicToolLoop({
+      apiKey: "my-secret",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-5-sonnet-20241022",
+      messages: [{ role: "user", content: "hi" }],
+      system: undefined,
+      tools: undefined,
+      registry: {},
+      maxRounds: 10,
+      maxTokens: 8192,
+      requestTimeout: 5000,
+    });
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("my-secret");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["content-type"]).toBe("application/json");
+  });
+
+  it("puts system prompt in request body system field, not in messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(endTurnResponse));
+    await runAnthropicToolLoop({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-5-sonnet-20241022",
+      messages: [{ role: "user", content: "hi" }],
+      system: "be concise",
+      tools: undefined,
+      registry: {},
+      maxRounds: 10,
+      maxTokens: 8192,
+      requestTimeout: 5000,
+    });
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.system).toBe("be concise");
+    // messages should not have a system role
+    const hasSystemMsg = (body.messages as Array<{ role: string }>).some(
+      (m) => m.role === "system",
+    );
+    expect(hasSystemMsg).toBe(false);
+  });
+
+  it("executes a tool and sends tool_result back, sums tokens", async () => {
+    const toolUseResponse: AnthropicResponse = {
+      id: "msg_2",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "echo",
+          input: { s: "hi" },
+        },
+      ],
+      model: "claude-3-5-sonnet-20241022",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(toolUseResponse))
+      .mockResolvedValueOnce(makeResponse(endTurnResponse));
+
+    const registry: ToolRegistry = {
+      echo: {
+        description: "echo",
+        parameters: { type: "object" },
+        execute: ({ s }) => `echoed:${s as string}`,
+      },
+    };
+
+    const res = await runAnthropicToolLoop({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-5-sonnet-20241022",
+      messages: [{ role: "user", content: "echo hi" }],
+      system: undefined,
+      tools: [
+        {
+          name: "echo",
+          description: "echo",
+          input_schema: { type: "object" },
+        },
+      ],
+      registry,
+      maxRounds: 10,
+      maxTokens: 8192,
+      requestTimeout: 5000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.finalText).toBe("done");
+    expect(res.toolCalls.length).toBe(1);
+    expect(res.toolCalls[0]?.name).toBe("echo");
+    expect(res.toolCalls[0]?.result).toBe("echoed:hi");
+    expect(res.tokensIn).toBe(15); // 10 + 5
+    expect(res.tokensOut).toBe(8); // 5 + 3
+
+    // Second fetch should have a user message with tool_result
+    const [_url2, init2] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const body2 = JSON.parse(init2.body as string);
+    const lastMsg = body2.messages[body2.messages.length - 1];
+    expect(lastMsg.role).toBe("user");
+    expect(lastMsg.content[0].type).toBe("tool_result");
+    expect(lastMsg.content[0].tool_use_id).toBe("tu_1");
+    expect(lastMsg.content[0].content).toBe("echoed:hi");
+  });
+
+  it("throws ToolNotFoundError when model calls unknown tool", async () => {
+    const toolUseResponse: AnthropicResponse = {
+      id: "msg_3",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_x",
+          name: "nonexistent",
+          input: {},
+        },
+      ],
+      model: "claude-3-5-sonnet-20241022",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 2, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(toolUseResponse));
+    await expect(
+      runAnthropicToolLoop({
+        apiKey: "k",
+        fetch: fetchMock as unknown as typeof fetch,
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "hi" }],
+        system: undefined,
+        tools: undefined,
+        registry: {},
+        maxRounds: 10,
+        maxTokens: 8192,
+        requestTimeout: 5000,
+      }),
+    ).rejects.toBeInstanceOf(ToolNotFoundError);
+  });
+
+  it("throws MaxToolRoundsError when ceiling exceeded", async () => {
+    const toolUseResponse: AnthropicResponse = {
+      id: "msg_loop",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_loop",
+          name: "noop",
+          input: {},
+        },
+      ],
+      model: "claude-3-5-sonnet-20241022",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(makeResponse(toolUseResponse)));
+
+    const registry: ToolRegistry = {
+      noop: { description: "", parameters: {}, execute: () => "ok" },
+    };
+
+    await expect(
+      runAnthropicToolLoop({
+        apiKey: "k",
+        fetch: fetchMock as unknown as typeof fetch,
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "loop" }],
+        system: undefined,
+        tools: undefined,
+        registry,
+        maxRounds: 2,
+        maxTokens: 8192,
+        requestTimeout: 5000,
+      }),
+    ).rejects.toBeInstanceOf(MaxToolRoundsError);
+  });
+
+  it("catches tool errors and feeds them back to the model", async () => {
+    const toolUseResponse: AnthropicResponse = {
+      id: "msg_err",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_err",
+          name: "boom",
+          input: {},
+        },
+      ],
+      model: "claude-3-5-sonnet-20241022",
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(toolUseResponse))
+      .mockResolvedValueOnce(makeResponse(endTurnResponse));
+
+    const registry: ToolRegistry = {
+      boom: {
+        description: "",
+        parameters: {},
+        execute: () => {
+          throw new Error("kaboom");
+        },
+      },
+    };
+
+    const res = await runAnthropicToolLoop({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-5-sonnet-20241022",
+      messages: [{ role: "user", content: "boom" }],
+      system: undefined,
+      tools: undefined,
+      registry,
+      maxRounds: 10,
+      maxTokens: 8192,
+      requestTimeout: 5000,
+    });
+
+    expect(res.toolCalls[0]?.result).toMatch(/kaboom/);
+
+    // The tool_result content should contain the error
+    const [_url2, init2] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const body2 = JSON.parse(init2.body as string);
+    const lastMsg = body2.messages[body2.messages.length - 1];
+    expect(lastMsg.content[0].content).toMatch(/kaboom/);
+  });
+
+  it("uses extended thinking when thinkingBudgetTokens is set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(endTurnResponse));
+    await runAnthropicToolLoop({
+      apiKey: "k",
+      fetch: fetchMock as unknown as typeof fetch,
+      model: "claude-3-7-sonnet-20250219",
+      messages: [{ role: "user", content: "think" }],
+      system: undefined,
+      tools: undefined,
+      registry: {},
+      maxRounds: 10,
+      maxTokens: 16000,
+      requestTimeout: 5000,
+      thinkingBudgetTokens: 10000,
+    });
+    const [_url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+});

--- a/packages/runners/anthropic/src/anthropic-runner.ts
+++ b/packages/runners/anthropic/src/anthropic-runner.ts
@@ -1,0 +1,297 @@
+/**
+ * anthropic-runner.ts
+ *
+ * AnthropicRunner — implements the Runner interface for the Anthropic Messages API.
+ * Uses native /v1/messages format, not the OpenAI-compatible endpoint.
+ *
+ * MCP client management is re-used from @ageflow/runner-api.
+ */
+
+import type {
+  Logger,
+  McpServerConfig,
+  Runner,
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+} from "@ageflow/core";
+import { McpPoolCollisionError } from "@ageflow/runner-api";
+import type { ToolRegistry } from "@ageflow/runner-api";
+import type { McpClient } from "../../api/src/mcp-client.js";
+import { shutdownAll, startMcpClients } from "../../api/src/mcp-client.js";
+import { mcpToolsToRegistry } from "../../api/src/mcp-tool-adapter.js";
+import type { AnthropicResponse } from "./anthropic-types.js";
+import {
+  buildAnthropicMessages,
+  toolsToAnthropicSchemas,
+} from "./message-builder.js";
+import {
+  type AnthropicSessionStore,
+  InMemoryAnthropicSessionStore,
+} from "./session-store.js";
+import {
+  ANTHROPIC_API_URL,
+  ANTHROPIC_VERSION,
+  DEFAULT_MAX_TOKENS,
+  runAnthropicToolLoop,
+} from "./tool-loop.js";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+export interface AnthropicRunnerConfig {
+  apiKey: string;
+  /** Fallback model when AgentDef.model is not set. */
+  defaultModel?: string;
+  tools?: ToolRegistry;
+  sessionStore?: AnthropicSessionStore;
+  /** Default: 10. Hard ceiling against infinite tool loops. */
+  maxToolRounds?: number;
+  /** Default: 8192. Required by Anthropic API. */
+  maxTokens?: number;
+  /** Default: 120_000ms. Per individual API call. */
+  requestTimeout?: number;
+  /** Injectable fetch for testing. Default: globalThis.fetch. */
+  fetch?: typeof fetch;
+  /** Optional logger. MCP subprocess stderr is teed here; never forwarded to the model. */
+  logger?: Logger;
+  /**
+   * Extended thinking budget in tokens. When set, enables extended thinking mode.
+   * Requires a claude-3-7-sonnet or later model.
+   */
+  thinkingBudgetTokens?: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when two McpServerConfig objects would spawn an identical process.
+ */
+function isSpawnEquivalent(a: McpServerConfig, b: McpServerConfig): boolean {
+  if (a.command !== b.command) return false;
+  if (a.cwd !== b.cwd) return false;
+
+  const aArgs = a.args ?? [];
+  const bArgs = b.args ?? [];
+  if (aArgs.length !== bArgs.length) return false;
+  for (let i = 0; i < aArgs.length; i++) {
+    if (aArgs[i] !== bArgs[i]) return false;
+  }
+
+  const aEnvEntries = Object.entries(a.env ?? {}).sort(([k1], [k2]) =>
+    k1 < k2 ? -1 : k1 > k2 ? 1 : 0,
+  );
+  const bEnvEntries = Object.entries(b.env ?? {}).sort(([k1], [k2]) =>
+    k1 < k2 ? -1 : k1 > k2 ? 1 : 0,
+  );
+  if (aEnvEntries.length !== bEnvEntries.length) return false;
+  for (let i = 0; i < aEnvEntries.length; i++) {
+    const ae = aEnvEntries[i];
+    const be = bEnvEntries[i];
+    if (ae === undefined || be === undefined) return false;
+    if (ae[0] !== be[0]) return false;
+    if (ae[1] !== be[1]) return false;
+  }
+
+  const aTools = a.tools ? [...a.tools].sort() : undefined;
+  const bTools = b.tools ? [...b.tools].sort() : undefined;
+  if ((aTools === undefined) !== (bTools === undefined)) return false;
+  if (aTools !== undefined && bTools !== undefined) {
+    if (aTools.length !== bTools.length) return false;
+    for (let i = 0; i < aTools.length; i++) {
+      if (aTools[i] !== bTools[i]) return false;
+    }
+  }
+
+  return true;
+}
+
+const DEFAULT_MAX_ROUNDS = 10;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+// ─── Runner class ─────────────────────────────────────────────────────────────
+
+export class AnthropicRunner implements Runner {
+  private readonly apiKey: string;
+  private readonly defaultModel: string | undefined;
+  private readonly tools: ToolRegistry;
+  private readonly sessionStore: AnthropicSessionStore;
+  private readonly maxToolRounds: number;
+  private readonly maxTokens: number;
+  private readonly requestTimeout: number;
+  private readonly fetch: typeof fetch;
+  private readonly logger: Logger | undefined;
+  private readonly thinkingBudgetTokens: number | undefined;
+  /** Pool of long-lived MCP clients keyed by server name (reusePerRunner=true). */
+  private readonly mcpPool = new Map<string, McpClient>();
+
+  constructor(config: AnthropicRunnerConfig) {
+    this.apiKey = config.apiKey;
+    this.defaultModel = config.defaultModel;
+    this.tools = config.tools ?? {};
+    this.sessionStore =
+      config.sessionStore ?? new InMemoryAnthropicSessionStore();
+    this.maxToolRounds = config.maxToolRounds ?? DEFAULT_MAX_ROUNDS;
+    this.maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.requestTimeout = config.requestTimeout ?? DEFAULT_TIMEOUT_MS;
+    this.fetch = config.fetch ?? globalThis.fetch;
+    this.logger = config.logger;
+    this.thinkingBudgetTokens = config.thinkingBudgetTokens;
+  }
+
+  async validate(): Promise<{ ok: boolean; version?: string; error?: string }> {
+    // Anthropic doesn't have a /models endpoint in the public API.
+    // We do a minimal real request: POST /v1/messages with 1 max_token
+    // using the default model (or a known-valid model) to check the key.
+    // If no defaultModel, we probe with claude-3-haiku-20240307.
+    const probeModel = this.defaultModel ?? "claude-3-haiku-20240307";
+    try {
+      const resp = await this.fetch(ANTHROPIC_API_URL, {
+        method: "POST",
+        headers: {
+          "x-api-key": this.apiKey,
+          "anthropic-version": ANTHROPIC_VERSION,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: probeModel,
+          max_tokens: 1,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+        signal: AbortSignal.timeout(this.requestTimeout),
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => "");
+        return {
+          ok: false,
+          error: `HTTP ${resp.status} ${resp.statusText} ${text}`.trim(),
+        };
+      }
+
+      const body = (await resp.json()) as AnthropicResponse;
+      return { ok: true, version: body.model };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  }
+
+  async spawn(args: RunnerSpawnArgs): Promise<RunnerSpawnResult> {
+    const model = args.model ?? this.defaultModel;
+    if (!model) {
+      throw new Error(
+        "AnthropicRunner.spawn: model not set and no defaultModel configured",
+      );
+    }
+
+    const handle =
+      args.sessionHandle && args.sessionHandle.length > 0
+        ? args.sessionHandle
+        : crypto.randomUUID();
+
+    const history = args.sessionHandle
+      ? await this.sessionStore.get(args.sessionHandle)
+      : undefined;
+
+    const initialMessages = buildAnthropicMessages({
+      prompt: args.prompt,
+      history,
+    });
+
+    // Filter registry to caller's allowlist
+    const filteredRegistry =
+      args.tools !== undefined
+        ? Object.fromEntries(
+            Object.entries(this.tools).filter(([name]) =>
+              (args.tools as string[]).includes(name),
+            ),
+          )
+        : this.tools;
+
+    // ── MCP clients ────────────────────────────────────────────────────────────
+    const servers = args.mcpServers ?? [];
+    const perSpawnClients: McpClient[] = [];
+
+    if (servers.length > 0) {
+      try {
+        for (const s of servers) {
+          if (s.reusePerRunner) {
+            let pooled = this.mcpPool.get(s.name);
+            if (!pooled) {
+              const [started] = await startMcpClients([s], this.logger);
+              if (started === undefined) {
+                throw new Error(
+                  `startMcpClients returned no client for ${s.name}`,
+                );
+              }
+              pooled = started;
+              this.mcpPool.set(s.name, pooled);
+            } else if (!isSpawnEquivalent(pooled.config, s)) {
+              throw new McpPoolCollisionError(s.name);
+            }
+            perSpawnClients.push(pooled);
+          } else {
+            const [c] = await startMcpClients([s], this.logger);
+            if (c === undefined) {
+              throw new Error(
+                `startMcpClients returned no client for ${s.name}`,
+              );
+            }
+            perSpawnClients.push(c);
+          }
+        }
+      } catch (startErr) {
+        const toStop = perSpawnClients.filter((c) => !c.config.reusePerRunner);
+        await shutdownAll(toStop);
+        throw startErr;
+      }
+    }
+
+    try {
+      const mcpRegistry = await mcpToolsToRegistry(perSpawnClients);
+      const merged: ToolRegistry = { ...filteredRegistry, ...mcpRegistry };
+
+      const mergedToolsArg: string[] | undefined =
+        args.tools !== undefined
+          ? [...args.tools, ...Object.keys(mcpRegistry)]
+          : Object.keys(mcpRegistry).length > 0
+            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpRegistry)]
+            : args.tools;
+
+      const toolSchemas = toolsToAnthropicSchemas(merged, mergedToolsArg);
+
+      const loop = await runAnthropicToolLoop({
+        apiKey: this.apiKey,
+        fetch: this.fetch,
+        model,
+        messages: initialMessages,
+        system: args.systemPrompt,
+        tools: toolSchemas,
+        registry: merged,
+        maxRounds: this.maxToolRounds,
+        maxTokens: this.maxTokens,
+        requestTimeout: this.requestTimeout,
+        ...(this.thinkingBudgetTokens !== undefined
+          ? { thinkingBudgetTokens: this.thinkingBudgetTokens }
+          : {}),
+      });
+
+      await this.sessionStore.set(handle, loop.finalMessages);
+
+      return {
+        stdout: loop.finalText,
+        sessionHandle: handle,
+        tokensIn: loop.tokensIn,
+        tokensOut: loop.tokensOut,
+        toolCalls: loop.toolCalls,
+      };
+    } finally {
+      const toStop = perSpawnClients.filter((c) => !c.config.reusePerRunner);
+      await Promise.allSettled(toStop.map((c) => c.stop()));
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await shutdownAll([...this.mcpPool.values()]);
+    this.mcpPool.clear();
+  }
+}

--- a/packages/runners/anthropic/src/anthropic-types.ts
+++ b/packages/runners/anthropic/src/anthropic-types.ts
@@ -1,0 +1,100 @@
+/**
+ * anthropic-types.ts
+ *
+ * Type definitions for the Anthropic Messages API (/v1/messages).
+ * Covers the subset used by this runner (text, tool_use, tool_result blocks).
+ */
+
+// ─── Content blocks ───────────────────────────────────────────────────────────
+
+export interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface ThinkingBlock {
+  type: "thinking";
+  thinking: string;
+}
+
+export interface ToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+}
+
+export type ContentBlock = TextBlock | ThinkingBlock | ToolUseBlock;
+
+// ─── Messages ─────────────────────────────────────────────────────────────────
+
+export interface AssistantMessage {
+  role: "assistant";
+  content: ContentBlock[];
+}
+
+export interface UserTextMessage {
+  role: "user";
+  content: string;
+}
+
+export interface UserToolResultMessage {
+  role: "user";
+  content: ToolResultBlock[];
+}
+
+export type AnthropicMessage =
+  | AssistantMessage
+  | UserTextMessage
+  | UserToolResultMessage;
+
+// ─── Tool schemas ─────────────────────────────────────────────────────────────
+
+export interface AnthropicToolSchema {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+}
+
+// ─── Extended thinking ────────────────────────────────────────────────────────
+
+export interface ThinkingConfig {
+  type: "enabled";
+  budget_tokens: number;
+}
+
+// ─── Request / Response ───────────────────────────────────────────────────────
+
+export interface AnthropicRequest {
+  model: string;
+  max_tokens: number;
+  messages: AnthropicMessage[];
+  system?: string;
+  tools?: AnthropicToolSchema[];
+  thinking?: ThinkingConfig;
+}
+
+export interface AnthropicResponse {
+  id: string;
+  type: "message";
+  role: "assistant";
+  content: ContentBlock[];
+  model: string;
+  stop_reason: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
+  stop_sequence: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}

--- a/packages/runners/anthropic/src/errors.ts
+++ b/packages/runners/anthropic/src/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * errors.ts
+ *
+ * Re-exports shared errors from runner-api and adds AnthropicRequestError.
+ */
+
+export {
+  MaxToolRoundsError,
+  ToolNotFoundError,
+  McpPoolCollisionError,
+} from "@ageflow/runner-api";
+
+export { AgentFlowError } from "@ageflow/core";
+
+import { AgentFlowError } from "@ageflow/core";
+
+export class AnthropicRequestError extends AgentFlowError {
+  readonly code = "anthropic_request_failed" as const;
+  constructor(
+    readonly status: number,
+    readonly body: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Anthropic API request failed (${status}): ${body}`, options);
+  }
+}

--- a/packages/runners/anthropic/src/index.ts
+++ b/packages/runners/anthropic/src/index.ts
@@ -1,0 +1,22 @@
+export { AnthropicRunner } from "./anthropic-runner.js";
+export type { AnthropicRunnerConfig } from "./anthropic-runner.js";
+export { InMemoryAnthropicSessionStore } from "./session-store.js";
+export type { AnthropicSessionStore } from "./session-store.js";
+export {
+  AnthropicRequestError,
+  MaxToolRoundsError,
+  ToolNotFoundError,
+  McpPoolCollisionError,
+} from "./errors.js";
+export type {
+  ContentBlock,
+  AnthropicMessage,
+  AnthropicRequest,
+  AnthropicResponse,
+  AnthropicToolSchema,
+  TextBlock,
+  ToolUseBlock,
+  ToolResultBlock,
+  ThinkingBlock,
+  ThinkingConfig,
+} from "./anthropic-types.js";

--- a/packages/runners/anthropic/src/message-builder.ts
+++ b/packages/runners/anthropic/src/message-builder.ts
@@ -1,0 +1,69 @@
+/**
+ * message-builder.ts
+ *
+ * Build the initial messages array for Anthropic Messages API.
+ * Note: system prompt is NOT included in messages — it goes in the `system` field.
+ *
+ * Also converts ToolRegistry → AnthropicToolSchema[].
+ */
+
+import type { ToolRegistry } from "@ageflow/runner-api";
+import type {
+  AnthropicMessage,
+  AnthropicToolSchema,
+} from "./anthropic-types.js";
+
+export interface BuildAnthropicMessagesInput {
+  prompt: string;
+  /**
+   * Prior conversation history. System messages are already excluded —
+   * system prompt is kept in the `system` field of the request.
+   */
+  history: AnthropicMessage[] | undefined;
+}
+
+/**
+ * Build the messages[] array for a new or resumed Anthropic session.
+ *
+ * Unlike the OpenAI runner, system prompts are NOT embedded in messages.
+ * They go in the top-level `system` field of the request body.
+ * This function only returns user/assistant turns.
+ */
+export function buildAnthropicMessages(
+  input: BuildAnthropicMessagesInput,
+): AnthropicMessage[] {
+  const history = input.history ?? [];
+  const out: AnthropicMessage[] = [...history];
+  out.push({ role: "user", content: input.prompt });
+  return out;
+}
+
+/**
+ * Convert the subset of the runner's tool registry named in `names` into
+ * Anthropic tool schemas. Unknown names are ignored.
+ */
+export function toolsToAnthropicSchemas(
+  registry: ToolRegistry,
+  names: readonly string[] | undefined,
+): AnthropicToolSchema[] | undefined {
+  if (!names || names.length === 0) return undefined;
+  const out: AnthropicToolSchema[] = [];
+  for (const name of names) {
+    const def = registry[name];
+    if (!def) continue;
+
+    // Extract properties/required from the parameters schema if available
+    const params = def.parameters;
+    const inputSchema: AnthropicToolSchema["input_schema"] = {
+      type: "object",
+      ...(params && typeof params === "object" ? params : {}),
+    };
+
+    out.push({
+      name,
+      description: def.description,
+      input_schema: inputSchema,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}

--- a/packages/runners/anthropic/src/session-store.ts
+++ b/packages/runners/anthropic/src/session-store.ts
@@ -1,0 +1,36 @@
+/**
+ * session-store.ts
+ *
+ * AnthropicSessionStore interface and in-memory implementation.
+ * Stores conversation history as AnthropicMessage arrays, keyed by session handle.
+ */
+
+import type { AnthropicMessage } from "./anthropic-types.js";
+
+export interface AnthropicSessionStore {
+  get(handle: string): Promise<AnthropicMessage[] | undefined>;
+  set(handle: string, messages: AnthropicMessage[]): Promise<void>;
+  delete(handle: string): Promise<void>;
+}
+
+/**
+ * Default session store. Map<handle, AnthropicMessage[]>, process-local.
+ * Stores deep-cloned copies so external mutation of message objects
+ * cannot silently rewrite recorded history.
+ */
+export class InMemoryAnthropicSessionStore implements AnthropicSessionStore {
+  private readonly data = new Map<string, AnthropicMessage[]>();
+
+  async get(handle: string): Promise<AnthropicMessage[] | undefined> {
+    const got = this.data.get(handle);
+    return got ? structuredClone(got) : undefined;
+  }
+
+  async set(handle: string, messages: AnthropicMessage[]): Promise<void> {
+    this.data.set(handle, structuredClone(messages));
+  }
+
+  async delete(handle: string): Promise<void> {
+    this.data.delete(handle);
+  }
+}

--- a/packages/runners/anthropic/src/tool-loop.ts
+++ b/packages/runners/anthropic/src/tool-loop.ts
@@ -1,0 +1,205 @@
+/**
+ * tool-loop.ts
+ *
+ * runAnthropicToolLoop() — the core request/tool-call loop for the Anthropic
+ * Messages API. Separate from runner-api because the message format is
+ * different (tool_result blocks vs OpenAI's "tool" role messages).
+ */
+
+import type { ToolCallRecord } from "@ageflow/core";
+import type { ToolRegistry } from "@ageflow/runner-api";
+import type {
+  AnthropicMessage,
+  AnthropicRequest,
+  AnthropicResponse,
+  AnthropicToolSchema,
+  ToolResultBlock,
+} from "./anthropic-types.js";
+import { MaxToolRoundsError, ToolNotFoundError } from "./errors.js";
+import { AnthropicRequestError } from "./errors.js";
+
+// ─── API constants ────────────────────────────────────────────────────────────
+
+export const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+export const ANTHROPIC_VERSION = "2023-06-01";
+export const DEFAULT_MAX_TOKENS = 8192;
+
+// ─── I/O types ────────────────────────────────────────────────────────────────
+
+export interface RunAnthropicToolLoopInput {
+  apiKey: string;
+  fetch: typeof fetch;
+  model: string;
+  messages: AnthropicMessage[];
+  system: string | undefined;
+  tools: AnthropicToolSchema[] | undefined;
+  registry: ToolRegistry;
+  maxRounds: number;
+  maxTokens: number;
+  requestTimeout: number;
+  thinkingBudgetTokens?: number;
+}
+
+export interface RunAnthropicToolLoopResult {
+  finalText: string;
+  tokensIn: number;
+  tokensOut: number;
+  toolCalls: ToolCallRecord[];
+  finalMessages: AnthropicMessage[];
+}
+
+// ─── Main loop ────────────────────────────────────────────────────────────────
+
+export async function runAnthropicToolLoop(
+  input: RunAnthropicToolLoopInput,
+): Promise<RunAnthropicToolLoopResult> {
+  const messages: AnthropicMessage[] = [...input.messages];
+  const toolCalls: ToolCallRecord[] = [];
+  let tokensIn = 0;
+  let tokensOut = 0;
+
+  for (let round = 0; round < input.maxRounds; round++) {
+    const body: AnthropicRequest = {
+      model: input.model,
+      max_tokens: input.maxTokens,
+      messages,
+      ...(input.system ? { system: input.system } : {}),
+      ...(input.tools && input.tools.length > 0 ? { tools: input.tools } : {}),
+      ...(input.thinkingBudgetTokens !== undefined
+        ? {
+            thinking: {
+              type: "enabled",
+              budget_tokens: input.thinkingBudgetTokens,
+            },
+          }
+        : {}),
+    };
+
+    const resp = await postMessages(input, body);
+    tokensIn += resp.usage?.input_tokens ?? 0;
+    tokensOut += resp.usage?.output_tokens ?? 0;
+
+    // Add assistant turn to history
+    messages.push({ role: "assistant", content: resp.content });
+
+    if (
+      resp.stop_reason === "end_turn" ||
+      resp.stop_reason === "stop_sequence" ||
+      resp.stop_reason === "max_tokens"
+    ) {
+      // Extract final text from content blocks
+      const finalText = extractFinalText(resp.content);
+      return {
+        finalText,
+        tokensIn,
+        tokensOut,
+        toolCalls,
+        finalMessages: messages,
+      };
+    }
+
+    if (resp.stop_reason === "tool_use") {
+      // Find all tool_use blocks
+      const toolUseBlocks = resp.content.filter((b) => b.type === "tool_use");
+
+      if (toolUseBlocks.length === 0) {
+        // stop_reason is tool_use but no tool blocks — treat as end_turn
+        const finalText = extractFinalText(resp.content);
+        return {
+          finalText,
+          tokensIn,
+          tokensOut,
+          toolCalls,
+          finalMessages: messages,
+        };
+      }
+
+      const toolResults: ToolResultBlock[] = [];
+
+      for (const block of toolUseBlocks) {
+        if (block.type !== "tool_use") continue;
+
+        const name = block.name;
+        const args = block.input;
+        const def = input.registry[name];
+        const startedAt = Date.now();
+        let result: unknown;
+
+        try {
+          if (!def) {
+            throw new ToolNotFoundError(name);
+          }
+          result = await def.execute(args);
+        } catch (err) {
+          if (err instanceof ToolNotFoundError) {
+            throw err;
+          }
+          result = `error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        toolCalls.push({ name, args, result, durationMs });
+
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: block.id,
+          content: typeof result === "string" ? result : JSON.stringify(result),
+        });
+      }
+
+      // Append tool results as a single user message
+      messages.push({ role: "user", content: toolResults });
+      continue;
+    }
+
+    // Unknown stop_reason — treat as end_turn
+    const finalText = extractFinalText(resp.content);
+    return {
+      finalText,
+      tokensIn,
+      tokensOut,
+      toolCalls,
+      finalMessages: messages,
+    };
+  }
+
+  throw new MaxToolRoundsError(input.maxRounds);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function extractFinalText(content: AnthropicResponse["content"]): string {
+  return content
+    .filter((b) => b.type === "text")
+    .map((b) => (b.type === "text" ? b.text : ""))
+    .join("");
+}
+
+async function postMessages(
+  input: RunAnthropicToolLoopInput,
+  body: AnthropicRequest,
+): Promise<AnthropicResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.requestTimeout);
+  try {
+    const resp = await input.fetch(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "x-api-key": input.apiKey,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      throw new AnthropicRequestError(resp.status, text);
+    }
+
+    return (await resp.json()) as AnthropicResponse;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/runners/anthropic/tsconfig.json
+++ b/packages/runners/anthropic/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "paths": {
+      "@ageflow/core": ["../../core/src/index.ts"],
+      "@ageflow/runner-api": ["../api/src/index.ts"]
+    }
+  },
+  "references": [
+    { "path": "../../core" },
+    { "path": "../api" }
+  ],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/runners/anthropic/vitest.config.ts
+++ b/packages/runners/anthropic/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@ageflow/core": resolve(__dirname, "../../core/src/index.ts"),
+      "@ageflow/runner-api": resolve(__dirname, "../api/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
New package: native Anthropic Messages API runner. No Claude CLI needed.

## What

- \`AnthropicRunner\` implementing \`Runner\` (validate, spawn, shutdown)
- Direct HTTP to \`/v1/messages\` with \`x-api-key\` auth
- Anthropic-native tool use (\`tool_use\`/\`tool_result\` content blocks)
- Extended thinking support (\`thinkingBudgetTokens\` config)
- Session management (AnthropicSessionStore)
- MCP server support (reuses runner-api MCP client)
- System prompt as separate \`system\` field (not message)

## Usage

\`\`\`ts
import { AnthropicRunner } from "@ageflow/runner-anthropic";
registerRunner("anthropic", new AnthropicRunner({
  apiKey: process.env.ANTHROPIC_API_KEY!,
  defaultModel: "claude-sonnet-4-20250514",
}));
\`\`\`

## Tests

45 tests (session store, message builder, tool loop, runner, exports).

## Version

\`@ageflow/runner-anthropic@0.4.0\` (new package)

Closes #91.