### PR TITLE
docs: #134 — clarify ctx shape in task-input-callbacks + loop ctx semantics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -129,6 +129,121 @@ type MyCtx = CtxFor<WorkflowTasks, "summarize">;
 // → { draft: { output: DraftOutput }, translate: { output: TranslateOutput } }
 ```
 
+## ctx in task-input-callbacks
+
+The `ctx` argument passed to a task's `input` function contains **only the outputs of completed tasks from earlier batches** in the current workflow. It is a flat map keyed by task name.
+
+```ts
+ctx.summarize.output  // output of the "summarize" task
+ctx.translate.output  // output of the "translate" task
+```
+
+Two things `ctx` does NOT contain:
+
+- **Workflow-level input** — the value passed to `executor.stream(input)` is emitted as the `workflow:start` event but is not injected into `ctx`. Use the **closure pattern** to pass workflow-level data into tasks:
+
+```ts
+// Closure pattern: wrap defineWorkflow in a factory function
+function buildWorkflow(input: { text: string; targetLang: string }) {
+  return defineWorkflow({
+    name: "translate-pipeline",
+    tasks: {
+      summarize: {
+        agent: summaryAgent,
+        // Close over `input` from the outer function
+        input: { text: input.text, maxWords: 50 },
+      },
+      translate: {
+        agent: translateAgent,
+        dependsOn: ["summarize"],
+        input: (ctx) => ({
+          // Prior task output from ctx
+          text: ctx.summarize.output as string,
+          // Workflow-level data from closure
+          targetLang: input.targetLang,
+        }),
+      },
+    },
+  });
+}
+
+const workflow = buildWorkflow({ text: "...", targetLang: "es" });
+const executor = new WorkflowExecutor(workflow);
+await executor.run();
+```
+
+- **Special keys like `$input`, `$parent`, or `$prev`** — these do not exist. See below for loop-specific context access.
+
+## Accessing outer ctx and previous iteration inside loop
+
+Inside a `loop`, the inner task `ctx` is built as follows:
+
+1. **Outer workflow's completed-task outputs** are flat-merged into the inner ctx. Access them the same way as any other task output — by their task name:
+
+```ts
+// Outer task named "draft" → available as ctx.draft inside the loop
+ctx.draft.output  // NOT ctx.$parent.draft
+```
+
+2. **Previous iteration's output** is available at `ctx.__loop_feedback__?.output` starting from the second iteration. It is `undefined` on the first iteration.
+
+```ts
+ctx.__loop_feedback__?.output  // NOT ctx.$prev
+```
+
+Example — a loop that uses the previous iteration's verify-gate reason to refine the build prompt:
+
+```ts
+import { loop, defineWorkflow } from "@ageflow/core";
+
+export default defineWorkflow({
+  name: "build-verify-loop",
+  tasks: {
+    scaffold: {
+      agent: scaffoldAgent,
+      input: { spec: "..." },
+    },
+    refine: loop({
+      dependsOn: ["scaffold"],
+      max: 5,
+      until: (ctx: unknown) => {
+        const c = ctx as Record<string, { output: { passed: boolean } }>;
+        return c.verify?.output?.passed === true;
+      },
+      tasks: {
+        build: {
+          agent: buildAgent,
+          dependsOn: [],
+          input: (ctx) => {
+            // Outer workflow's "scaffold" output is flat-merged into inner ctx
+            const spec = (ctx as Record<string, { output: { code: string } }>)
+              .scaffold?.output?.code ?? "";
+            // Previous iteration's full output is at __loop_feedback__
+            const feedback = (
+              ctx as Record<string, { output: { reason?: string } }>
+            ).__loop_feedback__?.output?.reason;
+            return {
+              spec,
+              refinementHint: feedback ?? "First attempt — build from spec.",
+            };
+          },
+        },
+        verify: {
+          agent: verifyAgent,
+          dependsOn: ["build"],
+          input: (ctx) => ({
+            code: (ctx as Record<string, { output: { code: string } }>)
+              .build.output.code,
+          }),
+        },
+      },
+    }),
+  },
+});
+```
+
+> **Note on types**: `__loop_feedback__` is not part of `BoundCtx<D>` — cast `ctx` to `unknown` or use a type assertion when accessing it. A typed helper will be added in a future version.
+
 ## Error types
 
 All errors extend `AgentFlowError`. Import individually or catch by base class:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -143,6 +143,8 @@ Two things `ctx` does NOT contain:
 - **Workflow-level input** — the value passed to `executor.stream(input)` is emitted as the `workflow:start` event but is not injected into `ctx`. Use the **closure pattern** to pass workflow-level data into tasks:
 
 ```ts
+import { WorkflowExecutor } from "@ageflow/executor";
+
 // Closure pattern: wrap defineWorkflow in a factory function
 function buildWorkflow(input: { text: string; targetLang: string }) {
   return defineWorkflow({
@@ -218,13 +220,16 @@ export default defineWorkflow({
             // Outer workflow's "scaffold" output is flat-merged into inner ctx
             const spec = (ctx as Record<string, { output: { code: string } }>)
               .scaffold?.output?.code ?? "";
-            // Previous iteration's full output is at __loop_feedback__
+            // Previous iteration's full output is at __loop_feedback__.output,
+            // which is a task-name-keyed map: Record<string, { output, _source }>
             const feedback = (
-              ctx as Record<string, { output: { reason?: string } }>
-            ).__loop_feedback__?.output?.reason;
+              ctx as Record<string, { output: Record<string, { output: unknown }> }>
+            ).__loop_feedback__?.output;
+            const prevReason = (feedback?.verify?.output as { reason?: string } | undefined)
+              ?.reason;
             return {
               spec,
-              refinementHint: feedback ?? "First attempt — build from spec.",
+              refinementHint: prevReason ?? "First attempt — build from spec.",
             };
           },
         },
@@ -243,6 +248,8 @@ export default defineWorkflow({
 ```
 
 > **Note on types**: `__loop_feedback__` is not part of `BoundCtx<D>` — cast `ctx` to `unknown` or use a type assertion when accessing it. A typed helper will be added in a future version.
+
+> **See also**: canonical `__loop_feedback__` usage in [`dogfooding/workflow.ts`](../../dogfooding/workflow.ts) and [`examples/bug-fix-pipeline/workflow.ts`](../../examples/bug-fix-pipeline/workflow.ts).
 
 ## Error types
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -434,6 +434,17 @@ export interface TaskDef<
 > {
   readonly agent: A;
   readonly dependsOn?: D;
+  /**
+   * Static input value or a callback that receives completed prior-task outputs.
+   *
+   * When a function, `ctx` contains only outputs of tasks listed in `dependsOn`
+   * (keyed by task name, each as `{ output: unknown }`). It does NOT carry
+   * workflow-level input — use the closure pattern for that.
+   * Inside a loop, outer-workflow task outputs are flat-merged into `ctx` and
+   * the previous iteration's output is at `ctx.__loop_feedback__?.output`.
+   *
+   * See the "ctx in task-input-callbacks" section in the @ageflow/core README.
+   */
   readonly input?:
     | import("zod").infer<
         A extends { input: infer I extends ZodType } ? I : never


### PR DESCRIPTION
## Summary

Closes docs-gap flagged in #134. Readers expected `ctx.\$input`, `ctx.\$parent`, `ctx.\$prev` in task input callbacks — but these don't exist (and don't need to; closure + flat-merge is cleaner). Adds two README sections + JSDoc on `TaskDef.input`.

## Changes

- `packages/core/README.md` — two new sections:
  - **ctx in task-input-callbacks** — `ctx` is a flat map of prior task outputs; workflow-level input is NOT in ctx; factory-function closure pattern example
  - **Accessing outer ctx and previous iteration inside loop** — outer task outputs flat-merged by task name (no `\$parent`); previous iteration at `ctx.__loop_feedback__?.output` (no `\$prev`); build-verify loop example
- `packages/core/src/types.ts` — JSDoc on `TaskDef.input` pointing to the README
- `@ageflow/core` patch bump 0.4.3 → 0.4.4

## Verification
- typecheck/build/lint: PASS
- Finder dupes: 0

Closes #134.