### PR TITLE
fix(runner-anthropic): #147 — bump @ageflow/runner-api dep to ^0.3.4 for MCP exports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -200,7 +200,7 @@
     },
     "packages/runners/anthropic": {
       "name": "@ageflow/runner-anthropic",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@ageflow/core": "^0.4.0",
         "@ageflow/runner-api": "^0.3.3",

--- a/packages/runners/anthropic/package.json
+++ b/packages/runners/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-anthropic",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native Anthropic Messages API runner for ageflow (/v1/messages)",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/anthropic",
   "type": "module",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ageflow/core": "^0.4.0",
-    "@ageflow/runner-api": "^0.3.3"
+    "@ageflow/runner-api": "^0.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

Codex P1 on #145: runner-anthropic imports MCP helpers from `@ageflow/runner-api` root, but pinned `^0.3.3`. Those exports were only promoted in 0.3.4 (as part of #145). Consumers resolving 0.3.3 would hit runtime module-load failure.

## Change
- `packages/runners/anthropic/package.json`: `@ageflow/runner-api: ^0.3.3 → ^0.3.4`
- runner-anthropic: `0.4.0 → 0.4.1`

## Verification
- typecheck/build/test/lint: all PASS
- Finder dupes: 0

Closes #147.