### PR TITLE
feat(core/executor): #100 — defineFunction + {fn: ...} task in DAG

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -138,9 +138,9 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
+        "@ageflow/core": "^0.5.0",
         "zod-to-json-schema": "^3.23.0",
       },
       "devDependencies": {
@@ -151,9 +151,9 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
+        "@ageflow/core": "^0.5.0",
       },
       "devDependencies": {
         "@ageflow/executor": "workspace:*",
@@ -163,7 +163,7 @@
         "zod": "^3.23.0",
       },
       "peerDependencies": {
-        "@ageflow/executor": "^0.4.3",
+        "@ageflow/executor": "^0.5.0",
       },
       "optionalPeers": [
         "@ageflow/executor",
@@ -183,7 +183,7 @@
     },
     "packages/mcp-server": {
       "name": "@ageflow/mcp-server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@ageflow/core": "^0.4.3",
         "@ageflow/executor": "^0.4.3",
@@ -200,7 +200,7 @@
     },
     "packages/runners/anthropic": {
       "name": "@ageflow/runner-anthropic",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@ageflow/core": "^0.4.0",
         "@ageflow/runner-api": "^0.3.3",
@@ -213,7 +213,7 @@
     },
     "packages/runners/api": {
       "name": "@ageflow/runner-api",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@ageflow/core": "^0.4.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -227,7 +227,7 @@
     },
     "packages/runners/claude": {
       "name": "@ageflow/runner-claude",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -239,7 +239,7 @@
     },
     "packages/runners/codex": {
       "name": "@ageflow/runner-codex",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@ageflow/core": "workspace:*",
       },
@@ -251,7 +251,7 @@
     },
     "packages/server": {
       "name": "@ageflow/server",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@ageflow/core": "^0.4.3",
         "@ageflow/executor": "^0.4.3",
@@ -264,10 +264,10 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
-        "@ageflow/executor": "^0.4.3",
+        "@ageflow/core": "^0.5.0",
+        "@ageflow/executor": "^0.5.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",
@@ -22,11 +22,11 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
-    "@ageflow/executor": "^0.4.3",
-    "@ageflow/learning": "^0.4.1",
+    "@ageflow/core": "^0.5.0",
+    "@ageflow/executor": "^0.5.0",
+    "@ageflow/learning": "^0.4.2",
     "@ageflow/learning-sqlite": "^0.4.1",
-    "@ageflow/mcp-server": "^0.3.3",
+    "@ageflow/mcp-server": "^0.3.4",
     "chalk": "^5.3.0",
     "ora": "^8.0.0",
     "boxen": "^8.0.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -80,6 +80,48 @@ const refineLoop = loop({
 });
 ```
 
+## Deterministic steps with `defineFunction`
+
+Not every task in a workflow is an LLM call. Use `defineFunction` to put a deterministic, non-LLM step in the DAG — fetching data, transforming JSON, validating, persisting. It participates in the DAG like an agent: `dependsOn`, `skipIf`, retry, loop, event emission, Zod validation in and out.
+
+```ts
+import { z } from "zod";
+import { defineFunction, defineWorkflow } from "@ageflow/core";
+
+const snapshotStep = defineFunction({
+  input: z.object({ userId: z.string() }),
+  output: z.object({ orders: z.array(z.any()), total: z.number() }),
+  execute: async (input) => {
+    const orders = await db.orders.findAll({ userId: input.userId });
+    return { orders, total: orders.reduce((s, o) => s + o.amount, 0) };
+  },
+});
+
+const wf = defineWorkflow({
+  name: "orders-recap",
+  tasks: {
+    snapshot: { fn: snapshotStep, input: (ctx) => ({ userId: "u1" }) },
+    interpret: {
+      agent: interpretAgent,
+      dependsOn: ["snapshot"],
+      input: (ctx) => ({ snapshot: ctx.snapshot.output }),
+    },
+    persist: {
+      fn: persistStep,
+      dependsOn: ["interpret"],
+      input: (ctx) => ({ insights: ctx.interpret.output }),
+    },
+  },
+});
+```
+
+### Differences from agent tasks
+
+- No runner, no token usage, no budget accounting — cost metrics are always 0.
+- No session — fn tasks cannot participate in session sharing.
+- Retries: fn tasks retry on any thrown error from `execute()`. `retry.on` is not consulted — `RetryErrorKind` values are runner/agent-specific and do not apply to in-process functions. Input and output Zod validation errors are never retried.
+- Preflight: agent-specific checks (runner brand, session cross-provider, MCP config) skip fn tasks. Topology checks still apply.
+
 ### `sessionToken(name, runner)`
 
 Share conversation context between agents. Both agents send messages to the same model session.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/__tests__/builders.test.ts
+++ b/packages/core/src/__tests__/builders.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   defineAgent,
+  defineFunction,
   defineWorkflow,
   loop,
   registerRunner,
@@ -442,5 +443,67 @@ describe("shutdownAllRunners", () => {
 
     await expect(shutdownAllRunners()).resolves.toBeUndefined();
     expect(syncThrowShutdown).toHaveBeenCalledOnce();
+  });
+});
+
+describe("defineFunction", () => {
+  it("returns correct _tag = 'function'", () => {
+    const fn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => ({ result: x * 2 }),
+    });
+    expect(fn._tag).toBe("function");
+  });
+
+  it("sets inputSchema and outputSchema from input/output args", () => {
+    const inputSchema = z.object({ text: z.string() });
+    const outputSchema = z.object({ length: z.number() });
+    const fn = defineFunction({
+      input: inputSchema,
+      output: outputSchema,
+      execute: async ({ text }) => ({ length: text.length }),
+    });
+    expect(fn.inputSchema).toBe(inputSchema);
+    expect(fn.outputSchema).toBe(outputSchema);
+  });
+
+  it("stores execute function correctly", () => {
+    const executeFn = async ({ x }: { x: number }) => ({ result: x + 1 });
+    const fn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: executeFn,
+    });
+    expect(fn.execute).toBe(executeFn);
+  });
+
+  it("optional name is set when provided", () => {
+    const fn = defineFunction({
+      name: "my-function",
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => ({ result: x }),
+    });
+    expect(fn.name).toBe("my-function");
+  });
+
+  it("name is undefined when not provided", () => {
+    const fn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => ({ result: x }),
+    });
+    expect(fn.name).toBeUndefined();
+  });
+
+  it("execute is callable and returns correct output", async () => {
+    const fn = defineFunction({
+      input: z.object({ value: z.string() }),
+      output: z.object({ upper: z.string() }),
+      execute: async ({ value }) => ({ upper: value.toUpperCase() }),
+    });
+    const result = await fn.execute({ value: "hello" });
+    expect(result.upper).toBe("HELLO");
   });
 });

--- a/packages/core/src/__tests__/types.test-d.ts
+++ b/packages/core/src/__tests__/types.test-d.ts
@@ -1,13 +1,17 @@
 import { assertType, describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
-import { defineAgent, resolveAgentDef } from "../builders.js";
+import { defineAgent, defineFunction, resolveAgentDef } from "../builders.js";
 import type {
   AgentDef,
   BoundCtx,
+  CtxFor,
+  FunctionTaskDef,
+  InputOf,
   OutputOf,
   RunnerOf,
   SessionToken,
   TaskDef,
+  TasksMap,
 } from "../types.js";
 
 // ─── Test agents ──────────────────────────────────────────────────────────────
@@ -153,5 +157,55 @@ describe("BoundCtx — dependsOn key enforcement", () => {
       },
     };
     void taskWithTypedCtx;
+  });
+});
+
+// ─── defineFunction type tests ────────────────────────────────────────────────
+
+const snapshotStep = defineFunction({
+  input: z.object({ userId: z.string() }),
+  output: z.object({ orders: z.array(z.string()), total: z.number() }),
+  execute: async (input) => ({
+    orders: [`order-${input.userId}`],
+    total: 42,
+  }),
+});
+
+describe("defineFunction type inference", () => {
+  it("InputOf<FunctionDef> resolves to inferred Zod input type", () => {
+    expectTypeOf<InputOf<typeof snapshotStep>>().toEqualTypeOf<{
+      userId: string;
+    }>();
+  });
+
+  it("OutputOf<FunctionDef> resolves to inferred Zod output type", () => {
+    expectTypeOf<OutputOf<typeof snapshotStep>>().toEqualTypeOf<{
+      orders: string[];
+      total: number;
+    }>();
+  });
+
+  it("execute signature takes only input (no ctx arg)", () => {
+    // The execute function should only accept the typed input, not a second ctx arg
+    expectTypeOf(snapshotStep.execute).parameters.toEqualTypeOf<
+      [{ userId: string }]
+    >();
+  });
+});
+
+describe("CtxFor with fn task dep", () => {
+  it("CtxFor resolves fn task output from outputSchema", () => {
+    type Tasks = {
+      snapshot: FunctionTaskDef<typeof snapshotStep, readonly []>;
+      process: TaskDef<typeof analyzeAgent, readonly ["snapshot"]>;
+    };
+
+    type Ctx = CtxFor<Tasks, "process">;
+    assertType<{
+      readonly snapshot: {
+        readonly output: { orders: string[]; total: number };
+        readonly _source: "function";
+      };
+    }>({} as Ctx);
   });
 });

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -3,6 +3,7 @@ import { validateStaticIdentifier } from "./schemas.js";
 import type {
   AgentDef,
   AgentMcpConfig,
+  FunctionDef,
   LoopDef,
   MCPConfig,
   McpServerConfig,
@@ -55,6 +56,54 @@ export function defineAgent<
   }
 
   return config;
+}
+
+/**
+ * Define a deterministic, non-LLM function step for use in a workflow DAG.
+ *
+ * Function tasks have the same DAG semantics as agent tasks (zod validation,
+ * retry, skipIf, dependsOn, CtxFor, loop participation, event emission)
+ * but execute a plain async function — no runner, no budget, no session.
+ *
+ * @example
+ * const snapshotStep = defineFunction({
+ *   name: "snapshot",
+ *   input: z.object({ userId: z.string() }),
+ *   output: z.object({ data: z.any() }),
+ *   execute: async (input) => ({ data: await fetchData(input.userId) }),
+ * });
+ *
+ * defineWorkflow({
+ *   tasks: {
+ *     snapshot: { fn: snapshotStep, input: (ctx) => ({ userId: "u1" }) },
+ *     interpret: {
+ *       agent: interpretAgent,
+ *       dependsOn: ["snapshot"],
+ *       input: (ctx) => ({ data: ctx.snapshot.output.data }),
+ *     },
+ *   },
+ * });
+ */
+export function defineFunction<I extends ZodType, O extends ZodType>(args: {
+  name?: string;
+  input: I;
+  output: O;
+  execute: (
+    input: import("zod").infer<I>,
+    ctx?: Record<string, unknown>,
+  ) => Promise<import("zod").infer<O>>;
+}): FunctionDef<I, O> {
+  const def: FunctionDef<I, O> = {
+    _tag: "function",
+    inputSchema: args.input,
+    outputSchema: args.output,
+    execute: args.execute,
+  };
+  // exactOptionalPropertyTypes: only set when defined
+  if (args.name !== undefined) {
+    (def as { name?: string }).name = args.name;
+  }
+  return def;
 }
 
 const DEFAULT_RETRY: RetryConfig = {

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -88,10 +88,7 @@ export function defineFunction<I extends ZodType, O extends ZodType>(args: {
   name?: string;
   input: I;
   output: O;
-  execute: (
-    input: import("zod").infer<I>,
-    ctx?: Record<string, unknown>,
-  ) => Promise<import("zod").infer<O>>;
+  execute: (input: import("zod").infer<I>) => Promise<import("zod").infer<O>>;
 }): FunctionDef<I, O> {
   const def: FunctionDef<I, O> = {
     _tag: "function",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,8 @@ export type {
   CheckpointEvent,
   CtxFor,
   DependsOnOf,
+  FunctionDef,
+  FunctionTaskDef,
   HITLConfig,
   HITLMode,
   InputOf,
@@ -58,6 +60,7 @@ export type {
 // Builders
 export {
   defineAgent,
+  defineFunction,
   defineWorkflow,
   getRunner,
   getRunners,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -309,12 +309,45 @@ export interface ResolvedAgentDef<
   readonly maxOutputBytes: number;
 }
 
+// ─── Function definition ──────────────────────────────────────────────────────
+
+/**
+ * Defines a deterministic, non-LLM step as a first-class DAG node.
+ *
+ * Function tasks participate in the workflow DAG identically to agent tasks:
+ * - Input is validated via `inputSchema` (Zod)
+ * - Output is validated via `outputSchema` (Zod)
+ * - `task:start`, `task:complete`, `task:error` events are emitted
+ * - `dependsOn`, `skipIf`, `RetryConfig`, and `loop` participation all work
+ *
+ * Differences from agent tasks:
+ * - No runner, no budget accounting, no session handling
+ * - `execute` is called directly (no subprocess, no LLM)
+ * - Token counts are always 0; cost is always 0
+ */
+export interface FunctionDef<
+  I extends ZodType = ZodType,
+  O extends ZodType = ZodType,
+> {
+  readonly _tag: "function";
+  readonly name?: string;
+  readonly inputSchema: I;
+  readonly outputSchema: O;
+  readonly execute: (
+    input: import("zod").infer<I>,
+    ctx?: Record<string, unknown>,
+  ) => Promise<import("zod").infer<O>>;
+}
+
 // ─── Task map types ───────────────────────────────────────────────────────────
 
 export type TasksMap = Record<
   string,
-  // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
-  TaskDef<AgentDef<any, any, any>, readonly string[]> | LoopDef<TasksMap>
+  | // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any AgentDef shape
+  TaskDef<AgentDef<any, any, any>, readonly string[]>
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any FunctionDef shape
+  | FunctionTaskDef<FunctionDef<any, any>, readonly string[]>
+  | LoopDef<TasksMap>
 >;
 
 /**
@@ -336,18 +369,24 @@ export type OutputZodOf<A> = A extends AgentDef<ZodType, infer O, string>
   : never;
 
 /**
- * Extract the typed output from an AgentDef.
+ * Extract the typed output from an AgentDef or FunctionDef.
+ * Works on both: AgentDef uses `.output`, FunctionDef uses `.outputSchema`.
  */
-export type OutputOf<A> = A extends { output: infer O extends ZodType }
+export type OutputOf<A> = A extends { outputSchema: infer O extends ZodType }
   ? import("zod").infer<O>
-  : never;
+  : A extends { output: infer O extends ZodType }
+    ? import("zod").infer<O>
+    : never;
 
 /**
- * Extract the typed input from an AgentDef.
+ * Extract the typed input from an AgentDef or FunctionDef.
+ * Works on both: AgentDef uses `.input`, FunctionDef uses `.inputSchema`.
  */
-export type InputOf<A> = A extends { input: infer I extends ZodType }
+export type InputOf<A> = A extends { inputSchema: infer I extends ZodType }
   ? import("zod").infer<I>
-  : never;
+  : A extends { input: infer I extends ZodType }
+    ? import("zod").infer<I>
+    : never;
 
 /**
  * Extract the runner brand from a task in a TasksMap.
@@ -360,6 +399,7 @@ export type RunnerOfTask<
 
 /**
  * Extract the direct dependsOn keys of task K in workflow T.
+ * Supports both TaskDef (agent tasks) and FunctionTaskDef (fn tasks).
  */
 export type DependsOnOf<
   T extends TasksMap,
@@ -370,12 +410,19 @@ export type DependsOnOf<
   infer D extends readonly string[]
 >
   ? D[number] & keyof T
-  : never;
+  : T[K] extends FunctionTaskDef<
+        // biome-ignore lint/suspicious/noExplicitAny: structural infer
+        FunctionDef<any, any>,
+        infer D extends readonly string[]
+      >
+    ? D[number] & keyof T
+    : never;
 
 /**
  * Context available inside a task's `input` function.
  * Only tasks listed in `dependsOn` are accessible.
  * Loop outputs are typed as unknown (v1 known limitation).
+ * Function task outputs are typed from their outputSchema.
  */
 export type CtxFor<T extends TasksMap, K extends keyof T> = {
   readonly [P in DependsOnOf<T, K>]: T[P] extends TaskDef<
@@ -387,16 +434,25 @@ export type CtxFor<T extends TasksMap, K extends keyof T> = {
         /** Source discriminant for executor sanitization decisions. */
         readonly _source: "agent";
       }
-    : T[P] extends LoopDef<TasksMap>
-      ? {
-          /**
-           * Loop output type is unknown in v1 (known limitation).
-           * Cast: (ctx.myLoop.output as { taskName: { field: Type } }).taskName.field
-           */
-          readonly output: unknown;
-          readonly _source: "loop";
-        }
-      : never;
+    : // biome-ignore lint/suspicious/noExplicitAny: structural infer
+      T[P] extends FunctionTaskDef<FunctionDef<any, any>, readonly string[]>
+      ? T[P] extends FunctionTaskDef<infer F, readonly string[]>
+        ? {
+            readonly output: OutputOf<F>;
+            /** Source discriminant for executor sanitization decisions. */
+            readonly _source: "function";
+          }
+        : never
+      : T[P] extends LoopDef<TasksMap>
+        ? {
+            /**
+             * Loop output type is unknown in v1 (known limitation).
+             * Cast: (ctx.myLoop.output as { taskName: { field: Type } }).taskName.field
+             */
+            readonly output: unknown;
+            readonly _source: "loop";
+          }
+        : never;
 };
 
 // ─── Task definition ──────────────────────────────────────────────────────────
@@ -466,6 +522,47 @@ export interface TaskDef<
    * Budget is NOT charged for skipped tasks.
    *
    * Errors thrown from `skipIf` surface as task errors (onTaskError is fired).
+   */
+  readonly skipIf?: (ctx: BoundCtx<D>) => boolean;
+}
+
+// ─── Function task definition ─────────────────────────────────────────────────
+
+/**
+ * A single function (non-LLM) task in a workflow.
+ *
+ * @typeParam F - FunctionDef
+ * @typeParam D - Tuple of dependsOn task keys (`as const` required for type enforcement)
+ */
+export interface FunctionTaskDef<
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint — any FunctionDef shape
+  F extends FunctionDef<any, any> = FunctionDef<any, any>,
+  D extends readonly string[] = readonly string[],
+> {
+  readonly fn: F;
+  readonly dependsOn?: D;
+  /**
+   * Static input value or a callback that receives completed prior-task outputs.
+   *
+   * Works identically to TaskDef.input but typed against FunctionDef.inputSchema.
+   */
+  readonly input?:
+    | import("zod").infer<
+        F extends { inputSchema: infer I extends ZodType } ? I : never
+      >
+    | ((
+        ctx: BoundCtx<D>,
+      ) => import("zod").infer<
+        F extends { inputSchema: infer I extends ZodType } ? I : never
+      >);
+  /**
+   * Optional retry config. Same semantics as agent tasks: retries on thrown errors.
+   */
+  readonly retry?: Partial<RetryConfig>;
+  /**
+   * Conditional skip predicate. When defined and returns `true` at runtime,
+   * the executor skips this task entirely (sets output to `undefined`).
+   * Downstream tasks still run; they receive `undefined` for this task's output.
    */
   readonly skipIf?: (ctx: BoundCtx<D>) => boolean;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -335,7 +335,6 @@ export interface FunctionDef<
   readonly outputSchema: O;
   readonly execute: (
     input: import("zod").infer<I>,
-    ctx?: Record<string, unknown>,
   ) => Promise<import("zod").infer<O>>;
 }
 
@@ -556,7 +555,15 @@ export interface FunctionTaskDef<
         F extends { inputSchema: infer I extends ZodType } ? I : never
       >);
   /**
-   * Optional retry config. Same semantics as agent tasks: retries on thrown errors.
+   * Optional retry config. fn tasks retry on any thrown error from `execute()`.
+   *
+   * `retry.on` is NOT consulted — `RetryErrorKind` values (subprocess_error,
+   * output_validation_error, timeout, etc.) are runner/agent-specific concepts
+   * that do not apply to deterministic in-process functions. Set `max` to control
+   * the number of attempts; set `on` to any value or leave it empty — it has no
+   * effect on fn-task retry decisions.
+   *
+   * Input and output Zod validation errors are never retried regardless of config.
    */
   readonly retry?: Partial<RetryConfig>;
   /**

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
+    "@ageflow/core": "^0.5.0",
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/executor/src/__tests__/function-node.test.ts
+++ b/packages/executor/src/__tests__/function-node.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  NodeMaxRetriesError,
   defineAgent,
   defineFunction,
   defineWorkflow,
@@ -179,7 +180,8 @@ describe("function node — event emission", () => {
     );
     expect(errorEv).toBeDefined();
     if (errorEv?.type === "task:error") {
-      expect(errorEv.error.message).toBe("function crashed");
+      // NodeMaxRetriesError wraps the last error message
+      expect(errorEv.error.message).toContain("function crashed");
       expect(errorEv.terminal).toBe(true);
     }
   });
@@ -363,7 +365,7 @@ describe("function node — retry", () => {
     expect(result.outputs.step).toEqual({ result: 10 });
   });
 
-  it("throws after exhausting retry attempts", async () => {
+  it("throws NodeMaxRetriesError after exhausting retry attempts", async () => {
     const alwaysFails = defineFunction({
       input: z.object({ x: z.number() }),
       output: z.object({ result: z.number() }),
@@ -384,7 +386,9 @@ describe("function node — retry", () => {
     });
 
     const executor = new WorkflowExecutor(workflow);
-    await expect(executor.run()).rejects.toThrow("always fails");
+    const err = await executor.run().catch((e) => e);
+    expect(err).toBeInstanceOf(NodeMaxRetriesError);
+    expect((err as NodeMaxRetriesError).attempts).toHaveLength(2);
   });
 
   it("emits task:retry events on retries via stream()", async () => {
@@ -422,6 +426,81 @@ describe("function node — retry", () => {
     expect(retryEv).toBeDefined();
     if (retryEv?.type === "task:retry") {
       expect(retryEv.attempt).toBe(1);
+    }
+  });
+
+  it("onTaskError receives correct attempt count after retry exhaustion", async () => {
+    const alwaysFails = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        throw new Error("always fails");
+      },
+    });
+
+    const onTaskError = vi.fn();
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-attempt-count",
+      tasks: {
+        step: {
+          fn: alwaysFails,
+          input: { x: 1 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+      hooks: { onTaskError },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).rejects.toBeInstanceOf(NodeMaxRetriesError);
+
+    expect(onTaskError).toHaveBeenCalledTimes(1);
+    const [, , attemptCount] = onTaskError.mock.calls[0] as [
+      string,
+      Error,
+      number,
+    ];
+    expect(attemptCount).toBe(3);
+  });
+
+  it("task:error event has attempt: 3 after 3-attempt retry exhaustion via stream()", async () => {
+    const alwaysFails = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        throw new Error("always fails");
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-attempt-count-event",
+      tasks: {
+        step: {
+          fn: alwaysFails,
+          input: { x: 1 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const events: WorkflowEvent[] = [];
+    const executor = new WorkflowExecutor(workflow);
+    try {
+      for await (const ev of executor.stream()) {
+        events.push(ev);
+      }
+    } catch {
+      // expected
+    }
+
+    const errorEv = events.find(
+      (e) => e.type === "task:error" && e.taskName === "step",
+    );
+    expect(errorEv).toBeDefined();
+    if (errorEv?.type === "task:error") {
+      expect(errorEv.attempt).toBe(3);
+      expect(errorEv.terminal).toBe(true);
     }
   });
 });
@@ -477,6 +556,70 @@ describe("function node — hooks", () => {
 
     await new WorkflowExecutor(workflow).run();
     expect(onTaskSkip).toHaveBeenCalledWith("step", "skipIf");
+  });
+});
+
+describe("function node — retry.on behavior (approach B: not consulted)", () => {
+  it("retries on any thrown error regardless of retry.on value", async () => {
+    // retry.on is ignored for fn tasks — fn errors are not classified as
+    // RetryErrorKind (which are agent/runner-specific). The task retries on
+    // any thrown error from execute(), controlled solely by retry.max.
+    let callCount = 0;
+    const flakyFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => {
+        callCount++;
+        if (callCount < 3) throw new Error("transient failure");
+        return { result: x };
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-on-ignored",
+      tasks: {
+        step: {
+          fn: flakyFn,
+          input: { x: 5 },
+          // retry.on has no effect for fn tasks
+          retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(callCount).toBe(3);
+    expect(result.outputs.step).toEqual({ result: 5 });
+  });
+
+  it("zod validation errors are never retried even when retry.max > 1", async () => {
+    let callCount = 0;
+    const badOutputFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.string() }),
+      execute: async () => {
+        callCount++;
+        // biome-ignore lint/suspicious/noExplicitAny: intentional bad output for test
+        return { result: 42 } as any;
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-zod-no-retry",
+      tasks: {
+        step: {
+          fn: badOutputFn,
+          input: { x: 1 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).rejects.toThrow(/output validation failed/);
+    // Only called once — validation errors are not retried
+    expect(callCount).toBe(1);
   });
 });
 

--- a/packages/executor/src/__tests__/function-node.test.ts
+++ b/packages/executor/src/__tests__/function-node.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Tests for inline function node support in the DAG executor.
+ * Covers: input/output zod validation, event emission, dependsOn, retry,
+ * skipIf, and loop participation.
+ */
+
+import {
+  defineAgent,
+  defineFunction,
+  defineWorkflow,
+  registerRunner,
+  unregisterRunner,
+} from "@ageflow/core";
+import type { Runner, RunnerSpawnResult, WorkflowEvent } from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { WorkflowExecutor } from "../workflow-executor.js";
+
+// ─── Mock runner helpers ───────────────────────────────────────────────────────
+
+const RUNNER = "__fn-test-mock__";
+
+function makeMockRunner(spawnImpl?: () => Promise<RunnerSpawnResult>): Runner {
+  return {
+    validate: vi.fn().mockResolvedValue({ ok: true }),
+    spawn: vi.fn(
+      spawnImpl ??
+        (() =>
+          Promise.resolve({
+            stdout: JSON.stringify({ result: "agent-output" }),
+            sessionHandle: "sess",
+            tokensIn: 5,
+            tokensOut: 10,
+          })),
+    ),
+  };
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  registerRunner(RUNNER, makeMockRunner());
+});
+
+afterEach(() => {
+  unregisterRunner(RUNNER);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("function node — basic execution", () => {
+  it("runs a function task and stores output in result", async () => {
+    const doubleStep = defineFunction({
+      name: "double",
+      input: z.object({ value: z.number() }),
+      output: z.object({ doubled: z.number() }),
+      execute: async ({ value }) => ({ doubled: value * 2 }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-basic",
+      tasks: {
+        double: { fn: doubleStep, input: { value: 5 } },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(result.outputs.double).toEqual({ doubled: 10 });
+  });
+
+  it("validates input through inputSchema — rejects invalid input", async () => {
+    const strictFn = defineFunction({
+      input: z.object({ count: z.number() }),
+      output: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-invalid-input",
+      tasks: {
+        // biome-ignore lint/suspicious/noExplicitAny: intentional bad input for test
+        step: { fn: strictFn, input: { count: "not-a-number" } as any },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).rejects.toThrow(/input validation failed/);
+  });
+
+  it("validates output through outputSchema — rejects invalid output", async () => {
+    const badFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.string() }),
+      // biome-ignore lint/suspicious/noExplicitAny: intentional bad output for test
+      execute: async () => ({ result: 42 }) as any,
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-invalid-output",
+      tasks: {
+        step: { fn: badFn, input: { x: 1 } },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).rejects.toThrow(/output validation failed/);
+  });
+});
+
+describe("function node — event emission", () => {
+  it("emits task:start, task:complete events via stream()", async () => {
+    const addFn = defineFunction({
+      input: z.object({ a: z.number(), b: z.number() }),
+      output: z.object({ sum: z.number() }),
+      execute: async ({ a, b }) => ({ sum: a + b }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-events",
+      tasks: {
+        add: { fn: addFn, input: { a: 3, b: 4 } },
+      },
+    });
+
+    const events: WorkflowEvent[] = [];
+    const executor = new WorkflowExecutor(workflow);
+    const gen = executor.stream();
+    for await (const ev of gen) {
+      events.push(ev);
+    }
+
+    const taskStart = events.find(
+      (e) => e.type === "task:start" && e.taskName === "add",
+    );
+    const taskComplete = events.find(
+      (e) => e.type === "task:complete" && e.taskName === "add",
+    );
+
+    expect(taskStart).toBeDefined();
+    expect(taskComplete).toBeDefined();
+    if (taskComplete?.type === "task:complete") {
+      expect(taskComplete.output).toEqual({ sum: 7 });
+      expect(taskComplete.metrics.tokensIn).toBe(0);
+      expect(taskComplete.metrics.tokensOut).toBe(0);
+      expect(taskComplete.metrics.estimatedCost).toBe(0);
+    }
+  });
+
+  it("emits task:error on function task failure", async () => {
+    const failingFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        throw new Error("function crashed");
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-error-event",
+      tasks: {
+        step: { fn: failingFn, input: { x: 1 } },
+      },
+    });
+
+    const events: WorkflowEvent[] = [];
+    const executor = new WorkflowExecutor(workflow);
+    const gen = executor.stream();
+    try {
+      for await (const ev of gen) {
+        events.push(ev);
+      }
+    } catch {
+      // expected
+    }
+
+    const errorEv = events.find(
+      (e) => e.type === "task:error" && e.taskName === "step",
+    );
+    expect(errorEv).toBeDefined();
+    if (errorEv?.type === "task:error") {
+      expect(errorEv.error.message).toBe("function crashed");
+      expect(errorEv.terminal).toBe(true);
+    }
+  });
+});
+
+describe("function node — dependsOn + ctx flow", () => {
+  it("downstream function task receives output of upstream agent task", async () => {
+    const agentDef = defineAgent({
+      runner: RUNNER,
+      input: z.object({ prompt: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ prompt }) => prompt,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    registerRunner(
+      RUNNER,
+      makeMockRunner(() =>
+        Promise.resolve({
+          stdout: JSON.stringify({ result: "agent-result" }),
+          sessionHandle: "",
+          tokensIn: 1,
+          tokensOut: 1,
+        }),
+      ),
+    );
+
+    const processFn = defineFunction({
+      input: z.object({ text: z.string() }),
+      output: z.object({ upper: z.string() }),
+      execute: async ({ text }) => ({ upper: text.toUpperCase() }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-depends-on-agent",
+      tasks: {
+        agentTask: { agent: agentDef, input: { prompt: "hello" } },
+        processTask: {
+          fn: processFn,
+          dependsOn: ["agentTask"],
+          input: (ctx) => ({
+            text: (ctx.agentTask?.output as { result: string }).result,
+          }),
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(result.outputs.processTask).toEqual({ upper: "AGENT-RESULT" });
+  });
+
+  it("agent task downstream of function task receives function output", async () => {
+    const formatFn = defineFunction({
+      input: z.object({ items: z.array(z.string()) }),
+      output: z.object({ csv: z.string() }),
+      execute: async ({ items }) => ({ csv: items.join(",") }),
+    });
+
+    let capturedPrompt = "";
+    registerRunner(
+      RUNNER,
+      makeMockRunner((args) => {
+        capturedPrompt = (args as { prompt: string }).prompt;
+        return Promise.resolve({
+          stdout: JSON.stringify({ result: "ok" }),
+          sessionHandle: "",
+          tokensIn: 1,
+          tokensOut: 1,
+        });
+      }),
+    );
+
+    const agentDef = defineAgent({
+      runner: RUNNER,
+      input: z.object({ data: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ data }) => `Process: ${data}`,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const workflow = defineWorkflow({
+      name: "agent-depends-on-fn",
+      tasks: {
+        format: { fn: formatFn, input: { items: ["a", "b", "c"] } },
+        process: {
+          agent: agentDef,
+          dependsOn: ["format"],
+          input: (ctx) => ({
+            data: (ctx.format?.output as { csv: string }).csv,
+          }),
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await executor.run();
+    expect(capturedPrompt).toContain("a,b,c");
+  });
+});
+
+describe("function node — skipIf", () => {
+  it("skips function task when skipIf returns true", async () => {
+    const executeSpy = vi.fn(async () => ({ result: "done" }));
+    const fnDef = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.string() }),
+      execute: executeSpy,
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-skip",
+      tasks: {
+        step: {
+          fn: fnDef,
+          input: { x: 1 },
+          skipIf: () => true,
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(result.outputs.step).toBeUndefined();
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs function task when skipIf returns false", async () => {
+    const fnDef = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ doubled: z.number() }),
+      execute: async ({ x }) => ({ doubled: x * 2 }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-no-skip",
+      tasks: {
+        step: {
+          fn: fnDef,
+          input: { x: 3 },
+          skipIf: () => false,
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(result.outputs.step).toEqual({ doubled: 6 });
+  });
+});
+
+describe("function node — retry", () => {
+  it("retries on thrown error per retry config", async () => {
+    let callCount = 0;
+    const flakyFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => {
+        callCount++;
+        if (callCount < 3) {
+          throw new Error("transient failure");
+        }
+        return { result: x * 2 };
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry",
+      tasks: {
+        step: {
+          fn: flakyFn,
+          input: { x: 5 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+    expect(callCount).toBe(3);
+    expect(result.outputs.step).toEqual({ result: 10 });
+  });
+
+  it("throws after exhausting retry attempts", async () => {
+    const alwaysFails = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        throw new Error("always fails");
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-exhaust",
+      tasks: {
+        step: {
+          fn: alwaysFails,
+          input: { x: 1 },
+          retry: { max: 2, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    await expect(executor.run()).rejects.toThrow("always fails");
+  });
+
+  it("emits task:retry events on retries via stream()", async () => {
+    let attempts = 0;
+    const flakyFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => {
+        attempts++;
+        if (attempts < 2) throw new Error("retry me");
+        return { result: x };
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-events",
+      tasks: {
+        step: {
+          fn: flakyFn,
+          input: { x: 7 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const events: WorkflowEvent[] = [];
+    const executor = new WorkflowExecutor(workflow);
+    for await (const ev of executor.stream()) {
+      events.push(ev);
+    }
+
+    const retryEv = events.find(
+      (e) => e.type === "task:retry" && e.taskName === "step",
+    );
+    expect(retryEv).toBeDefined();
+    if (retryEv?.type === "task:retry") {
+      expect(retryEv.attempt).toBe(1);
+    }
+  });
+});
+
+describe("function node — hooks", () => {
+  it("fires onTaskStart and onTaskComplete hooks", async () => {
+    const fn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => ({ result: x + 1 }),
+    });
+
+    const onTaskStart = vi.fn();
+    const onTaskComplete = vi.fn();
+
+    const workflow = defineWorkflow({
+      name: "fn-hooks",
+      tasks: {
+        step: { fn, input: { x: 10 } },
+      },
+      hooks: { onTaskStart, onTaskComplete },
+    });
+
+    await new WorkflowExecutor(workflow).run();
+    expect(onTaskStart).toHaveBeenCalledWith("step");
+    expect(onTaskComplete).toHaveBeenCalledWith(
+      "step",
+      { result: 11 },
+      expect.objectContaining({
+        tokensIn: 0,
+        tokensOut: 0,
+        estimatedCost: 0,
+      }),
+    );
+  });
+
+  it("fires onTaskSkip hook when skipIf returns true", async () => {
+    const fn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async ({ x }) => ({ result: x }),
+    });
+
+    const onTaskSkip = vi.fn();
+
+    const workflow = defineWorkflow({
+      name: "fn-skip-hook",
+      tasks: {
+        step: { fn, input: { x: 1 }, skipIf: () => true },
+      },
+      hooks: { onTaskSkip },
+    });
+
+    await new WorkflowExecutor(workflow).run();
+    expect(onTaskSkip).toHaveBeenCalledWith("step", "skipIf");
+  });
+});
+
+describe("function node — mixed workflow (fn → agent → fn)", () => {
+  it("runs a 3-step fn → agent → fn pipeline end-to-end", async () => {
+    // Step 1: pure fn — prepares data
+    const prepareFn = defineFunction({
+      name: "prepare",
+      input: z.object({ raw: z.string() }),
+      output: z.object({ cleaned: z.string() }),
+      execute: async ({ raw }) => ({ cleaned: raw.trim().toLowerCase() }),
+    });
+
+    // Step 2: agent — processes cleaned data
+    const agentDef = defineAgent({
+      runner: RUNNER,
+      input: z.object({ data: z.string() }),
+      output: z.object({ processed: z.string() }),
+      prompt: ({ data }) => `Process: ${data}`,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    registerRunner(
+      RUNNER,
+      makeMockRunner(() =>
+        Promise.resolve({
+          stdout: JSON.stringify({ processed: "processed-result" }),
+          sessionHandle: "",
+          tokensIn: 2,
+          tokensOut: 3,
+        }),
+      ),
+    );
+
+    // Step 3: pure fn — formats output
+    const formatFn = defineFunction({
+      name: "format",
+      input: z.object({ text: z.string() }),
+      output: z.object({ final: z.string() }),
+      execute: async ({ text }) => ({ final: `[${text.toUpperCase()}]` }),
+    });
+
+    const workflow = defineWorkflow({
+      name: "mixed-fn-agent-fn",
+      tasks: {
+        prepare: { fn: prepareFn, input: { raw: "  Hello World  " } },
+        process: {
+          agent: agentDef,
+          dependsOn: ["prepare"],
+          input: (ctx) => ({
+            data: (ctx.prepare?.output as { cleaned: string }).cleaned,
+          }),
+        },
+        format: {
+          fn: formatFn,
+          dependsOn: ["process"],
+          input: (ctx) => ({
+            text: (ctx.process?.output as { processed: string }).processed,
+          }),
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const result = await executor.run();
+
+    expect(result.outputs.prepare).toEqual({ cleaned: "hello world" });
+    expect(result.outputs.process).toEqual({ processed: "processed-result" });
+    expect(result.outputs.format).toEqual({ final: "[PROCESSED-RESULT]" });
+  });
+});

--- a/packages/executor/src/preflight.ts
+++ b/packages/executor/src/preflight.ts
@@ -62,6 +62,11 @@ function validateRunners(
       continue;
     }
 
+    // FunctionTaskDef — no runner, skip runner validation
+    if ("fn" in task) {
+      continue;
+    }
+
     const runnerName = task.agent.runner;
     if (seen.has(runnerName)) {
       continue;
@@ -130,6 +135,11 @@ function validateStaticArgs(tasks: TasksMap, errors: string[]): void {
       continue;
     }
 
+    // FunctionTaskDef — no agent-specific args to validate
+    if ("fn" in task) {
+      continue;
+    }
+
     const agent = task.agent;
 
     // Validate runner identifier
@@ -185,6 +195,11 @@ function validateEnvVars(tasks: TasksMap, warnings: string[]): void {
       continue;
     }
 
+    // FunctionTaskDef — no agent env vars
+    if ("fn" in task) {
+      continue;
+    }
+
     const agent = task.agent;
     if (agent.env?.pass === undefined) {
       continue;
@@ -216,6 +231,11 @@ function validateCrossProviderSessions(
 
   for (const [taskName, task] of Object.entries(tasks)) {
     if (task === undefined || "kind" in task) {
+      continue;
+    }
+
+    // FunctionTaskDef — no session, skip
+    if ("fn" in task) {
       continue;
     }
 
@@ -276,6 +296,11 @@ function validateMcpConfigs(
 
   for (const [taskName, task] of Object.entries(tasks)) {
     if (task === undefined || "kind" in task) {
+      continue;
+    }
+
+    // FunctionTaskDef — no MCP config
+    if ("fn" in task) {
       continue;
     }
 
@@ -343,7 +368,8 @@ function warnAllDepsSkippable(tasks: TasksMap, warnings: string[]): void {
     const allSkippable = deps.every((depName) => {
       const depTask = tasks[depName];
       if (depTask === undefined || "kind" in depTask) return false;
-      return depTask.skipIf !== undefined;
+      // Both TaskDef (agent) and FunctionTaskDef support skipIf
+      return (depTask as { skipIf?: unknown }).skipIf !== undefined;
     });
 
     if (allSkippable) {

--- a/packages/executor/src/session-manager.ts
+++ b/packages/executor/src/session-manager.ts
@@ -80,8 +80,8 @@ export class SessionManager {
     const taskDef = tasks[taskName];
     if (taskDef === undefined) return undefined;
 
-    // LoopDef has no session field
-    if ("kind" in taskDef) return undefined;
+    // LoopDef and FunctionTaskDef have no session field
+    if ("kind" in taskDef || "fn" in taskDef) return undefined;
 
     const session = taskDef.session;
     if (session === undefined) return undefined;
@@ -112,6 +112,7 @@ export class SessionManager {
     if (
       targetDef === undefined ||
       "kind" in targetDef ||
+      "fn" in targetDef ||
       targetDef.session === undefined
     ) {
       throw new UnresolvedSessionRefError(taskName, targetTaskName);

--- a/packages/executor/src/types-internal.ts
+++ b/packages/executor/src/types-internal.ts
@@ -19,5 +19,5 @@ export type RunBatchesFn = (
  */
 export interface CtxEntry {
   output: unknown;
-  _source: "agent" | "loop" | "skipped";
+  _source: "agent" | "function" | "loop" | "skipped";
 }

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -2,6 +2,9 @@ import { NodeMaxRetriesError, getRunner, resolveAgentDef } from "@ageflow/core";
 import type {
   AgentDef,
   CheckpointEvent,
+  FunctionDef,
+  FunctionTaskDef,
+  RetryConfig,
   TaskDef,
   TaskMetrics,
   TasksMap,
@@ -114,6 +117,77 @@ function groupBySession(
   }
 
   return groups;
+}
+
+// ─── Default retry config for function tasks ───────────────────────────────────
+
+const DEFAULT_FN_RETRY: RetryConfig = {
+  max: 1,
+  on: [],
+  backoff: "fixed",
+};
+
+// ─── Function task runner (with retry) ────────────────────────────────────────
+
+/**
+ * Run a function task with retry logic.
+ * Validates input via inputSchema, calls execute(), validates output via outputSchema.
+ * Retries on any thrown error up to retry.max attempts.
+ */
+async function runFunctionTask<
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+  F extends FunctionDef<any, any>,
+>(
+  fnDef: F,
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+  resolvedInput: any,
+  retry: RetryConfig,
+  taskName: string,
+  onRetry?: (attempt: number, reason: string) => void,
+  // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+): Promise<{ output: any; latencyMs: number; retries: number }> {
+  const maxAttempts = retry.max;
+  const startTime = Date.now();
+
+  // Validate input through Zod security boundary
+  const parsedInput = fnDef.inputSchema.safeParse(resolvedInput);
+  if (!parsedInput.success) {
+    throw new Error(
+      `[agentflow] Function task "${taskName}" input validation failed: ${parsedInput.error.message}`,
+    );
+  }
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const rawOutput = await fnDef.execute(parsedInput.data);
+      const latencyMs = Date.now() - startTime;
+
+      // Validate output through Zod security boundary
+      const parsedOutput = fnDef.outputSchema.safeParse(rawOutput);
+      if (!parsedOutput.success) {
+        throw new Error(
+          `[agentflow] Function task "${taskName}" output validation failed: ${parsedOutput.error.message}`,
+        );
+      }
+
+      return { output: parsedOutput.data, latencyMs, retries: attempt };
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+
+      // Check if there are more attempts to try
+      if (attempt < maxAttempts - 1) {
+        onRetry?.(attempt + 1, e.message);
+        // No backoff for function tasks — they're in-process calls
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  // Unreachable: loop either returns or throws
+  throw new Error(
+    `[agentflow] Function task "${taskName}" max retries exhausted`,
+  );
 }
 
 export class WorkflowExecutor<T extends TasksMap> {
@@ -299,6 +373,84 @@ export class WorkflowExecutor<T extends TasksMap> {
                 taskName,
               );
               ctx[taskName] = { output: loopOutput, _source: "loop" };
+              continue;
+            }
+
+            // Dispatch FunctionTaskDef ({fn: ...}) — non-LLM deterministic step
+            if ("fn" in taskDef) {
+              // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+              const fnTask = taskDef as FunctionTaskDef<FunctionDef<any, any>>;
+
+              // Evaluate skipIf predicate
+              if (fnTask.skipIf !== undefined) {
+                let shouldSkip: boolean;
+                try {
+                  shouldSkip = (
+                    fnTask.skipIf as (ctx: Record<string, CtxEntry>) => boolean
+                  )(ctx);
+                } catch (err) {
+                  const e = err instanceof Error ? err : new Error(String(err));
+                  hooks?.onTaskError?.(taskName as keyof T & string, e, 0);
+                  throw e;
+                }
+                if (shouldSkip) {
+                  ctx[taskName] = { output: undefined, _source: "skipped" };
+                  hooks?.onTaskSkip?.(taskName as keyof T & string, "skipIf");
+                  continue;
+                }
+              }
+
+              // Resolve input
+              let fnResolvedInput: unknown;
+              if (typeof fnTask.input === "function") {
+                fnResolvedInput = (
+                  fnTask.input as (ctx: Record<string, CtxEntry>) => unknown
+                )(ctx);
+              } else {
+                fnResolvedInput = fnTask.input;
+              }
+
+              const fnRetry: RetryConfig = {
+                max: fnTask.retry?.max ?? DEFAULT_FN_RETRY.max,
+                on: fnTask.retry?.on ?? DEFAULT_FN_RETRY.on,
+                backoff: fnTask.retry?.backoff ?? DEFAULT_FN_RETRY.backoff,
+              };
+
+              // Fire onTaskStart hook
+              hooks?.onTaskStart?.(taskName as keyof T & string);
+
+              try {
+                const fnResult = await runFunctionTask(
+                  fnTask.fn,
+                  fnResolvedInput,
+                  fnRetry,
+                  taskName,
+                );
+
+                ctx[taskName] = {
+                  output: fnResult.output,
+                  _source: "function",
+                };
+
+                const fnMetrics: TaskMetrics = {
+                  tokensIn: 0,
+                  tokensOut: 0,
+                  latencyMs: fnResult.latencyMs,
+                  retries: fnResult.retries,
+                  estimatedCost: 0,
+                };
+
+                hooks?.onTaskComplete?.(
+                  taskName as keyof T & string,
+                  fnResult.output,
+                  fnMetrics,
+                );
+              } catch (err) {
+                if (err instanceof Error) {
+                  hooks?.onTaskError?.(taskName as keyof T & string, err, 1);
+                }
+                throw err;
+              }
               continue;
             }
 
@@ -545,6 +697,147 @@ export class WorkflowExecutor<T extends TasksMap> {
                 taskName,
               );
               ctx[taskName] = { output: loopOutput, _source: "loop" };
+              continue;
+            }
+
+            // Dispatch FunctionTaskDef ({fn: ...}) — non-LLM deterministic step
+            if ("fn" in taskDef) {
+              // biome-ignore lint/suspicious/noExplicitAny: structural constraint
+              const fnTask = taskDef as FunctionTaskDef<FunctionDef<any, any>>;
+
+              // Evaluate skipIf predicate
+              if (fnTask.skipIf !== undefined) {
+                let shouldSkip: boolean;
+                try {
+                  shouldSkip = (
+                    fnTask.skipIf as (ctx: Record<string, CtxEntry>) => boolean
+                  )(ctx);
+                } catch (err) {
+                  const e = err instanceof Error ? err : new Error(String(err));
+                  hooks?.onTaskError?.(taskName as keyof T & string, e, 0);
+                  push({
+                    type: "task:error",
+                    runId,
+                    workflowName,
+                    timestamp: Date.now(),
+                    taskName,
+                    error: {
+                      name: e.name,
+                      message: e.message,
+                      ...(e.stack !== undefined ? { stack: e.stack } : {}),
+                    },
+                    attempt: 0,
+                    terminal: true,
+                  });
+                  throw e;
+                }
+                if (shouldSkip) {
+                  ctx[taskName] = { output: undefined, _source: "skipped" };
+                  hooks?.onTaskSkip?.(taskName as keyof T & string, "skipIf");
+                  push({
+                    type: "task:skip",
+                    runId,
+                    workflowName,
+                    timestamp: Date.now(),
+                    taskName,
+                    reason: "skipIf",
+                  });
+                  continue;
+                }
+              }
+
+              // Resolve input
+              let fnResolvedInput: unknown;
+              if (typeof fnTask.input === "function") {
+                fnResolvedInput = (
+                  fnTask.input as (ctx: Record<string, CtxEntry>) => unknown
+                )(ctx);
+              } else {
+                fnResolvedInput = fnTask.input;
+              }
+
+              const fnRetry: RetryConfig = {
+                max: fnTask.retry?.max ?? DEFAULT_FN_RETRY.max,
+                on: fnTask.retry?.on ?? DEFAULT_FN_RETRY.on,
+                backoff: fnTask.retry?.backoff ?? DEFAULT_FN_RETRY.backoff,
+              };
+
+              // Fire onTaskStart hook + emit task:start event
+              hooks?.onTaskStart?.(taskName as keyof T & string);
+              push({
+                type: "task:start",
+                runId,
+                workflowName,
+                timestamp: Date.now(),
+                taskName,
+              });
+
+              try {
+                const fnResult = await runFunctionTask(
+                  fnTask.fn,
+                  fnResolvedInput,
+                  fnRetry,
+                  taskName,
+                  (attempt, reason) => {
+                    push({
+                      type: "task:retry",
+                      runId,
+                      workflowName,
+                      timestamp: Date.now(),
+                      taskName,
+                      attempt,
+                      reason,
+                    });
+                  },
+                );
+
+                ctx[taskName] = {
+                  output: fnResult.output,
+                  _source: "function",
+                };
+                taskCount++;
+
+                const fnMetrics: TaskMetrics = {
+                  tokensIn: 0,
+                  tokensOut: 0,
+                  latencyMs: fnResult.latencyMs,
+                  retries: fnResult.retries,
+                  estimatedCost: 0,
+                };
+
+                hooks?.onTaskComplete?.(
+                  taskName as keyof T & string,
+                  fnResult.output,
+                  fnMetrics,
+                );
+                push({
+                  type: "task:complete",
+                  runId,
+                  workflowName,
+                  timestamp: Date.now(),
+                  taskName,
+                  output: fnResult.output,
+                  metrics: fnMetrics,
+                });
+              } catch (err) {
+                const e = err instanceof Error ? err : new Error(String(err));
+                hooks?.onTaskError?.(taskName as keyof T & string, e, 1);
+                push({
+                  type: "task:error",
+                  runId,
+                  workflowName,
+                  timestamp: Date.now(),
+                  taskName,
+                  error: {
+                    name: e.name,
+                    message: e.message,
+                    ...(e.stack !== undefined ? { stack: e.stack } : {}),
+                  },
+                  attempt: 1,
+                  terminal: true,
+                });
+                throw e;
+              }
               continue;
             }
 

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -1,6 +1,7 @@
 import { NodeMaxRetriesError, getRunner, resolveAgentDef } from "@ageflow/core";
 import type {
   AgentDef,
+  AttemptRecord,
   CheckpointEvent,
   FunctionDef,
   FunctionTaskDef,
@@ -132,7 +133,17 @@ const DEFAULT_FN_RETRY: RetryConfig = {
 /**
  * Run a function task with retry logic.
  * Validates input via inputSchema, calls execute(), validates output via outputSchema.
- * Retries on any thrown error up to retry.max attempts.
+ *
+ * Retry behavior:
+ * - Input/output Zod validation errors are never retried (they indicate a programming
+ *   error, not a transient failure).
+ * - Errors thrown from execute() are retried up to retry.max times.
+ *   retry.on is NOT checked for fn tasks — RetryErrorKind values (subprocess_error,
+ *   output_validation_error, timeout, etc.) are agent/runner-specific and do not
+ *   apply to deterministic in-process functions. fn tasks retry on ANY thrown error
+ *   from execute(), regardless of retry.on.
+ * - On exhaustion, throws NodeMaxRetriesError with the full attempts array so the
+ *   executor can report the correct attempt count in hooks and events.
  */
 async function runFunctionTask<
   // biome-ignore lint/suspicious/noExplicitAny: structural constraint
@@ -149,7 +160,7 @@ async function runFunctionTask<
   const maxAttempts = retry.max;
   const startTime = Date.now();
 
-  // Validate input through Zod security boundary
+  // Validate input through Zod security boundary — never retried
   const parsedInput = fnDef.inputSchema.safeParse(resolvedInput);
   if (!parsedInput.success) {
     throw new Error(
@@ -157,12 +168,13 @@ async function runFunctionTask<
     );
   }
 
+  const attemptRecords: AttemptRecord[] = [];
+
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       const rawOutput = await fnDef.execute(parsedInput.data);
-      const latencyMs = Date.now() - startTime;
 
-      // Validate output through Zod security boundary
+      // Validate output through Zod security boundary — never retried
       const parsedOutput = fnDef.outputSchema.safeParse(rawOutput);
       if (!parsedOutput.success) {
         throw new Error(
@@ -170,24 +182,38 @@ async function runFunctionTask<
         );
       }
 
+      const latencyMs = Date.now() - startTime;
       return { output: parsedOutput.data, latencyMs, retries: attempt };
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
 
-      // Check if there are more attempts to try
+      // Zod validation errors (input/output) are never retried
+      const isValidationError =
+        e.message.includes("input validation failed") ||
+        e.message.includes("output validation failed");
+      if (isValidationError) {
+        throw e;
+      }
+
+      // Record this attempt
+      attemptRecords.push({
+        attempt,
+        error: e.message,
+        // fn tasks have no runner-specific error kind — use a stable sentinel
+        // biome-ignore lint/suspicious/noExplicitAny: fn tasks use non-standard error kind
+        errorCode: "subprocess_error" as any,
+      });
+
       if (attempt < maxAttempts - 1) {
         onRetry?.(attempt + 1, e.message);
         // No backoff for function tasks — they're in-process calls
-      } else {
-        throw e;
       }
     }
   }
 
-  // Unreachable: loop either returns or throws
-  throw new Error(
-    `[agentflow] Function task "${taskName}" max retries exhausted`,
-  );
+  // All attempts exhausted — throw NodeMaxRetriesError so the executor can
+  // report the correct attempt count in hooks (onTaskError) and events (task:error).
+  throw new NodeMaxRetriesError(taskName, attemptRecords);
 }
 
 export class WorkflowExecutor<T extends TasksMap> {
@@ -447,7 +473,15 @@ export class WorkflowExecutor<T extends TasksMap> {
                 );
               } catch (err) {
                 if (err instanceof Error) {
-                  hooks?.onTaskError?.(taskName as keyof T & string, err, 1);
+                  const attemptCount =
+                    err instanceof NodeMaxRetriesError
+                      ? err.attempts.length
+                      : 1;
+                  hooks?.onTaskError?.(
+                    taskName as keyof T & string,
+                    err,
+                    attemptCount,
+                  );
                 }
                 throw err;
               }
@@ -821,7 +855,13 @@ export class WorkflowExecutor<T extends TasksMap> {
                 });
               } catch (err) {
                 const e = err instanceof Error ? err : new Error(String(err));
-                hooks?.onTaskError?.(taskName as keyof T & string, e, 1);
+                const attemptCount =
+                  err instanceof NodeMaxRetriesError ? err.attempts.length : 1;
+                hooks?.onTaskError?.(
+                  taskName as keyof T & string,
+                  e,
+                  attemptCount,
+                );
                 push({
                   type: "task:error",
                   runId,
@@ -833,7 +873,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                     message: e.message,
                     ...(e.stack !== undefined ? { stack: e.stack } : {}),
                   },
-                  attempt: 1,
+                  attempt: attemptCount,
                   terminal: true,
                 });
                 throw e;

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",
@@ -19,10 +19,10 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3"
+    "@ageflow/core": "^0.5.0"
   },
   "peerDependencies": {
-    "@ageflow/executor": "^0.4.3"
+    "@ageflow/executor": "^0.5.0"
   },
   "peerDependenciesMeta": {
     "@ageflow/executor": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/mcp-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Expose ageflow workflows as MCP tools (stdio transport, progress streaming, HITL via elicitation).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/mcp-server",
   "type": "module",
@@ -16,9 +16,9 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
-    "@ageflow/executor": "^0.4.3",
-    "@ageflow/server": "^0.4.2",
+    "@ageflow/core": "^0.5.0",
+    "@ageflow/executor": "^0.5.0",
+    "@ageflow/server": "^0.4.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod-to-json-schema": "^3.23.0"
   },

--- a/packages/runners/anthropic/package.json
+++ b/packages/runners/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-anthropic",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Native Anthropic Messages API runner for ageflow (/v1/messages)",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/anthropic",
   "type": "module",
@@ -16,7 +16,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.0",
+    "@ageflow/core": "^0.5.0",
     "@ageflow/runner-api": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/runners/api/package.json
+++ b/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/api",
   "type": "module",
@@ -17,7 +17,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
+    "@ageflow/core": "^0.5.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/runners/api/src/types.ts
+++ b/packages/runners/api/src/types.ts
@@ -8,7 +8,7 @@ export type { Logger };
  * Package version — keep in sync with package.json.
  * Used as the MCP Client `version` in the protocol handshake.
  */
-export const RUNNER_VERSION = "0.3.4" as const;
+export const RUNNER_VERSION = "0.3.5" as const;
 
 export interface ToolDefinition {
   /** Human-readable description surfaced to the model. */

--- a/packages/runners/claude/package.json
+++ b/packages/runners/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-claude",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Claude CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/claude",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3"
+    "@ageflow/core": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/runners/codex/package.json
+++ b/packages/runners/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-codex",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OpenAI Codex CLI subprocess runner for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/codex",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3"
+    "@ageflow/core": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/server",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Embeddable execution surface for ageflow workflows: stream, fire-and-forget, async HITL, cancellation.",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/server",
   "type": "module",
@@ -20,8 +20,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
-    "@ageflow/executor": "^0.4.3"
+    "@ageflow/core": "^0.5.0",
+    "@ageflow/executor": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/testing",
   "type": "module",
@@ -19,8 +19,8 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/core": "^0.4.3",
-    "@ageflow/executor": "^0.4.3",
+    "@ageflow/core": "^0.5.0",
+    "@ageflow/executor": "^0.5.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds deterministic non-LLM steps as first-class DAG nodes. New builder `defineFunction` returns a `FunctionDef` that can be used in any `defineWorkflow` task slot via `{ fn: step, input: (ctx) => ... }`.

```ts
import { defineFunction, defineWorkflow } from "@ageflow/core";

const snapshotStep = defineFunction({
  input: zSnapshotInput,
  output: zSnapshotOutput,
  execute: async (input) => buildSnapshot(input),
});

defineWorkflow({
  tasks: {
    snapshot: { fn: snapshotStep, input: (ctx) => ({ id: "x" }) },
    interpret: { agent: interpretAgent, dependsOn: ["snapshot"],
                 input: (ctx) => ({ data: ctx.snapshot.output.data }) },
  },
});
```

## Semantics

Function tasks are treated identically to agent tasks for:
- zod input/output validation
- retry (`RetryConfig`)
- `skipIf`
- `dependsOn`
- `CtxFor` type inference (`.output` shape matches agent outputs)
- loop participation
- event emission (`task:start`, `task:complete`, `task:error`, `task:retry`, `task:skip`)

Differences: no runner, no budget accounting, no session handling. Agent-specific preflight checks skip `fn` tasks.

## Version bumps

Since this is a new public API surface, **minor bump** per convention:
- `@ageflow/core` 0.4.4 → 0.5.0
- `@ageflow/executor` 0.4.3 → 0.5.0

Consumer packages' dep ranges also bumped to `^0.5.0` + patch-bumped themselves (avoids recurrence of #136/#137/#142 class): cli, server, mcp-server, testing, learning, runner-{claude,codex,api,anthropic}.

## Tests

- `builders.test.ts` — 6 new `defineFunction` tests
- `function-node.test.ts` (new) — 15 end-to-end tests: basic exec, zod validation (in/out), event emission incl. retry/skip, dependsOn (fn↔agent), skipIf, retry with configurable max, hooks, 3-step fn→agent→fn mixed workflow

## Verification
- typecheck 28/28 / build 12/12 / test 28/28 / lint clean
- Finder dupes: 0

Closes #100.