### PR TITLE
fix(executor): #152 — honor retry.on in fn-task retry classification

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -119,7 +119,7 @@ const wf = defineWorkflow({
 
 - No runner, no token usage, no budget accounting — cost metrics are always 0.
 - No session — fn tasks cannot participate in session sharing.
-- Retries: fn tasks retry on any thrown error from `execute()`. `retry.on` is not consulted — `RetryErrorKind` values are runner/agent-specific and do not apply to in-process functions. Input and output Zod validation errors are never retried.
+- Retries: fn tasks honor `retry.on` the same as agent tasks. Errors from `execute()` are classified as `"transient"` (generic) or `"timeout"` (`TimeoutError`). To retry, include the matching kind in `retry.on` (e.g. `on: ["transient"]`). Zod validation errors (input or output) never retry regardless of config — the data contract is wrong and retrying won't fix it.
 - Preflight: agent-specific checks (runner brand, session cross-provider, MCP config) skip fn tasks. Topology checks still apply.
 
 ### `sessionToken(name, runner)`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,7 +11,18 @@ export type RetryErrorKind =
   | "provider_unavailable"
   | "budget_exceeded"
   | "agent_hitl_conflict"
-  | "mcp_server_start_failed";
+  | "mcp_server_start_failed"
+  /**
+   * Generic transient error from an in-process function task (`{fn: ...}`).
+   * Thrown by `execute()` that is not a Zod validation error.
+   * Consult `retry.on` to decide whether to retry.
+   */
+  | "transient"
+  /**
+   * Zod input or output validation error on a function task (`{fn: ...}`).
+   * Never retried — the data contract is wrong, retrying won't fix it.
+   */
+  | "validation";
 
 // ─── Config types ─────────────────────────────────────────────────────────────
 
@@ -555,15 +566,18 @@ export interface FunctionTaskDef<
         F extends { inputSchema: infer I extends ZodType } ? I : never
       >);
   /**
-   * Optional retry config. fn tasks retry on any thrown error from `execute()`.
+   * Optional retry config. Fn tasks honor `retry.on` identically to agent tasks.
    *
-   * `retry.on` is NOT consulted — `RetryErrorKind` values (subprocess_error,
-   * output_validation_error, timeout, etc.) are runner/agent-specific concepts
-   * that do not apply to deterministic in-process functions. Set `max` to control
-   * the number of attempts; set `on` to any value or leave it empty — it has no
-   * effect on fn-task retry decisions.
+   * Error classification for fn tasks:
+   * - `"transient"` — any `Error` thrown from `execute()` that is not a Zod validation error
+   * - `"timeout"` — `TimeoutError` thrown from `execute()` (if the fn imposes its own timeout)
+   * - `"validation"` — Zod input/output validation error; **never retried** regardless of `retry.on`
    *
-   * Input and output Zod validation errors are never retried regardless of config.
+   * If `retry.on` is empty (`[]`), no errors are retried (single attempt).
+   * To retry transient errors: `retry: { max: 3, on: ["transient"], backoff: "fixed" }`.
+   *
+   * Zod input and output validation errors are **always** non-retryable — the data
+   * contract is wrong and retrying will not fix it.
    */
   readonly retry?: Partial<RetryConfig>;
   /**

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/function-node.test.ts
+++ b/packages/executor/src/__tests__/function-node.test.ts
@@ -334,7 +334,7 @@ describe("function node — skipIf", () => {
 });
 
 describe("function node — retry", () => {
-  it("retries on thrown error per retry config", async () => {
+  it("retries on thrown error when error kind is in retry.on", async () => {
     let callCount = 0;
     const flakyFn = defineFunction({
       input: z.object({ x: z.number() }),
@@ -354,7 +354,8 @@ describe("function node — retry", () => {
         step: {
           fn: flakyFn,
           input: { x: 5 },
-          retry: { max: 3, on: [], backoff: "fixed" },
+          // "transient" covers any non-timeout, non-validation error from execute()
+          retry: { max: 3, on: ["transient"], backoff: "fixed" },
         },
       },
     });
@@ -380,7 +381,7 @@ describe("function node — retry", () => {
         step: {
           fn: alwaysFails,
           input: { x: 1 },
-          retry: { max: 2, on: [], backoff: "fixed" },
+          retry: { max: 2, on: ["transient"], backoff: "fixed" },
         },
       },
     });
@@ -409,7 +410,7 @@ describe("function node — retry", () => {
         step: {
           fn: flakyFn,
           input: { x: 7 },
-          retry: { max: 3, on: [], backoff: "fixed" },
+          retry: { max: 3, on: ["transient"], backoff: "fixed" },
         },
       },
     });
@@ -446,7 +447,7 @@ describe("function node — retry", () => {
         step: {
           fn: alwaysFails,
           input: { x: 1 },
-          retry: { max: 3, on: [], backoff: "fixed" },
+          retry: { max: 3, on: ["transient"], backoff: "fixed" },
         },
       },
       hooks: { onTaskError },
@@ -479,7 +480,7 @@ describe("function node — retry", () => {
         step: {
           fn: alwaysFails,
           input: { x: 1 },
-          retry: { max: 3, on: [], backoff: "fixed" },
+          retry: { max: 3, on: ["transient"], backoff: "fixed" },
         },
       },
     });
@@ -559,38 +560,102 @@ describe("function node — hooks", () => {
   });
 });
 
-describe("function node — retry.on behavior (approach B: not consulted)", () => {
-  it("retries on any thrown error regardless of retry.on value", async () => {
-    // retry.on is ignored for fn tasks — fn errors are not classified as
-    // RetryErrorKind (which are agent/runner-specific). The task retries on
-    // any thrown error from execute(), controlled solely by retry.max.
+describe("function node — retry.on classification", () => {
+  it("retry.on=[] — does NOT retry on any error (single attempt)", async () => {
+    // With on: [] the retry set is empty — no error kind is retryable.
+    // execute() should be called exactly once even though max=3.
+    let callCount = 0;
+    const flakyFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        callCount++;
+        throw new Error("transient failure");
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-on-empty",
+      tasks: {
+        step: {
+          fn: flakyFn,
+          input: { x: 5 },
+          retry: { max: 3, on: [], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const err = await executor.run().catch((e) => e);
+    expect(err).toBeInstanceOf(NodeMaxRetriesError);
+    // Called exactly once — no retries
+    expect(callCount).toBe(1);
+    expect((err as NodeMaxRetriesError).attempts).toHaveLength(1);
+  });
+
+  it('retry.on=["timeout"] with non-timeout error — does NOT retry', async () => {
+    // "transient" errors are not in retry.on, so no retry happens.
+    let callCount = 0;
+    const flakyFn = defineFunction({
+      input: z.object({ x: z.number() }),
+      output: z.object({ result: z.number() }),
+      execute: async () => {
+        callCount++;
+        throw new Error("generic error — not a timeout");
+      },
+    });
+
+    const workflow = defineWorkflow({
+      name: "fn-retry-on-timeout-no-match",
+      tasks: {
+        step: {
+          fn: flakyFn,
+          input: { x: 1 },
+          retry: { max: 3, on: ["timeout"], backoff: "fixed" },
+        },
+      },
+    });
+
+    const executor = new WorkflowExecutor(workflow);
+    const err = await executor.run().catch((e) => e);
+    expect(err).toBeInstanceOf(NodeMaxRetriesError);
+    // Called exactly once — "transient" not in retry.on
+    expect(callCount).toBe(1);
+    expect((err as NodeMaxRetriesError).attempts).toHaveLength(1);
+  });
+
+  it('retry.on=["timeout"] with TimeoutError — retries up to max', async () => {
+    // TimeoutError is classified as "timeout" — present in retry.on → retries happen.
+    const { TimeoutError } = await import("@ageflow/core");
     let callCount = 0;
     const flakyFn = defineFunction({
       input: z.object({ x: z.number() }),
       output: z.object({ result: z.number() }),
       execute: async ({ x }) => {
         callCount++;
-        if (callCount < 3) throw new Error("transient failure");
+        if (callCount < 3) {
+          throw new TimeoutError("step", 100);
+        }
         return { result: x };
       },
     });
 
     const workflow = defineWorkflow({
-      name: "fn-retry-on-ignored",
+      name: "fn-retry-on-timeout-match",
       tasks: {
         step: {
           fn: flakyFn,
-          input: { x: 5 },
-          // retry.on has no effect for fn tasks
-          retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+          input: { x: 7 },
+          retry: { max: 3, on: ["timeout"], backoff: "fixed" },
         },
       },
     });
 
     const executor = new WorkflowExecutor(workflow);
     const result = await executor.run();
+    // Retried twice (attempts 1 and 2 failed), third succeeded
     expect(callCount).toBe(3);
-    expect(result.outputs.step).toEqual({ result: 5 });
+    expect(result.outputs.step).toEqual({ result: 7 });
   });
 
   it("zod validation errors are never retried even when retry.max > 1", async () => {
@@ -611,7 +676,7 @@ describe("function node — retry.on behavior (approach B: not consulted)", () =
         step: {
           fn: badOutputFn,
           input: { x: 1 },
-          retry: { max: 3, on: [], backoff: "fixed" },
+          retry: { max: 3, on: ["transient"], backoff: "fixed" },
         },
       },
     });

--- a/packages/executor/src/retry-classify.ts
+++ b/packages/executor/src/retry-classify.ts
@@ -1,0 +1,23 @@
+import { TimeoutError } from "@ageflow/core";
+import type { RetryErrorKind } from "@ageflow/core";
+
+/**
+ * Classify an error thrown from a function task's `execute()` call into a
+ * `RetryErrorKind` that can be checked against `retry.on`.
+ *
+ * Classification rules:
+ * - `TimeoutError` → `"timeout"`
+ * - Any other thrown `Error` → `"transient"`
+ *
+ * Note: Zod input/output validation errors are handled BEFORE calling this
+ * helper — they use the `"validation"` kind and are never retried regardless
+ * of `retry.on`.
+ */
+export function classifyFnError(
+  err: Error,
+): Extract<RetryErrorKind, "transient" | "timeout"> {
+  if (err instanceof TimeoutError) {
+    return "timeout";
+  }
+  return "transient";
+}

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -23,6 +23,7 @@ import {
 import { HITLManager } from "./hitl-manager.js";
 import { LoopExecutor } from "./loop-executor.js";
 import { runNode } from "./node-runner.js";
+import { classifyFnError } from "./retry-classify.js";
 import { SessionManager } from "./session-manager.js";
 import type { CtxEntry, RunBatchesFn } from "./types-internal.js";
 
@@ -135,15 +136,14 @@ const DEFAULT_FN_RETRY: RetryConfig = {
  * Validates input via inputSchema, calls execute(), validates output via outputSchema.
  *
  * Retry behavior:
- * - Input/output Zod validation errors are never retried (they indicate a programming
- *   error, not a transient failure).
- * - Errors thrown from execute() are retried up to retry.max times.
- *   retry.on is NOT checked for fn tasks — RetryErrorKind values (subprocess_error,
- *   output_validation_error, timeout, etc.) are agent/runner-specific and do not
- *   apply to deterministic in-process functions. fn tasks retry on ANY thrown error
- *   from execute(), regardless of retry.on.
- * - On exhaustion, throws NodeMaxRetriesError with the full attempts array so the
- *   executor can report the correct attempt count in hooks and events.
+ * - Input/output Zod validation errors are never retried (classified as "validation").
+ *   They indicate a data contract violation; retrying won't fix it.
+ * - Errors thrown from execute() are classified (see classifyFnError) and checked
+ *   against retry.on before retrying — same semantics as agent tasks.
+ *   If retry.on is empty ([]) no errors are retried regardless of retry.max.
+ * - On exhaustion (or a non-retryable error kind), throws NodeMaxRetriesError with
+ *   the full attempts array so the executor can report the correct attempt count
+ *   in hooks and events.
  */
 async function runFunctionTask<
   // biome-ignore lint/suspicious/noExplicitAny: structural constraint
@@ -187,7 +187,7 @@ async function runFunctionTask<
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
 
-      // Zod validation errors (input/output) are never retried
+      // Zod validation errors (input/output) are never retried — data is wrong
       const isValidationError =
         e.message.includes("input validation failed") ||
         e.message.includes("output validation failed");
@@ -195,14 +195,17 @@ async function runFunctionTask<
         throw e;
       }
 
-      // Record this attempt
-      attemptRecords.push({
-        attempt,
-        error: e.message,
-        // fn tasks have no runner-specific error kind — use a stable sentinel
-        // biome-ignore lint/suspicious/noExplicitAny: fn tasks use non-standard error kind
-        errorCode: "subprocess_error" as any,
-      });
+      // Classify the error and check retry.on — same semantics as agent tasks
+      const errorCode = classifyFnError(e);
+      if (!retry.on.includes(errorCode)) {
+        // Error kind not in retry list — throw immediately without consuming attempts
+        // Wrap as NodeMaxRetriesError so onTaskError gets attempt count = 1
+        attemptRecords.push({ attempt, error: e.message, errorCode });
+        throw new NodeMaxRetriesError(taskName, attemptRecords);
+      }
+
+      // Error is retryable — record this attempt
+      attemptRecords.push({ attempt, error: e.message, errorCode });
 
       if (attempt < maxAttempts - 1) {
         onRetry?.(attempt + 1, e.message);


### PR DESCRIPTION
## Summary

Codex P1 follow-up to #100/#149: \`runFunctionTask\` now classifies thrown errors and consults \`retry.on\` instead of retrying on any error.

## Changes
- \`packages/executor/src/retry-classify.ts\` (new) — \`classifyFnError(err)\` returns \`\"timeout\"\` / \`\"transient\"\`
- \`packages/executor/src/workflow-executor.ts\` — \`runFunctionTask\` now classifies + consults \`retry.on\` before retrying; non-matching kinds wrap immediately
- \`packages/core/src/types.ts\` — \`RetryErrorKind\` extended with \`\"transient\"\` and \`\"validation\"\`; \`FunctionTaskDef.retry\` JSDoc updated to describe parity with agent tasks
- \`packages/core/README.md\` — fn-task differences section updated to remove the retry.on caveat
- 3 new tests + 1 updated in \`function-node.test.ts\`
- \`@ageflow/executor\` patch bump 0.5.0 → 0.5.1

## Semantics

| Thrown error | Kind | Retried? |
|---|---|---|
| ZodError (input/output validation) | \`validation\` | Never |
| TimeoutError | \`timeout\` | If \`\"timeout\" ∈ retry.on\` |
| Any other Error | \`transient\` | If \`\"transient\" ∈ retry.on\` |

\`retry.on === []\` ⇒ no retries regardless of error kind.

## Verification
- typecheck 28/28 / build 12/12 / test 28/28 / lint clean
- Finder dupes: 0

Closes #152.