### PR TITLE
fix(security): #160 — HITL filter must apply to runnerOverrides + empty deny-all stays empty

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",
@@ -200,7 +200,7 @@
     },
     "packages/runners/anthropic": {
       "name": "@ageflow/runner-anthropic",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@ageflow/core": "^0.4.0",
         "@ageflow/runner-api": "^0.3.3",
@@ -213,7 +213,7 @@
     },
     "packages/runners/api": {
       "name": "@ageflow/runner-api",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/runner-overrides.test.ts
+++ b/packages/executor/src/__tests__/runner-overrides.test.ts
@@ -431,6 +431,199 @@ describe("WorkflowExecutor.run() — runnerOverrides end-to-end", () => {
   });
 });
 
+// ─── HITL security: deny-all + runnerOverrides filtering (#160) ──────────────
+
+describe("HITL security — Issue A: deny-all propagates empty allowlist", () => {
+  it("spawnArgs.tools is [] when HITL denies all tools", async () => {
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // filteredTools = [] means HITL denied everything
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined, // sessionHandle
+      undefined, // permissions
+      [], // filteredTools — deny-all
+    );
+
+    const call = spawnCalls[0];
+    // tools must be set to [] — not undefined (which would allow all tools)
+    expect(call?.tools).toBeDefined();
+    expect(call?.tools).toEqual([]);
+  });
+
+  it("spawnArgs.inlineTools is undefined when HITL denies all tools", async () => {
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined, // sessionHandle
+      undefined, // permissions
+      [], // filteredTools — deny-all
+    );
+
+    const call = spawnCalls[0];
+    // No inline tools should be passed either — all denied
+    expect(call?.inlineTools).toBeUndefined();
+  });
+});
+
+describe("HITL security — Issue B: runnerOverrides.tools filtered through HITL", () => {
+  it("denied tool X in runnerOverrides is blocked even if passed as per-call override", async () => {
+    const toolX = makeInlineTool(
+      "tool X (denied)",
+      z.object({}),
+      async () => "x",
+    );
+    const toolZ = makeInlineTool("tool Z (new)", z.object({}), async () => "z");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: ["tool_y"], // agent has tool_y as string allowlist
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // HITL allows tool_y but not tool_x or tool_z
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined, // sessionHandle
+      undefined, // permissions
+      ["tool_y"], // filteredTools — HITL allows only tool_y
+      undefined, // onRetry
+      undefined, // workflowMcpServers
+      undefined, // hooks
+      {
+        "mock-ro": {
+          tools: { tool_x: toolX, tool_z: toolZ },
+        },
+      },
+    );
+
+    const call = spawnCalls[0];
+    // tool_x is denied by HITL — must NOT appear in tools allowlist
+    expect(call?.tools).not.toContain("tool_x");
+    // tool_z is also not in HITL allowlist — must NOT appear
+    expect(call?.tools).not.toContain("tool_z");
+    // tool_y was approved by HITL — must appear
+    expect(call?.tools).toContain("tool_y");
+  });
+
+  it("inlineTools does not contain a denied per-call tool", async () => {
+    const toolX = makeInlineTool(
+      "tool X (denied inline)",
+      z.object({}),
+      async () => "x",
+    );
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // HITL denies tool_x (empty allowlist)
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      undefined,
+      [], // filteredTools — deny-all
+      undefined,
+      undefined,
+      undefined,
+      {
+        "mock-ro": {
+          tools: { tool_x: toolX },
+        },
+      },
+    );
+
+    const call = spawnCalls[0];
+    // tool_x must NOT be in inlineTools — it was blocked by HITL deny-all
+    expect(call?.inlineTools).toBeUndefined();
+    // tools must be empty (deny-all preserved)
+    expect(call?.tools).toEqual([]);
+  });
+});
+
+describe("HITL security — Issue B (inline): agent inline tools filtered through HITL", () => {
+  it("agent inline tools are filtered: denied name X is excluded from inlineTools", async () => {
+    const toolX = makeInlineTool("tool X", z.object({}), async () => "x");
+    const toolY = makeInlineTool("tool Y", z.object({}), async () => "y");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_x: toolX, tool_y: toolY },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // HITL allows tool_y but denies tool_x
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      undefined,
+      ["tool_y"], // filteredTools — only tool_y passes
+    );
+
+    const call = spawnCalls[0];
+    // inlineTools should only contain tool_y
+    expect(call?.inlineTools).toBeDefined();
+    expect(Object.keys(call?.inlineTools ?? {})).toContain("tool_y");
+    expect(Object.keys(call?.inlineTools ?? {})).not.toContain("tool_x");
+    // tools allowlist should only have tool_y
+    expect(call?.tools).toEqual(["tool_y"]);
+  });
+});
+
 // ─── InlineToolsNotSupportedError: subprocess runners ────────────────────────
 
 describe("InlineToolsNotSupportedError — subprocess runner guard", () => {

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -168,52 +168,92 @@ export async function runNode<
 
       const perCallInlineTools = overridesForRunner?.tools;
 
-      // Build the merged inline map that goes into spawnArgs.inlineTools
+      // ── String[] allowlist for tools ────────────────────────────────────────
+      // Step 1: Build the base allowlist from the agent definition (no HITL yet).
+      let baseToolNames: readonly string[] | undefined;
+      if (Array.isArray(resolvedDef.tools)) {
+        baseToolNames = resolvedDef.tools as readonly string[];
+      } else if (resolvedDef.tools !== undefined) {
+        // Inline map — keys are the allowlist
+        baseToolNames = Object.keys(
+          resolvedDef.tools as Record<string, InlineToolDef>,
+        );
+      }
+
+      // Step 2: Merge per-call inline tool names into the candidate set BEFORE
+      // HITL filtering.  Per-call names are only allowed through if HITL permits
+      // them (i.e. their name appears in filteredTools).
+      const perCallNames =
+        perCallInlineTools !== undefined ? Object.keys(perCallInlineTools) : [];
+
+      // Candidate set: agent tools + per-call tools (deduped)
+      let candidateToolNames: readonly string[] | undefined;
+      if (baseToolNames !== undefined || perCallNames.length > 0) {
+        const seen = new Set<string>(baseToolNames ?? []);
+        for (const n of perCallNames) {
+          seen.add(n);
+        }
+        candidateToolNames = [...seen];
+      }
+
+      // Step 3: Apply HITL filter.
+      // - If filteredTools is defined (HITL mode = permissions), it is the
+      //   authoritative set.  Any candidate not in filteredTools is dropped —
+      //   including per-call overrides.  An empty filteredTools means deny-all.
+      // - If filteredTools is undefined (no HITL), all candidates pass.
+      let effectiveToolNames: readonly string[] | undefined;
+      if (filteredTools !== undefined) {
+        // HITL is active: intersect candidates with the HITL-approved set.
+        // candidateToolNames may be undefined when the agent has no tools; in
+        // that case effectiveToolNames takes the HITL value directly (which may
+        // be [] — deny-all).
+        const hitlSet = new Set<string>(filteredTools);
+        if (candidateToolNames !== undefined) {
+          effectiveToolNames = candidateToolNames.filter((n) => hitlSet.has(n));
+        } else {
+          // No agent/per-call tools — HITL provides the allowlist (may be []).
+          effectiveToolNames = filteredTools;
+        }
+      } else {
+        effectiveToolNames = candidateToolNames;
+      }
+
+      // Step 4: Build inlineTools map filtered to effectiveToolNames.
+      // Only include inline defs whose names survived HITL filtering.
       let mergedInlineTools:
         | Readonly<Record<string, InlineToolDef>>
         | undefined;
       if (agentInlineTools !== undefined || perCallInlineTools !== undefined) {
-        mergedInlineTools = {
+        const unfiltered: Record<string, InlineToolDef> = {
           ...(agentInlineTools ?? {}),
           ...(perCallInlineTools ?? {}),
         };
+        if (effectiveToolNames !== undefined) {
+          const allowed = new Set<string>(effectiveToolNames);
+          const filtered: Record<string, InlineToolDef> = {};
+          for (const [name, def] of Object.entries(unfiltered)) {
+            if (allowed.has(name)) {
+              filtered[name] = def;
+            }
+          }
+          mergedInlineTools =
+            Object.keys(filtered).length > 0 ? filtered : undefined;
+        } else {
+          mergedInlineTools = unfiltered;
+        }
       }
 
       if (mergedInlineTools !== undefined) {
         spawnArgs.inlineTools = mergedInlineTools;
       }
 
-      // ── String[] allowlist for tools ────────────────────────────────────────
-      // If filteredTools (HITL) is provided, use it.
-      // Otherwise: if agent tools is string[], use that; if inline map, use its keys.
-      // If per-call inline tools exist, append their names to the allowlist.
-      let effectiveToolNames: readonly string[] | undefined;
-      if (filteredTools !== undefined) {
-        // HITL-filtered — already a string[]
-        effectiveToolNames = filteredTools;
-      } else if (Array.isArray(resolvedDef.tools)) {
-        effectiveToolNames = resolvedDef.tools as readonly string[];
-      } else if (resolvedDef.tools !== undefined) {
-        // Inline map — keys are the allowlist
-        effectiveToolNames = Object.keys(
-          resolvedDef.tools as Record<string, InlineToolDef>,
-        );
-      }
-
-      // Merge per-call inline tool names into allowlist
-      if (
-        perCallInlineTools !== undefined &&
-        Object.keys(perCallInlineTools).length > 0
-      ) {
-        const perCallNames = Object.keys(perCallInlineTools);
-        if (effectiveToolNames !== undefined) {
-          effectiveToolNames = [...effectiveToolNames, ...perCallNames];
-        } else {
-          effectiveToolNames = perCallNames;
-        }
-      }
-
-      if (effectiveToolNames !== undefined && effectiveToolNames.length > 0) {
+      // Step 5: Set tools allowlist.
+      // SECURITY: always set spawnArgs.tools when effectiveToolNames is defined —
+      // even when the list is empty (deny-all).  Skipping the assignment when
+      // length === 0 would leave the runner without a tools constraint, causing
+      // it to default to "all tools available" and silently turning a deny-all
+      // into an allow-all.
+      if (effectiveToolNames !== undefined) {
         spawnArgs.tools = effectiveToolNames;
       }
 

--- a/packages/runners/anthropic/package.json
+++ b/packages/runners/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-anthropic",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Native Anthropic Messages API runner for ageflow (/v1/messages)",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/anthropic",
   "type": "module",

--- a/packages/runners/anthropic/src/__tests__/message-builder.test.ts
+++ b/packages/runners/anthropic/src/__tests__/message-builder.test.ts
@@ -63,11 +63,13 @@ describe("toolsToAnthropicSchemas", () => {
     },
   };
 
-  it("returns undefined when names is empty", () => {
-    expect(toolsToAnthropicSchemas(registry, [])).toBeUndefined();
+  it("returns [] (not undefined) when names is [] — explicit deny-all (#160)", () => {
+    // Empty array = explicit deny-all. Must NOT return undefined (which means
+    // "no restriction"), otherwise runners would fall back to all tools.
+    expect(toolsToAnthropicSchemas(registry, [])).toEqual([]);
   });
 
-  it("returns undefined when names is undefined", () => {
+  it("returns undefined when names is undefined (no restriction)", () => {
     expect(toolsToAnthropicSchemas(registry, undefined)).toBeUndefined();
   });
 
@@ -86,8 +88,11 @@ describe("toolsToAnthropicSchemas", () => {
     expect(schemas?.[0]?.name).toBe("echo");
   });
 
-  it("returns undefined when all names are unknown", () => {
-    expect(toolsToAnthropicSchemas(registry, ["unknown"])).toBeUndefined();
+  it("returns empty array (not undefined) when all names are unknown (#160)", () => {
+    // The caller provided an explicit allowlist — all names happen to be
+    // unknown in the registry.  Must return [] (not undefined) so the
+    // deny-all semantics are preserved.
+    expect(toolsToAnthropicSchemas(registry, ["unknown"])).toEqual([]);
   });
 
   it("tool schema has input_schema with type: object", () => {

--- a/packages/runners/anthropic/src/anthropic-runner.ts
+++ b/packages/runners/anthropic/src/anthropic-runner.ts
@@ -259,13 +259,25 @@ export class AnthropicRunner implements Runner {
 
     try {
       const mcpRegistry = await mcpToolsToRegistry(perSpawnClients);
-      const merged: ToolRegistry = { ...filteredRegistry, ...mcpRegistry };
 
+      // When args.tools is defined it is the explicit allowlist (possibly []).
+      // MCP tools are always additive — UNLESS args.tools is an explicit empty
+      // allowlist (deny-all from HITL), in which case MCP tools are also blocked.
+      const mcpAllowed =
+        args.tools !== undefined && args.tools.length === 0
+          ? {} // deny-all: no MCP tools either
+          : mcpRegistry;
+
+      const merged: ToolRegistry = { ...filteredRegistry, ...mcpAllowed };
+
+      // Build the effective names list passed to toolsToAnthropicSchemas:
+      //  - args.tools defined     → explicit allowlist + permitted MCP tool names
+      //  - args.tools undefined   → no restriction; use all registered tools
       const mergedToolsArg: string[] | undefined =
         args.tools !== undefined
-          ? [...args.tools, ...Object.keys(mcpRegistry)]
-          : Object.keys(mcpRegistry).length > 0
-            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpRegistry)]
+          ? [...args.tools, ...Object.keys(mcpAllowed)]
+          : Object.keys(mcpAllowed).length > 0
+            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpAllowed)]
             : args.tools;
 
       const toolSchemas = toolsToAnthropicSchemas(merged, mergedToolsArg);

--- a/packages/runners/anthropic/src/message-builder.ts
+++ b/packages/runners/anthropic/src/message-builder.ts
@@ -41,12 +41,18 @@ export function buildAnthropicMessages(
 /**
  * Convert the subset of the runner's tool registry named in `names` into
  * Anthropic tool schemas. Unknown names are ignored.
+ *
+ * Semantics:
+ *  - `names === undefined` → no restriction; returns undefined (caller passes no `tools` key)
+ *  - `names === []`        → explicit deny-all; returns [] (zero schemas — no tools available)
+ *  - `names.length > 0`   → allowlist; returns matching schemas
  */
 export function toolsToAnthropicSchemas(
   registry: ToolRegistry,
   names: readonly string[] | undefined,
 ): AnthropicToolSchema[] | undefined {
-  if (!names || names.length === 0) return undefined;
+  if (names === undefined) return undefined;
+  if (names.length === 0) return [];
   const out: AnthropicToolSchema[] = [];
   for (const name of names) {
     const def = registry[name];
@@ -65,5 +71,5 @@ export function toolsToAnthropicSchemas(
       input_schema: inputSchema,
     });
   }
-  return out.length > 0 ? out : undefined;
+  return out;
 }

--- a/packages/runners/api/package.json
+++ b/packages/runners/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/runner-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenAI-compatible HTTP runner for ageflow (OpenAI, Groq, Together, Ollama, vLLM, LM Studio, Azure).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/runners/api",
   "type": "module",

--- a/packages/runners/api/src/__tests__/message-builder.test.ts
+++ b/packages/runners/api/src/__tests__/message-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildInitialMessages } from "../message-builder.js";
+import { buildInitialMessages, toolsToSchemas } from "../message-builder.js";
 import type { ChatMessage } from "../openai-types.js";
+import type { ToolRegistry } from "../types.js";
 
 describe("buildInitialMessages", () => {
   it("user-only prompt with no system and no history", () => {
@@ -62,5 +63,38 @@ describe("buildInitialMessages", () => {
     expect(msgs.filter((m) => m.content === "old schema").length).toBe(0);
     // User prompt is last
     expect(msgs[msgs.length - 1]).toEqual({ role: "user", content: "next" });
+  });
+});
+
+describe("toolsToSchemas — empty-allowlist / deny-all semantics (#160)", () => {
+  const registry: ToolRegistry = {
+    my_tool: {
+      description: "a tool",
+      parameters: { type: "object", properties: {} },
+      execute: async () => "result",
+    },
+  };
+
+  it("returns undefined when names is undefined (no restriction)", () => {
+    expect(toolsToSchemas(registry, undefined)).toBeUndefined();
+  });
+
+  it("returns [] when names is [] (explicit deny-all)", () => {
+    const result = toolsToSchemas(registry, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns matching schemas for a non-empty allowlist", () => {
+    const result = toolsToSchemas(registry, ["my_tool"]);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.function.name).toBe("my_tool");
+  });
+
+  it("returns [] (not undefined) for an allowlist with no registry matches", () => {
+    // All names unknown — but list is defined → deny-all semantics preserved
+    const result = toolsToSchemas(registry, ["unknown_tool"]);
+    // The function skips unknown names but still returns an array (possibly empty)
+    // since the caller explicitly provided a non-empty allowlist
+    expect(Array.isArray(result)).toBe(true);
   });
 });

--- a/packages/runners/api/src/api-runner.ts
+++ b/packages/runners/api/src/api-runner.ts
@@ -212,13 +212,25 @@ export class ApiRunner implements Runner {
 
     try {
       const mcpRegistry = await mcpToolsToRegistry(perSpawnClients);
-      const merged: ToolRegistry = { ...filteredRegistry, ...mcpRegistry };
 
+      // When args.tools is defined it is the explicit allowlist (possibly []).
+      // MCP tools are always additive — UNLESS args.tools is an explicit empty
+      // allowlist (deny-all from HITL), in which case MCP tools are also blocked.
+      const mcpAllowed =
+        args.tools !== undefined && args.tools.length === 0
+          ? {} // deny-all: no MCP tools either
+          : mcpRegistry;
+
+      const merged: ToolRegistry = { ...filteredRegistry, ...mcpAllowed };
+
+      // Build the effective names list passed to toolsToSchemas:
+      //  - args.tools defined     → explicit allowlist + permitted MCP tool names
+      //  - args.tools undefined   → no restriction; use all registered tools
       const mergedToolsArg: string[] | undefined =
         args.tools !== undefined
-          ? [...args.tools, ...Object.keys(mcpRegistry)]
-          : Object.keys(mcpRegistry).length > 0
-            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpRegistry)]
+          ? [...args.tools, ...Object.keys(mcpAllowed)]
+          : Object.keys(mcpAllowed).length > 0
+            ? [...Object.keys(filteredRegistry), ...Object.keys(mcpAllowed)]
             : args.tools;
 
       const toolSchemas = toolsToSchemas(merged, mergedToolsArg);

--- a/packages/runners/api/src/message-builder.ts
+++ b/packages/runners/api/src/message-builder.ts
@@ -35,12 +35,18 @@ export function buildInitialMessages(input: BuildMessagesInput): ChatMessage[] {
  * Convert the subset of the runner's tool registry named in `names` into
  * OpenAI tool schemas. Unknown names are ignored (executor is responsible
  * for validating tool names against the registry before spawn).
+ *
+ * Semantics:
+ *  - `names === undefined` → no restriction; returns undefined (caller passes no `tools` key)
+ *  - `names === []`        → explicit deny-all; returns [] (zero schemas — no tools available)
+ *  - `names.length > 0`   → allowlist; returns matching schemas
  */
 export function toolsToSchemas(
   registry: ToolRegistry,
   names: readonly string[] | undefined,
 ): ToolSchema[] | undefined {
-  if (!names || names.length === 0) return undefined;
+  if (names === undefined) return undefined;
+  if (names.length === 0) return [];
   const out: ToolSchema[] = [];
   for (const name of names) {
     const def = registry[name];
@@ -54,5 +60,5 @@ export function toolsToSchemas(
       },
     });
   }
-  return out.length > 0 ? out : undefined;
+  return out;
 }

--- a/packages/runners/api/src/tool-loop.ts
+++ b/packages/runners/api/src/tool-loop.ts
@@ -45,7 +45,11 @@ export async function runToolLoop(
     const body: ChatCompletionRequest = {
       model: input.model,
       messages,
-      ...(input.tools ? { tools: input.tools } : {}),
+      // Only include `tools` when there are schemas to send.  An empty array
+      // would cause most APIs to return a 400; an absent key means "no tools".
+      // Registry-level enforcement (empty filteredRegistry) prevents tool
+      // execution even when the key is omitted.
+      ...(input.tools && input.tools.length > 0 ? { tools: input.tools } : {}),
     };
 
     const resp = await postChat(input, body);

--- a/packages/runners/api/src/types.ts
+++ b/packages/runners/api/src/types.ts
@@ -8,7 +8,7 @@ export type { Logger };
  * Package version — keep in sync with package.json.
  * Used as the MCP Client `version` in the protocol handshake.
  */
-export const RUNNER_VERSION = "0.4.0" as const;
+export const RUNNER_VERSION = "0.4.1" as const;
 
 export interface ToolDefinition {
   /** Human-readable description surfaced to the model. */


### PR DESCRIPTION
Two HITL bypass paths from #158 fixed: (A) empty effectiveToolNames now stays empty (was skipped → runners defaulted to all tools), (B) per-call runnerOverrides tools now go through HITL filter. Plus runner-side empty-tools handling fixed in api/anthropic. Bumps: executor 0.6.0→0.6.1, runner-api 0.4.0→0.4.1, runner-anthropic 0.5.0→0.5.1. 5 new tests. Closes #160.