### PR TITLE
fix(executor): #164 — skip HITL filter when no enforcement is active

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/hitl-manager.test.ts
+++ b/packages/executor/src/__tests__/hitl-manager.test.ts
@@ -42,41 +42,46 @@ describe("HITLManager", () => {
   describe("applyPermissions", () => {
     const hm = new HITLManager();
 
-    it("mode 'off' → returns tools unchanged, no permissions", () => {
+    it("mode 'off' → returns tools unchanged, no permissions, enforcing false", () => {
       const result = hm.applyPermissions(["bash", "read"], { mode: "off" });
       expect(result.tools).toEqual(["bash", "read"]);
       expect(result.permissions).toBeUndefined();
+      expect(result.enforcing).toBe(false);
     });
 
-    it("mode 'checkpoint' → returns tools unchanged, no permissions", () => {
+    it("mode 'checkpoint' → returns tools unchanged, no permissions, enforcing false", () => {
       const result = hm.applyPermissions(["bash"], { mode: "checkpoint" });
       expect(result.tools).toEqual(["bash"]);
       expect(result.permissions).toBeUndefined();
+      expect(result.enforcing).toBe(false);
     });
 
-    it("mode 'permissions' with all allowed → returns all tools", () => {
+    it("mode 'permissions' with all allowed → returns all tools, enforcing true", () => {
       const result = hm.applyPermissions(["bash", "read", "write"], {
         mode: "permissions",
         permissions: { bash: true, read: true, write: true },
       });
       expect(result.tools).toEqual(["bash", "read", "write"]);
+      expect(result.enforcing).toBe(true);
     });
 
-    it("mode 'permissions' with deny → filters out denied tools", () => {
+    it("mode 'permissions' with deny → filters out denied tools, enforcing true", () => {
       const result = hm.applyPermissions(["bash", "read", "write"], {
         mode: "permissions",
         permissions: { bash: true, read: false, write: true },
       });
       expect(result.tools).toEqual(["bash", "write"]);
       expect(result.tools).not.toContain("read");
+      expect(result.enforcing).toBe(true);
     });
 
-    it("mode 'permissions' with empty tools → returns empty array", () => {
+    it("mode 'permissions' with empty tools → returns empty array, enforcing true", () => {
       const result = hm.applyPermissions(undefined, {
         mode: "permissions",
         permissions: { bash: true },
       });
       expect(result.tools).toEqual([]);
+      expect(result.enforcing).toBe(true);
     });
 
     it("mode 'permissions' → returns permissions map", () => {

--- a/packages/executor/src/__tests__/node-runner.retry-event.test.ts
+++ b/packages/executor/src/__tests__/node-runner.retry-event.test.ts
@@ -28,6 +28,7 @@ describe("runNode onRetry callback", () => {
         undefined,
         undefined,
         undefined,
+        undefined, // hitlEnforcing
         onRetry,
       ),
     ).rejects.toThrow();
@@ -67,6 +68,7 @@ describe("runNode onRetry callback", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // hitlEnforcing
       onRetry,
     );
     expect(onRetry).toHaveBeenCalledTimes(2); // two failures before success

--- a/packages/executor/src/__tests__/node-runner.test.ts
+++ b/packages/executor/src/__tests__/node-runner.test.ts
@@ -436,6 +436,7 @@ describe("runNode", () => {
           undefined,
           undefined,
           undefined,
+          undefined, // hitlEnforcing
           undefined,
           undefined,
           hooks,
@@ -484,6 +485,7 @@ describe("runNode", () => {
           undefined,
           undefined,
           undefined,
+          undefined, // hitlEnforcing
           undefined,
           undefined,
           hooks,
@@ -544,6 +546,7 @@ describe("runNode", () => {
           undefined,
           undefined,
           undefined,
+          undefined, // hitlEnforcing
           undefined,
           undefined,
           hooks,

--- a/packages/executor/src/__tests__/runner-overrides.test.ts
+++ b/packages/executor/src/__tests__/runner-overrides.test.ts
@@ -192,6 +192,7 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       undefined, // sessionHandle
       undefined, // permissions
       undefined, // filteredTools
+      undefined, // hitlEnforcing
       undefined, // onRetry
       undefined, // workflowMcpServers
       undefined, // hooks
@@ -239,6 +240,7 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // hitlEnforcing
       undefined,
       undefined,
       undefined,
@@ -275,6 +277,7 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // hitlEnforcing
       undefined,
       undefined,
       undefined,
@@ -316,6 +319,7 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       "old-handle", // default session handle
       undefined,
       undefined,
+      undefined, // hitlEnforcing
       undefined,
       undefined,
       undefined,
@@ -457,6 +461,7 @@ describe("HITL security — Issue A: deny-all propagates empty allowlist", () =>
       undefined, // sessionHandle
       undefined, // permissions
       [], // filteredTools — deny-all
+      true, // hitlEnforcing
     );
 
     const call = spawnCalls[0];
@@ -487,6 +492,7 @@ describe("HITL security — Issue A: deny-all propagates empty allowlist", () =>
       undefined, // sessionHandle
       undefined, // permissions
       [], // filteredTools — deny-all
+      true, // hitlEnforcing
     );
 
     const call = spawnCalls[0];
@@ -524,6 +530,7 @@ describe("HITL security — Issue B: runnerOverrides.tools filtered through HITL
       undefined, // sessionHandle
       undefined, // permissions
       ["tool_y"], // filteredTools — HITL allows only tool_y
+      true, // hitlEnforcing
       undefined, // onRetry
       undefined, // workflowMcpServers
       undefined, // hooks
@@ -569,6 +576,7 @@ describe("HITL security — Issue B: runnerOverrides.tools filtered through HITL
       undefined,
       undefined,
       [], // filteredTools — deny-all
+      true, // hitlEnforcing
       undefined,
       undefined,
       undefined,
@@ -612,6 +620,7 @@ describe("HITL security — Issue B (inline): agent inline tools filtered throug
       undefined,
       undefined,
       ["tool_y"], // filteredTools — only tool_y passes
+      true, // hitlEnforcing
     );
 
     const call = spawnCalls[0];
@@ -621,6 +630,107 @@ describe("HITL security — Issue B (inline): agent inline tools filtered throug
     expect(Object.keys(call?.inlineTools ?? {})).not.toContain("tool_x");
     // tools allowlist should only have tool_y
     expect(call?.tools).toEqual(["tool_y"]);
+  });
+});
+
+// ─── Issue #164 regression: HITL OFF must not filter per-call tools ──────────
+
+describe("HITL OFF — Issue #164: per-call runnerOverrides tools pass through unchanged", () => {
+  it("HITL OFF + per-call tools → all per-call tools survive (regression case)", async () => {
+    const perCallTool = makeInlineTool(
+      "per-call only",
+      z.object({ q: z.string() }),
+      async ({ q }) => q,
+    );
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // hitlEnforcing is undefined (HITL OFF) — per-call tools must survive
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined, // sessionHandle
+      undefined, // permissions
+      undefined, // filteredTools
+      undefined, // hitlEnforcing — HITL OFF
+      undefined, // onRetry
+      undefined, // workflowMcpServers
+      undefined, // hooks
+      {
+        "mock-ro": {
+          tools: { per_call_tool: perCallTool },
+        },
+      },
+    );
+
+    const call = spawnCalls[0];
+    // per_call_tool must NOT be dropped — HITL is off
+    expect(call?.tools).toContain("per_call_tool");
+    expect(call?.inlineTools).toBeDefined();
+    expect(Object.keys(call?.inlineTools ?? {})).toContain("per_call_tool");
+  });
+
+  it("HITL OFF + agent inline tools + per-call tools → all merged, none filtered", async () => {
+    const agentTool = makeInlineTool(
+      "agent tool",
+      z.object({}),
+      async () => "a",
+    );
+    const perCallTool = makeInlineTool(
+      "per-call tool",
+      z.object({}),
+      async () => "p",
+    );
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { agent_tool: agentTool },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // hitlEnforcing is false (HITL OFF) — both tools must survive
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined, // sessionHandle
+      undefined, // permissions
+      undefined, // filteredTools
+      false, // hitlEnforcing — explicitly false (HITL OFF)
+      undefined, // onRetry
+      undefined, // workflowMcpServers
+      undefined, // hooks
+      {
+        "mock-ro": {
+          tools: { per_call_tool: perCallTool },
+        },
+      },
+    );
+
+    const call = spawnCalls[0];
+    // Both tools must appear — no intersection when HITL is off
+    expect(call?.tools).toContain("agent_tool");
+    expect(call?.tools).toContain("per_call_tool");
+    expect(Object.keys(call?.inlineTools ?? {}).sort()).toEqual([
+      "agent_tool",
+      "per_call_tool",
+    ]);
   });
 });
 

--- a/packages/executor/src/hitl-manager.ts
+++ b/packages/executor/src/hitl-manager.ts
@@ -29,6 +29,8 @@ export class HITLManager {
   ): {
     tools: readonly string[] | undefined;
     permissions: Record<string, boolean> | undefined;
+    /** true only when mode === "permissions" and the filter is actively enforced */
+    enforcing: boolean;
   } {
     // Normalise tools to string[] for HITL filtering
     const toolNames: readonly string[] | undefined =
@@ -39,13 +41,14 @@ export class HITLManager {
           : Object.keys(tools as Record<string, InlineToolDef>);
 
     if (config.mode !== "permissions") {
-      return { tools: toolNames, permissions: undefined };
+      return { tools: toolNames, permissions: undefined, enforcing: false };
     }
     const perms = config.permissions;
     const allowed = (toolNames ?? []).filter((t) => perms[t] === true);
     return {
       tools: allowed,
       permissions: Object.fromEntries(Object.entries(perms)),
+      enforcing: true,
     };
   }
 

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -111,6 +111,7 @@ export async function runNode<
   sessionHandle?: string,
   permissions?: Record<string, boolean>,
   filteredTools?: readonly string[],
+  hitlEnforcing?: boolean,
   onRetry?: (attempt: number, reason: string) => void,
   workflowMcpServers?: readonly McpServerConfig[],
   // biome-ignore lint/suspicious/noExplicitAny: hooks generic T not available here
@@ -197,13 +198,14 @@ export async function runNode<
       }
 
       // Step 3: Apply HITL filter.
-      // - If filteredTools is defined (HITL mode = permissions), it is the
-      //   authoritative set.  Any candidate not in filteredTools is dropped —
+      // - If hitlEnforcing is true (mode === "permissions"), filteredTools is
+      //   the authoritative set.  Any candidate not in filteredTools is dropped —
       //   including per-call overrides.  An empty filteredTools means deny-all.
-      // - If filteredTools is undefined (no HITL), all candidates pass.
+      // - If hitlEnforcing is false/undefined (HITL off or checkpoint-only),
+      //   all candidates pass through unchanged.
       let effectiveToolNames: readonly string[] | undefined;
-      if (filteredTools !== undefined) {
-        // HITL is active: intersect candidates with the HITL-approved set.
+      if (hitlEnforcing === true && filteredTools !== undefined) {
+        // HITL is actively enforcing: intersect candidates with the HITL-approved set.
         // candidateToolNames may be undefined when the agent has no tools; in
         // that case effectiveToolNames takes the HITL value directly (which may
         // be [] — deny-all).

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -564,8 +564,14 @@ export class WorkflowExecutor<T extends TasksMap> {
             );
 
             // Apply permissions if mode is "permissions"
-            const { tools: filteredTools, permissions } =
-              this.hitlManager.applyPermissions(resolvedDef.tools, hitlConfig);
+            const {
+              tools: filteredTools,
+              permissions,
+              enforcing: hitlEnforcing,
+            } = this.hitlManager.applyPermissions(
+              resolvedDef.tools,
+              hitlConfig,
+            );
 
             // Run HITL checkpoint if mode is "checkpoint"
             if (hitlConfig.mode === "checkpoint") {
@@ -596,6 +602,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                 sessionHandle,
                 permissions ?? undefined,
                 filteredTools,
+                hitlEnforcing,
                 undefined,
                 this.workflow.mcpServers,
                 hooks,
@@ -983,8 +990,14 @@ export class WorkflowExecutor<T extends TasksMap> {
             );
 
             // Apply permissions if mode is "permissions"
-            const { tools: filteredTools, permissions } =
-              this.hitlManager.applyPermissions(resolvedDef.tools, hitlConfig);
+            const {
+              tools: filteredTools,
+              permissions,
+              enforcing: hitlEnforcing,
+            } = this.hitlManager.applyPermissions(
+              resolvedDef.tools,
+              hitlConfig,
+            );
 
             // Run HITL checkpoint if mode is "checkpoint"
             if (hitlConfig.mode === "checkpoint") {
@@ -1050,6 +1063,7 @@ export class WorkflowExecutor<T extends TasksMap> {
                 sessionHandle,
                 permissions ?? undefined,
                 filteredTools,
+                hitlEnforcing,
                 (attempt, reason) => {
                   push({
                     type: "task:retry",


### PR DESCRIPTION
PR #161 (security fix) introduced a regression: when HITL is disabled, applyPermissions still returned a tools array which incorrectly filtered runnerOverrides. Now applyPermissions returns enforcing: boolean — intersection only runs when true. Bumps executor 0.6.1→0.6.2. 2 new tests + #161 tests still pass. Closes #164.