### PR TITLE
fix(executor): #167 — runNode options object + restore legacy filteredTools enforcement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/node-runner.retry-event.test.ts
+++ b/packages/executor/src/__tests__/node-runner.retry-event.test.ts
@@ -20,17 +20,9 @@ describe("runNode onRetry callback", () => {
     });
     const onRetry = vi.fn();
     await expect(
-      runNode(
-        { agent: a, input: {} },
-        {},
-        alwaysFail,
-        "t",
-        undefined,
-        undefined,
-        undefined,
-        undefined, // hitlEnforcing
+      runNode({ agent: a, input: {} }, {}, alwaysFail, "t", undefined, {
         onRetry,
-      ),
+      }),
     ).rejects.toThrow();
     // With max=1 there is no retry — onRetry must not be called
     expect(onRetry).not.toHaveBeenCalled();
@@ -60,17 +52,9 @@ describe("runNode onRetry callback", () => {
       retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
     });
     const onRetry = vi.fn();
-    await runNode(
-      { agent: a, input: {} },
-      {},
-      flaky,
-      "t",
-      undefined,
-      undefined,
-      undefined,
-      undefined, // hitlEnforcing
+    await runNode({ agent: a, input: {} }, {}, flaky, "t", undefined, {
       onRetry,
-    );
+    });
     expect(onRetry).toHaveBeenCalledTimes(2); // two failures before success
     expect(onRetry.mock.calls[0]?.[0]).toBe(1); // attempt about to start (1, then 2)
     expect(String(onRetry.mock.calls[0]?.[1])).toMatch(/subprocess/);

--- a/packages/executor/src/__tests__/node-runner.test.ts
+++ b/packages/executor/src/__tests__/node-runner.test.ts
@@ -428,19 +428,9 @@ describe("runNode", () => {
 
       const task = { agent: simpleAgent };
       await Promise.all([
-        runNode(
-          task,
-          { text: "hello" },
-          runner,
-          "prefix-task",
-          undefined,
-          undefined,
-          undefined,
-          undefined, // hitlEnforcing
-          undefined,
-          undefined,
+        runNode(task, { text: "hello" }, runner, "prefix-task", undefined, {
           hooks,
-        ),
+        }),
         vi.runAllTimersAsync(),
       ]);
 
@@ -477,19 +467,9 @@ describe("runNode", () => {
 
       const task = { agent: simpleAgent };
       await Promise.all([
-        runNode(
-          task,
-          { text: "hello" },
-          runner,
-          "no-prefix-task",
-          undefined,
-          undefined,
-          undefined,
-          undefined, // hitlEnforcing
-          undefined,
-          undefined,
+        runNode(task, { text: "hello" }, runner, "no-prefix-task", undefined, {
           hooks,
-        ),
+        }),
         vi.runAllTimersAsync(),
       ]);
 
@@ -538,19 +518,9 @@ describe("runNode", () => {
 
       const task = { agent: simpleAgent };
       await Promise.all([
-        runNode(
-          task,
-          { text: "hello" },
-          runner,
-          "my-named-task",
-          undefined,
-          undefined,
-          undefined,
-          undefined, // hitlEnforcing
-          undefined,
-          undefined,
+        runNode(task, { text: "hello" }, runner, "my-named-task", undefined, {
           hooks,
-        ),
+        }),
         vi.runAllTimersAsync(),
       ]);
 

--- a/packages/executor/src/__tests__/runner-overrides.test.ts
+++ b/packages/executor/src/__tests__/runner-overrides.test.ts
@@ -190,15 +190,11 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      undefined, // filteredTools
-      undefined, // hitlEnforcing
-      undefined, // onRetry
-      undefined, // workflowMcpServers
-      undefined, // hooks
       {
-        "mock-ro": {
-          tools: { per_call_tool: perCallTool },
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { per_call_tool: perCallTool },
+          },
         },
       },
     );
@@ -238,15 +234,11 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       runner,
       "test-task",
       undefined,
-      undefined,
-      undefined,
-      undefined, // hitlEnforcing
-      undefined,
-      undefined,
-      undefined,
       {
-        "mock-ro": {
-          tools: { shared_tool: perCallTool },
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { shared_tool: perCallTool },
+          },
         },
       },
     );
@@ -275,21 +267,17 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       runner,
       "test-task",
       undefined,
-      undefined,
-      undefined,
-      undefined, // hitlEnforcing
-      undefined,
-      undefined,
-      undefined,
       {
-        // override for a different brand — should not affect "mock-ro"
-        "other-brand": {
-          tools: {
-            unrelated_tool: makeInlineTool(
-              "unrelated",
-              z.object({}),
-              async () => "x",
-            ),
+        runnerOverrides: {
+          // override for a different brand — should not affect "mock-ro"
+          "other-brand": {
+            tools: {
+              unrelated_tool: makeInlineTool(
+                "unrelated",
+                z.object({}),
+                async () => "x",
+              ),
+            },
           },
         },
       },
@@ -317,15 +305,11 @@ describe("runNode — runnerOverrides (per-call tools)", () => {
       runner,
       "test-task",
       "old-handle", // default session handle
-      undefined,
-      undefined,
-      undefined, // hitlEnforcing
-      undefined,
-      undefined,
-      undefined,
       {
-        "mock-ro": {
-          sessionHandle: "override-handle",
+        runnerOverrides: {
+          "mock-ro": {
+            sessionHandle: "override-handle",
+          },
         },
       },
     );
@@ -459,9 +443,10 @@ describe("HITL security — Issue A: deny-all propagates empty allowlist", () =>
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      [], // filteredTools — deny-all
-      true, // hitlEnforcing
+      {
+        filteredTools: [], // deny-all
+        hitlEnforcing: true,
+      },
     );
 
     const call = spawnCalls[0];
@@ -490,9 +475,10 @@ describe("HITL security — Issue A: deny-all propagates empty allowlist", () =>
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      [], // filteredTools — deny-all
-      true, // hitlEnforcing
+      {
+        filteredTools: [], // deny-all
+        hitlEnforcing: true,
+      },
     );
 
     const call = spawnCalls[0];
@@ -528,15 +514,13 @@ describe("HITL security — Issue B: runnerOverrides.tools filtered through HITL
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      ["tool_y"], // filteredTools — HITL allows only tool_y
-      true, // hitlEnforcing
-      undefined, // onRetry
-      undefined, // workflowMcpServers
-      undefined, // hooks
       {
-        "mock-ro": {
-          tools: { tool_x: toolX, tool_z: toolZ },
+        filteredTools: ["tool_y"], // HITL allows only tool_y
+        hitlEnforcing: true,
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { tool_x: toolX, tool_z: toolZ },
+          },
         },
       },
     );
@@ -574,15 +558,13 @@ describe("HITL security — Issue B: runnerOverrides.tools filtered through HITL
       runner,
       "test-task",
       undefined,
-      undefined,
-      [], // filteredTools — deny-all
-      true, // hitlEnforcing
-      undefined,
-      undefined,
-      undefined,
       {
-        "mock-ro": {
-          tools: { tool_x: toolX },
+        filteredTools: [], // deny-all
+        hitlEnforcing: true,
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { tool_x: toolX },
+          },
         },
       },
     );
@@ -618,9 +600,10 @@ describe("HITL security — Issue B (inline): agent inline tools filtered throug
       runner,
       "test-task",
       undefined,
-      undefined,
-      ["tool_y"], // filteredTools — only tool_y passes
-      true, // hitlEnforcing
+      {
+        filteredTools: ["tool_y"], // only tool_y passes
+        hitlEnforcing: true,
+      },
     );
 
     const call = spawnCalls[0];
@@ -653,22 +636,20 @@ describe("HITL OFF — Issue #164: per-call runnerOverrides tools pass through u
 
     const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
 
-    // hitlEnforcing is undefined (HITL OFF) — per-call tools must survive
+    // hitlEnforcing is undefined, filteredTools is undefined → HITL OFF
+    // per-call tools must survive
     await runNode(
       { agent, input: { v: "hi" } },
       { v: "hi" },
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      undefined, // filteredTools
-      undefined, // hitlEnforcing — HITL OFF
-      undefined, // onRetry
-      undefined, // workflowMcpServers
-      undefined, // hooks
       {
-        "mock-ro": {
-          tools: { per_call_tool: perCallTool },
+        // No filteredTools, no hitlEnforcing — defensive default = no filter
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { per_call_tool: perCallTool },
+          },
         },
       },
     );
@@ -703,22 +684,19 @@ describe("HITL OFF — Issue #164: per-call runnerOverrides tools pass through u
 
     const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
 
-    // hitlEnforcing is false (HITL OFF) — both tools must survive
+    // hitlEnforcing is explicitly false (HITL OFF) — both tools must survive
     await runNode(
       { agent, input: { v: "hi" } },
       { v: "hi" },
       runner,
       "test-task",
       undefined, // sessionHandle
-      undefined, // permissions
-      undefined, // filteredTools
-      false, // hitlEnforcing — explicitly false (HITL OFF)
-      undefined, // onRetry
-      undefined, // workflowMcpServers
-      undefined, // hooks
       {
-        "mock-ro": {
-          tools: { per_call_tool: perCallTool },
+        hitlEnforcing: false, // explicitly false (HITL OFF)
+        runnerOverrides: {
+          "mock-ro": {
+            tools: { per_call_tool: perCallTool },
+          },
         },
       },
     );
@@ -786,5 +764,143 @@ describe("InlineToolsNotSupportedError — subprocess runner guard", () => {
     expect(err.runnerName).toBe("codex");
     expect(err.message).toContain("codex");
     expect(err.message).toContain("inline tool");
+  });
+});
+
+// ─── Issue #167 regressions: options-object signature + defensive default ─────
+
+describe("Issue #167 — options-object signature + defensive hitlEnforcing default", () => {
+  it("legacy shape: filteredTools without hitlEnforcing → filter applied (regression guard)", async () => {
+    // Regression test: before the fix, passing filteredTools without explicit
+    // hitlEnforcing=true would skip the filter entirely (HITL bypass).
+    // Defensive default: filteredTools present + hitlEnforcing undefined → enforce.
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+    const toolB = makeInlineTool("tool B", z.object({}), async () => "b");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA, tool_b: toolB },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // Legacy call: filteredTools provided, hitlEnforcing NOT provided
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      {
+        filteredTools: ["tool_a"], // only tool_a allowed — tool_b must be blocked
+        // hitlEnforcing deliberately omitted → defensive default = true
+      },
+    );
+
+    const call = spawnCalls[0];
+    // Defensive default: filter MUST apply even without explicit hitlEnforcing
+    expect(call?.tools).toContain("tool_a");
+    expect(call?.tools).not.toContain("tool_b");
+  });
+
+  it("new shape: hitlEnforcing: true + filteredTools → filter applied", async () => {
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+    const toolB = makeInlineTool("tool B", z.object({}), async () => "b");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA, tool_b: toolB },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      {
+        filteredTools: ["tool_a"],
+        hitlEnforcing: true,
+      },
+    );
+
+    const call = spawnCalls[0];
+    expect(call?.tools).toContain("tool_a");
+    expect(call?.tools).not.toContain("tool_b");
+  });
+
+  it("new shape: hitlEnforcing: false + filteredTools → filter SKIPPED", async () => {
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+    const toolB = makeInlineTool("tool B", z.object({}), async () => "b");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA, tool_b: toolB },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    // Explicit false: caller explicitly opts out of HITL filtering
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      {
+        filteredTools: ["tool_a"], // would block tool_b, but hitlEnforcing=false skips it
+        hitlEnforcing: false,
+      },
+    );
+
+    const call = spawnCalls[0];
+    // Filter skipped — both tools must appear
+    expect(call?.tools).toContain("tool_a");
+    expect(call?.tools).toContain("tool_b");
+  });
+
+  it("no filteredTools at all → no filter regardless of hitlEnforcing", async () => {
+    const toolA = makeInlineTool("tool A", z.object({}), async () => "a");
+
+    const agent = defineAgent({
+      runner: "mock-ro",
+      input: z.object({ v: z.string() }),
+      output: z.object({ r: z.string() }),
+      prompt: ({ v }) => `do: ${v}`,
+      tools: { tool_a: toolA },
+      retry: { max: 1, on: [], backoff: "fixed" },
+    });
+
+    const { runner, spawnCalls } = makeCapturingRunner({ r: "ok" });
+
+    await runNode(
+      { agent, input: { v: "hi" } },
+      { v: "hi" },
+      runner,
+      "test-task",
+      undefined,
+      {
+        // No filteredTools → no filter, tools come from agent definition
+        hitlEnforcing: true,
+      },
+    );
+
+    const call = spawnCalls[0];
+    // Agent tools pass through unchanged (no HITL set to filter against)
+    expect(call?.tools).toContain("tool_a");
   });
 });

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -32,6 +32,45 @@ export interface NodeRunResult<O> {
   promptSent: string;
 }
 
+/**
+ * Optional arguments to runNode — grouped into a single object to prevent
+ * positional-argument mis-alignment when new options are added.
+ *
+ * Defensive default for hitlEnforcing:
+ *   - When filteredTools is provided and hitlEnforcing is undefined → behaves
+ *     as hitlEnforcing: true (preserves 0.6.1 strict enforcement; protects
+ *     legacy callers from HITL bypass regression).
+ *   - Only when hitlEnforcing is explicitly false does the filter skip.
+ *   - When filteredTools is undefined → no filter regardless of hitlEnforcing.
+ */
+export interface RunNodeOpts {
+  /** Workflow / task hooks (getSystemPromptPrefix, etc.). */
+  // biome-ignore lint/suspicious/noExplicitAny: hooks generic T not available here
+  hooks?: WorkflowHooks<any>;
+  /** Boolean permission map forwarded to the runner. */
+  permissions?: Record<string, boolean>;
+  /**
+   * HITL-approved tool allowlist. When provided without an explicit
+   * hitlEnforcing value the filter is applied (defensive default = enforcing).
+   */
+  filteredTools?: readonly string[];
+  /**
+   * Whether HITL is actively enforcing the tool allowlist.
+   *
+   * - true  → intersection of candidates with filteredTools is applied.
+   * - false → filter skipped; all candidate tools pass through unchanged.
+   * - undefined (default) → behaves as true when filteredTools is provided,
+   *   false otherwise.
+   */
+  hitlEnforcing?: boolean;
+  /** Callback invoked before each retry attempt. */
+  onRetry?: (attempt: number, reason: string) => void;
+  /** Workflow-level MCP server configs. */
+  workflowMcpServers?: readonly McpServerConfig[];
+  /** Per-runner overrides (session handle, inline tools). */
+  runnerOverrides?: RunnerOverrides;
+}
+
 // ─── Input sanitization ───────────────────────────────────────────────────────
 
 // Patterns cover first-line injection ((?:^|\n)), leading whitespace (\s*),
@@ -109,14 +148,7 @@ export async function runNode<
   runner: Runner,
   taskName: string,
   sessionHandle?: string,
-  permissions?: Record<string, boolean>,
-  filteredTools?: readonly string[],
-  hitlEnforcing?: boolean,
-  onRetry?: (attempt: number, reason: string) => void,
-  workflowMcpServers?: readonly McpServerConfig[],
-  // biome-ignore lint/suspicious/noExplicitAny: hooks generic T not available here
-  hooks?: WorkflowHooks<any>,
-  runnerOverrides?: RunnerOverrides,
+  opts?: RunNodeOpts,
 ): Promise<
   NodeRunResult<
     import("zod").infer<
@@ -124,6 +156,23 @@ export async function runNode<
     >
   >
 > {
+  // Destructure opts with defaults
+  const {
+    hooks,
+    permissions,
+    filteredTools,
+    hitlEnforcing,
+    onRetry,
+    workflowMcpServers,
+    runnerOverrides,
+  } = opts ?? {};
+
+  // Defensive default: when filteredTools is provided and hitlEnforcing is
+  // not explicitly set, treat as enforcing (preserves 0.6.1 strict behavior
+  // and protects legacy callers from HITL bypass regression).
+  const effectiveHitlEnforcing =
+    hitlEnforcing !== undefined ? hitlEnforcing : filteredTools !== undefined;
+
   const resolvedDef = resolveAgentDef(task.agent);
   const maxAttempts = resolvedDef.retry.max;
   const attempts: AttemptRecord[] = [];
@@ -198,13 +247,13 @@ export async function runNode<
       }
 
       // Step 3: Apply HITL filter.
-      // - If hitlEnforcing is true (mode === "permissions"), filteredTools is
+      // - If effectiveHitlEnforcing is true (mode === "permissions"), filteredTools is
       //   the authoritative set.  Any candidate not in filteredTools is dropped —
       //   including per-call overrides.  An empty filteredTools means deny-all.
-      // - If hitlEnforcing is false/undefined (HITL off or checkpoint-only),
+      // - If effectiveHitlEnforcing is false (HITL off or checkpoint-only),
       //   all candidates pass through unchanged.
       let effectiveToolNames: readonly string[] | undefined;
-      if (hitlEnforcing === true && filteredTools !== undefined) {
+      if (effectiveHitlEnforcing === true && filteredTools !== undefined) {
         // HITL is actively enforcing: intersect candidates with the HITL-approved set.
         // candidateToolNames may be undefined when the agent has no tools; in
         // that case effectiveToolNames takes the HITL value directly (which may
@@ -286,7 +335,7 @@ export async function runNode<
         spawnArgs.sessionHandle = effectiveSessionHandle;
       }
 
-      // Pass permissions if available
+      // Pass permissions if available (from opts.permissions)
       if (permissions !== undefined) {
         spawnArgs.permissions = permissions;
       }

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -594,19 +594,23 @@ export class WorkflowExecutor<T extends TasksMap> {
 
             const taskStart = Date.now();
             try {
+              const nodeOpts: import("./node-runner.js").RunNodeOpts = {
+                ...(hooks !== undefined ? { hooks } : {}),
+                ...(permissions !== undefined ? { permissions } : {}),
+                ...(filteredTools !== undefined ? { filteredTools } : {}),
+                hitlEnforcing,
+                ...(this.workflow.mcpServers !== undefined
+                  ? { workflowMcpServers: this.workflow.mcpServers }
+                  : {}),
+                ...(runnerOverrides !== undefined ? { runnerOverrides } : {}),
+              };
               const result = await runNode(
                 task,
                 resolvedInput,
                 runner,
                 taskName,
                 sessionHandle,
-                permissions ?? undefined,
-                filteredTools,
-                hitlEnforcing,
-                undefined,
-                this.workflow.mcpServers,
-                hooks,
-                runnerOverrides,
+                nodeOpts,
               );
 
               const latencyMs = Date.now() - taskStart;
@@ -1055,16 +1059,12 @@ export class WorkflowExecutor<T extends TasksMap> {
 
             const taskStart = Date.now();
             try {
-              const result = await runNode(
-                task,
-                resolvedInput,
-                runner,
-                taskName,
-                sessionHandle,
-                permissions ?? undefined,
-                filteredTools,
+              const nodeOpts: import("./node-runner.js").RunNodeOpts = {
+                ...(hooks !== undefined ? { hooks } : {}),
+                ...(permissions !== undefined ? { permissions } : {}),
+                ...(filteredTools !== undefined ? { filteredTools } : {}),
                 hitlEnforcing,
-                (attempt, reason) => {
+                onRetry: (attempt, reason) => {
                   push({
                     type: "task:retry",
                     runId,
@@ -1075,9 +1075,18 @@ export class WorkflowExecutor<T extends TasksMap> {
                     reason,
                   });
                 },
-                this.workflow.mcpServers,
-                hooks,
-                runnerOverrides,
+                ...(this.workflow.mcpServers !== undefined
+                  ? { workflowMcpServers: this.workflow.mcpServers }
+                  : {}),
+                ...(runnerOverrides !== undefined ? { runnerOverrides } : {}),
+              };
+              const result = await runNode(
+                task,
+                resolvedInput,
+                runner,
+                taskName,
+                sessionHandle,
+                nodeOpts,
               );
 
               const latencyMs = Date.now() - taskStart;


### PR DESCRIPTION
PR #165 regressions: (1) hitlEnforcing inserted before onRetry shifted positional args, (2) undefined hitlEnforcing in legacy callers caused filteredTools to be ignored. Refactored runNode trailing optionals into options object (immune to ordering); defensive default applies filter when filteredTools provided + hitlEnforcing undefined. 4 new regression tests. Bumps executor 0.6.2→0.6.3. Closes #167.