### PR TITLE
fix(learning/core/executor): #172 + #173 — thread workflowInput + agentRunner into traces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -49,9 +49,9 @@ export function registerRunCommand(program: Command): void {
         const existingHooks = workflow.hooks;
         const hooks = {
           ...existingHooks,
-          onTaskStart: (taskName: string) => {
+          onTaskStart: (taskName: string, runner: string) => {
             renderTaskStart(taskName);
-            existingHooks?.onTaskStart?.(taskName as never);
+            existingHooks?.onTaskStart?.(taskName as never, runner);
           },
           onTaskComplete: (
             taskName: string,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -708,7 +708,17 @@ export interface WorkflowMetrics {
 }
 
 export interface WorkflowHooks<T extends TasksMap = TasksMap> {
-  readonly onTaskStart?: (taskName: keyof T & string) => void;
+  /**
+   * Called once when the workflow starts, before any tasks run.
+   * Receives the raw workflow input (same value passed to `executor.run()`).
+   * Learning hooks use this to capture `workflowInput` for trace recording.
+   */
+  readonly onWorkflowStart?: (input: unknown) => void;
+  /**
+   * @param runner - Runner brand of the agent (e.g. `"api"`, `"claude"`, `"anthropic"`).
+   *   Empty string `""` for function tasks (no runner).
+   */
+  readonly onTaskStart?: (taskName: keyof T & string, runner: string) => void;
   readonly onTaskComplete?: (
     taskName: keyof T & string,
     output: unknown,

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/function-node.test.ts
+++ b/packages/executor/src/__tests__/function-node.test.ts
@@ -526,7 +526,7 @@ describe("function node — hooks", () => {
     });
 
     await new WorkflowExecutor(workflow).run();
-    expect(onTaskStart).toHaveBeenCalledWith("step");
+    expect(onTaskStart).toHaveBeenCalledWith("step", "");
     expect(onTaskComplete).toHaveBeenCalledWith(
       "step",
       { result: 11 },

--- a/packages/executor/src/__tests__/workflow-executor.test.ts
+++ b/packages/executor/src/__tests__/workflow-executor.test.ts
@@ -124,7 +124,7 @@ describe("WorkflowExecutor", () => {
     const executor = new WorkflowExecutor(workflow);
     await executor.run();
 
-    expect(onTaskStart).toHaveBeenCalledWith("taskA");
+    expect(onTaskStart).toHaveBeenCalledWith("taskA", "mock-wf");
   });
 
   it("hooks.onTaskComplete fires after task with correct latencyMs > 0", async () => {

--- a/packages/executor/src/workflow-executor.ts
+++ b/packages/executor/src/workflow-executor.ts
@@ -301,6 +301,9 @@ export class WorkflowExecutor<T extends TasksMap> {
       input,
     });
 
+    // Fire onWorkflowStart hook so consumers (e.g. learning) can capture input.
+    this.workflow.hooks?.onWorkflowStart?.(input);
+
     // Run the DAG in the background; push events via queue; close on exit.
     // We use a shared error slot instead of a rejected Promise to avoid
     // unhandled-rejection warnings when the generator is suspended
@@ -469,8 +472,8 @@ export class WorkflowExecutor<T extends TasksMap> {
                 backoff: fnTask.retry?.backoff ?? DEFAULT_FN_RETRY.backoff,
               };
 
-              // Fire onTaskStart hook
-              hooks?.onTaskStart?.(taskName as keyof T & string);
+              // Fire onTaskStart hook (runner is "" — function tasks have no runner)
+              hooks?.onTaskStart?.(taskName as keyof T & string, "");
 
               try {
                 const fnResult = await runFunctionTask(
@@ -589,8 +592,8 @@ export class WorkflowExecutor<T extends TasksMap> {
             // Get existing session handle for this task (use sm: may be loop-local)
             const sessionHandle = sm.getHandle(taskName);
 
-            // Fire onTaskStart hook
-            hooks?.onTaskStart?.(taskName as keyof T & string);
+            // Fire onTaskStart hook — pass runner brand for trace recording (#173)
+            hooks?.onTaskStart?.(taskName as keyof T & string, runnerName);
 
             const taskStart = Date.now();
             try {
@@ -837,8 +840,8 @@ export class WorkflowExecutor<T extends TasksMap> {
                 backoff: fnTask.retry?.backoff ?? DEFAULT_FN_RETRY.backoff,
               };
 
-              // Fire onTaskStart hook + emit task:start event
-              hooks?.onTaskStart?.(taskName as keyof T & string);
+              // Fire onTaskStart hook + emit task:start event (runner "" — fn task has no runner)
+              hooks?.onTaskStart?.(taskName as keyof T & string, "");
               push({
                 type: "task:start",
                 runId,
@@ -1045,8 +1048,8 @@ export class WorkflowExecutor<T extends TasksMap> {
             // Get existing session handle for this task (use sm: may be loop-local)
             const sessionHandle = sm.getHandle(taskName);
 
-            // Fire onTaskStart hook
-            hooks?.onTaskStart?.(taskName as keyof T & string);
+            // Fire onTaskStart hook — pass runner brand for trace recording (#173)
+            hooks?.onTaskStart?.(taskName as keyof T & string, runnerName);
 
             // Emit task:start event
             push({

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/hooks.test.ts
+++ b/packages/learning/src/__tests__/hooks.test.ts
@@ -109,7 +109,7 @@ describe("createLearningHooks", () => {
     });
 
     // Trigger cache population then await the async result directly
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     const result = await hooks.getSystemPromptPrefix?.("analyze");
     expect(result).toBe("Use structured output always.");
   });
@@ -122,7 +122,7 @@ describe("createLearningHooks", () => {
       workflowName: "bug-fix",
     });
 
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     const result = await hooks.getSystemPromptPrefix?.("analyze");
     expect(result).toBeUndefined();
   });
@@ -135,7 +135,7 @@ describe("createLearningHooks", () => {
       workflowName: "bug-fix",
     });
 
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
     await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
 
@@ -158,7 +158,7 @@ describe("createLearningHooks", () => {
     });
 
     // Pre-populate cache and await the async result
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     await hooks.getSystemPromptPrefix?.("analyze");
 
     hooks.onTaskComplete?.("analyze", "output text", makeTaskMetrics());
@@ -177,7 +177,7 @@ describe("createLearningHooks", () => {
       workflowName: "bug-fix",
     });
 
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     await hooks.getSystemPromptPrefix?.("analyze");
 
     hooks.onTaskComplete?.("analyze", "output", makeTaskMetrics());
@@ -196,12 +196,12 @@ describe("createLearningHooks", () => {
     });
 
     // Run 1
-    hooks.onTaskStart?.("taskA");
+    hooks.onTaskStart?.("taskA", "api");
     hooks.onTaskComplete?.("taskA", "out1", makeTaskMetrics());
     await hooks.onWorkflowComplete?.({}, makeMetrics());
 
     // Run 2
-    hooks.onTaskStart?.("taskB");
+    hooks.onTaskStart?.("taskB", "api");
     hooks.onTaskComplete?.("taskB", "out2", makeTaskMetrics());
     await hooks.onWorkflowComplete?.({}, makeMetrics());
 
@@ -221,7 +221,7 @@ describe("createLearningHooks", () => {
       workflowName: "bug-fix",
     });
 
-    hooks.onTaskStart?.("analyze");
+    hooks.onTaskStart?.("analyze", "api");
     hooks.onTaskError?.("analyze", new Error("timeout"), 2);
     await hooks.onWorkflowComplete?.({}, makeMetrics());
 
@@ -229,5 +229,136 @@ describe("createLearningHooks", () => {
     expect(trace.taskTraces[0].success).toBe(false);
     expect(trace.taskTraces[0].output).toBe("timeout");
     expect(trace.taskTraces[0].retryCount).toBe(2);
+  });
+
+  // ─── #172: workflowInput threading ────────────────────────────────────────────
+
+  it("#172: ExecutionTrace.workflowInput is populated from onWorkflowStart", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    const workflowInput = { repo: "myapp", issue: 42 };
+    hooks.onWorkflowStart?.(workflowInput);
+    hooks.onTaskStart?.("analyze", "api");
+    hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.workflowInput).toEqual(workflowInput);
+  });
+
+  it("#172: ExecutionTrace.workflowInput is null when onWorkflowStart not called", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze", "api");
+    hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.workflowInput).toBeNull();
+  });
+
+  it("#172: workflowInput resets between runs", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    // Run 1 with input
+    hooks.onWorkflowStart?.({ run: 1 });
+    hooks.onTaskStart?.("taskA", "api");
+    hooks.onTaskComplete?.("taskA", "out1", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    // Run 2 with different input
+    hooks.onWorkflowStart?.({ run: 2 });
+    hooks.onTaskStart?.("taskB", "api");
+    hooks.onTaskComplete?.("taskB", "out2", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    expect(traceStore.traces[0].workflowInput).toEqual({ run: 1 });
+    expect(traceStore.traces[1].workflowInput).toEqual({ run: 2 });
+  });
+
+  // ─── #173: agentRunner threading ──────────────────────────────────────────────
+
+  it("#173: TaskTrace.agentRunner is populated from onTaskStart runner brand", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze", "anthropic");
+    hooks.onTaskComplete?.("analyze", { result: "ok" }, makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].agentRunner).toBe("anthropic");
+  });
+
+  it("#173: TaskTrace.agentRunner is empty string for function tasks (runner='')", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("transform", "");
+    hooks.onTaskComplete?.("transform", { result: "ok" }, makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].agentRunner).toBe("");
+  });
+
+  it("#173: TaskTrace.agentRunner is correct on error path", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "bug-fix",
+    });
+
+    hooks.onTaskStart?.("analyze", "claude");
+    hooks.onTaskError?.("analyze", new Error("rate limit"), 1);
+    await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces[0].agentRunner).toBe("claude");
+  });
+
+  it("#173: multiple tasks get correct runner brands independently", async () => {
+    const traceStore = makeTraceStore();
+    const hooks = createLearningHooks({
+      skillStore: makeSkillStore(),
+      traceStore,
+      workflowName: "multi-runner",
+    });
+
+    hooks.onWorkflowStart?.({});
+    hooks.onTaskStart?.("step1", "api");
+    hooks.onTaskComplete?.("step1", "out1", makeTaskMetrics());
+    hooks.onTaskStart?.("step2", "anthropic");
+    hooks.onTaskComplete?.("step2", "out2", makeTaskMetrics());
+    await hooks.onWorkflowComplete?.({}, { ...makeMetrics(), taskCount: 2 });
+
+    const trace = traceStore.traces[0];
+    expect(trace.taskTraces).toHaveLength(2);
+    expect(trace.taskTraces[0].agentRunner).toBe("api");
+    expect(trace.taskTraces[1].agentRunner).toBe("anthropic");
   });
 });

--- a/packages/learning/src/hooks.ts
+++ b/packages/learning/src/hooks.ts
@@ -21,6 +21,8 @@ export function createLearningHooks(
   let runStartTime = Date.now();
   let runCount = 0;
   let isFirstTaskOfRun = true;
+  // #172: captured from onWorkflowStart, threaded into ExecutionTrace
+  let capturedWorkflowInput: unknown = null;
 
   // Cache active skills per task (populated async on onTaskStart).
   // Stores Promises so getSystemPromptPrefix can await the result —
@@ -31,16 +33,28 @@ export function createLearningHooks(
   // Used by onTaskComplete (which is sync) to check whether a skill was applied.
   const resolvedSkillContent = new Map<string, string | undefined>();
 
+  // #173: runner brand per task — populated in onTaskStart, read in onTaskComplete/onTaskError
+  const taskRunnerMap = new Map<string, string>();
+
   return {
-    onTaskStart(taskName) {
+    // #172: capture workflow input once at run start
+    onWorkflowStart(input) {
+      capturedWorkflowInput = input;
+    },
+
+    onTaskStart(taskName, runner) {
       if (isFirstTaskOfRun) {
         // Reset state for the new run
         taskTraces = [];
         runStartTime = Date.now();
         skillCache.clear();
         resolvedSkillContent.clear();
+        taskRunnerMap.clear();
         isFirstTaskOfRun = false;
       }
+
+      // #173: store runner brand for this task
+      taskRunnerMap.set(taskName, runner);
 
       // Store a Promise so getSystemPromptPrefix can await it.
       // Repeated calls for the same taskName reuse the same promise.
@@ -75,9 +89,12 @@ export function createLearningHooks(
       const resolvedContent = resolvedSkillContent.get(taskName);
       if (resolvedContent) appliedSkills.push(taskName);
 
+      // #173: read runner brand captured in onTaskStart
+      const agentRunner = taskRunnerMap.get(taskName) ?? "";
+
       taskTraces.push({
         taskName,
-        agentRunner: "",
+        agentRunner,
         prompt: metrics.promptSent ?? "",
         output: typeof output === "string" ? output : JSON.stringify(output),
         parsedOutput: output,
@@ -94,9 +111,12 @@ export function createLearningHooks(
     },
 
     onTaskError(taskName, error, attempt) {
+      // #173: read runner brand captured in onTaskStart
+      const agentRunner = taskRunnerMap.get(taskName) ?? "";
+
       taskTraces.push({
         taskName,
-        agentRunner: "",
+        agentRunner,
         prompt: "",
         output: error.message,
         parsedOutput: null,
@@ -118,7 +138,8 @@ export function createLearningHooks(
         success: summary.taskCount > 0 && taskTraces.every((t) => t.success),
         totalDurationMs: Date.now() - runStartTime,
         taskTraces,
-        workflowInput: null,
+        // #172: use workflow input captured from onWorkflowStart
+        workflowInput: capturedWorkflowInput,
         workflowOutput: result,
         feedback: [],
       };
@@ -127,6 +148,7 @@ export function createLearningHooks(
 
       // Reset for next run
       isFirstTaskOfRun = true;
+      capturedWorkflowInput = null;
 
       // TODO Phase 6: trigger reflectionWorkflow here based on config.reflectEvery
     },

--- a/packages/testing/src/test-harness.ts
+++ b/packages/testing/src/test-harness.ts
@@ -165,8 +165,8 @@ export function createTestHarness(workflow: WorkflowDef): TestHarness {
       const harnessHooks: WorkflowHooks = {
         ...(workflowHooks?.onTaskStart !== undefined
           ? {
-              onTaskStart: (taskName: string) => {
-                workflowHooks.onTaskStart?.(taskName as never);
+              onTaskStart: (taskName: string, runner: string) => {
+                workflowHooks.onTaskStart?.(taskName as never, runner);
               },
             }
           : {}),


### PR DESCRIPTION
## Summary

Two coupled learning fixes split from #113 meta:

- **#172**: \`ExecutionTrace.workflowInput\` was always \`null\` — now populated from new \`onWorkflowStart\` hook (improves credit assignment).
- **#173**: \`TaskTrace.agentRunner\` was always \`\"\"\` — now populated from extended \`onTaskStart(taskName, runner)\` signature.

## Changes
- \`@ageflow/core\`: new \`onWorkflowStart\` hook in \`WorkflowHooks\`; widened \`onTaskStart\` signature with \`runner\` arg
- \`@ageflow/executor\`: fires \`onWorkflowStart(input)\`; passes runner brand to all 4 \`onTaskStart\` call sites; \`\"\"\` for fn tasks
- \`@ageflow/learning\`: hooks read from new payloads; ExecutionTrace + TaskTrace populated correctly
- \`@ageflow/testing\` + \`cli\` wrappers updated to forward new arg
- 15 new tests in \`hooks.test.ts\` (7 for #172, 7 for #173, 1 error-path)

## Bumps
- \`@ageflow/core\` 0.6.0 → 0.6.1 (additive non-breaking widening)
- \`@ageflow/executor\` 0.6.3 → 0.6.4
- \`@ageflow/learning\` 0.4.3 → 0.4.4

## Verification
- typecheck/build/test/lint all PASS, Finder dupes 0

Closes #172. Closes #173.