### PR TITLE
fix(learning): #174 — detect downstream tasks via DAG closure, not array order

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/dag-utils.test.ts
+++ b/packages/learning/src/__tests__/dag-utils.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { computeDownstream } from "../dag-utils.js";
+
+// ─── computeDownstream — DAG-based downstream detection ────────────────────────
+//
+// Tests cover the 4 cases specified in issue #174:
+//   1. Parallel branches: a→c, b→d   → downstream(a)={c}, downstream(b)={d}
+//   2. Linear chain:      a→b→c      → downstream(a)={b,c}
+//   3. Diamond:           a→{b,c}→d  → downstream(a)={b,c,d}
+//   4. Terminal task:     no dependents → empty set
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("computeDownstream — parallel branches", () => {
+  // DAG: a → c, b → d  (c and d are independent; no cross-branch relationship)
+  const dag: Record<string, readonly string[]> = {
+    a: [],
+    b: [],
+    c: ["a"],
+    d: ["b"],
+  };
+
+  it("downstream of a is {c} — NOT {c, d}", () => {
+    const result = computeDownstream(dag, "a");
+    expect(result.has("c")).toBe(true);
+    expect(result.has("d")).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it("downstream of b is {d} — NOT {c, d}", () => {
+    const result = computeDownstream(dag, "b");
+    expect(result.has("d")).toBe(true);
+    expect(result.has("c")).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it("downstream of c is empty (terminal)", () => {
+    const result = computeDownstream(dag, "c");
+    expect(result.size).toBe(0);
+  });
+
+  it("downstream of d is empty (terminal)", () => {
+    const result = computeDownstream(dag, "d");
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("computeDownstream — linear chain", () => {
+  // DAG: a → b → c
+  const dag: Record<string, readonly string[]> = {
+    a: [],
+    b: ["a"],
+    c: ["b"],
+  };
+
+  it("downstream of a is {b, c}", () => {
+    const result = computeDownstream(dag, "a");
+    expect(result.has("b")).toBe(true);
+    expect(result.has("c")).toBe(true);
+    expect(result.size).toBe(2);
+  });
+
+  it("downstream of b is {c} only", () => {
+    const result = computeDownstream(dag, "b");
+    expect(result.has("c")).toBe(true);
+    expect(result.has("a")).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it("downstream of c (terminal) is empty", () => {
+    const result = computeDownstream(dag, "c");
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("computeDownstream — diamond", () => {
+  // DAG: a → b, a → c, b → d, c → d
+  const dag: Record<string, readonly string[]> = {
+    a: [],
+    b: ["a"],
+    c: ["a"],
+    d: ["b", "c"],
+  };
+
+  it("downstream of a is {b, c, d}", () => {
+    const result = computeDownstream(dag, "a");
+    expect(result.has("b")).toBe(true);
+    expect(result.has("c")).toBe(true);
+    expect(result.has("d")).toBe(true);
+    expect(result.size).toBe(3);
+  });
+
+  it("downstream of b is {d}", () => {
+    const result = computeDownstream(dag, "b");
+    expect(result.has("d")).toBe(true);
+    expect(result.has("c")).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it("downstream of c is {d}", () => {
+    const result = computeDownstream(dag, "c");
+    expect(result.has("d")).toBe(true);
+    expect(result.has("b")).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it("downstream of d (terminal) is empty", () => {
+    const result = computeDownstream(dag, "d");
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("computeDownstream — terminal task (no downstream)", () => {
+  it("single-task workflow returns empty set", () => {
+    const dag: Record<string, readonly string[]> = { only: [] };
+    const result = computeDownstream(dag, "only");
+    expect(result.size).toBe(0);
+  });
+
+  it("task not present in dag returns empty set", () => {
+    const dag: Record<string, readonly string[]> = { a: [], b: ["a"] };
+    const result = computeDownstream(dag, "unknown");
+    expect(result.size).toBe(0);
+  });
+});

--- a/packages/learning/src/dag-utils.ts
+++ b/packages/learning/src/dag-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * DAG utility: compute the transitive set of downstream tasks for a given task.
+ *
+ * "Downstream" means: any task T' where T' has taskName in its transitive
+ * dependsOn closure (i.e. T is an ancestor of T' in the dependency graph).
+ *
+ * @param dagStructure  Map of taskName → direct dependsOn list.
+ *                      Matches the `dagStructure` field in ReflectionInput.
+ * @param taskName      The task whose descendants we want.
+ * @returns             A Set of task names that transitively depend on taskName.
+ *                      Never includes taskName itself.
+ */
+export function computeDownstream(
+  dagStructure: Record<string, readonly string[]>,
+  taskName: string,
+): ReadonlySet<string> {
+  const downstream = new Set<string>();
+
+  // BFS/DFS from taskName following the reverse of dependsOn edges.
+  // Build a "dependents" map: for each task A, which tasks directly depend on A?
+  const dependents = new Map<string, string[]>();
+  for (const [name, deps] of Object.entries(dagStructure)) {
+    for (const dep of deps) {
+      if (!dependents.has(dep)) {
+        dependents.set(dep, []);
+      }
+      dependents.get(dep)?.push(name);
+    }
+  }
+
+  // BFS from taskName over dependents edges
+  const queue: string[] = [...(dependents.get(taskName) ?? [])];
+  for (const t of queue) {
+    downstream.add(t);
+  }
+
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i] as string;
+    for (const next of dependents.get(current) ?? []) {
+      if (!downstream.has(next)) {
+        downstream.add(next);
+        queue.push(next);
+      }
+    }
+  }
+
+  return downstream;
+}

--- a/packages/learning/src/index.ts
+++ b/packages/learning/src/index.ts
@@ -26,6 +26,9 @@ export type { SkillStore, TraceStore } from "./interfaces.js";
 // Scoring
 export { shouldRollback, updateScore } from "./scoring.js";
 
+// DAG utilities
+export { computeDownstream } from "./dag-utils.js";
+
 // Hooks
 export { createLearningHooks } from "./hooks.js";
 export type { CreateLearningHooksOptions } from "./hooks.js";

--- a/packages/learning/src/workflows/evaluation.ts
+++ b/packages/learning/src/workflows/evaluation.ts
@@ -2,6 +2,7 @@ import { defineAgent, defineWorkflow } from "@ageflow/core";
 import type { BoundCtx } from "@ageflow/core";
 import { WorkflowExecutor } from "@ageflow/executor";
 import { z } from "zod";
+import { computeDownstream } from "../dag-utils.js";
 import type { SkillStore, TraceStore } from "../interfaces.js";
 import type { ExecutionTrace, SkillRecord, TraceFilter } from "../types.js";
 import { DEFAULT_THRESHOLDS } from "../types.js";
@@ -165,6 +166,15 @@ export interface EvaluationResult {
 export interface EvaluationInput {
   skillStore: SkillStore;
   traceStore: TraceStore;
+  /**
+   * DAG structure for the workflow being evaluated.
+   * Maps taskName → direct dependsOn list.
+   *
+   * When provided, downstream task detection uses proper transitive-closure
+   * over the dependency graph (fix for #174).  When omitted, downstream
+   * defaults to an empty set (safe: no incorrect cross-branch pollution).
+   */
+  dagStructure?: Record<string, readonly string[]>;
   /** Only evaluate skills with these statuses. Default: ["active", "retired"] */
   statuses?: Array<"active" | "retired">;
   /** Number of recent traces to sample per skill. Default: 10 */
@@ -238,9 +248,14 @@ export async function runEvaluation(
       );
       if (!taskTrace) continue;
 
-      // Build downstream results: task traces that depended on this task
-      const taskIndex = trace.taskTraces.indexOf(taskTrace);
-      const downstreamTraces = trace.taskTraces.slice(taskIndex + 1);
+      // Build downstream results: task traces that transitively depend on this
+      // task, computed via DAG closure rather than array index (#174).
+      const downstreamNames = input.dagStructure
+        ? computeDownstream(input.dagStructure, skill.targetAgent)
+        : new Set<string>();
+      const downstreamTraces = trace.taskTraces.filter((tt) =>
+        downstreamNames.has(tt.taskName),
+      );
 
       const dynamicWorkflow = defineWorkflow({
         name: "__ageflow_evaluation",


### PR DESCRIPTION
Bug fix from #113 split. Old behavior: `downstream(T)` = tasks appearing after T in object key order — wrong for parallel branches. New: BFS over reverse-dependsOn edges via new `computeDownstream` helper. `EvaluationInput` now optionally accepts `dagStructure`; absent = empty downstream (safe default). 13 new tests covering parallel/linear/diamond/terminal. Bumps learning 0.4.4→0.4.5. Closes #174.