### PR TITLE
fix(testing): #178 — forward onWorkflowStart hook in createTestHarness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -265,7 +265,7 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.6.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/testing",
   "type": "module",

--- a/packages/testing/src/__tests__/test-harness.test.ts
+++ b/packages/testing/src/__tests__/test-harness.test.ts
@@ -355,4 +355,31 @@ describe("createTestHarness", () => {
     const result = await harness.run();
     expect(result.outputs.task).toEqual({});
   });
+
+  // ── Workflow hooks ───────────────────────────────────────────────────────
+
+  it("onWorkflowStart hook is forwarded to the executor", async () => {
+    const workflowInput = { context: "test-data" };
+    let receivedInput: unknown = undefined;
+
+    const workflow = defineWorkflow({
+      name: "test-onWorkflowStart",
+      tasks: {
+        analyze: { agent: analyzeAgent, input: { value: "src/" } },
+      },
+      hooks: {
+        onWorkflowStart: (input: unknown) => {
+          receivedInput = input;
+        },
+      },
+    });
+
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("analyze", { issues: ["test issue"] });
+
+    await harness.run(workflowInput);
+
+    // Assert that the hook was called with the workflow input
+    expect(receivedInput).toEqual(workflowInput);
+  });
 });

--- a/packages/testing/src/test-harness.ts
+++ b/packages/testing/src/test-harness.ts
@@ -163,6 +163,13 @@ export function createTestHarness(workflow: WorkflowDef): TestHarness {
       // Build hooks object carefully — exactOptionalPropertyTypes means we cannot
       // assign `undefined` to an optional property; we must omit the key instead.
       const harnessHooks: WorkflowHooks = {
+        ...(workflowHooks?.onWorkflowStart !== undefined
+          ? {
+              onWorkflowStart: (input: unknown) => {
+                workflowHooks.onWorkflowStart?.(input);
+              },
+            }
+          : {}),
         ...(workflowHooks?.onTaskStart !== undefined
           ? {
               onTaskStart: (taskName: string, runner: string) => {


### PR DESCRIPTION
PR #175 added onWorkflowStart hook in core; createTestHarness's hook wrapping subset didn't include it → harness silently dropped the hook. Now forwarded alongside task/error/checkpoint/complete. Bumps testing 0.3.5→0.3.6. Closes #178.