### PR TITLE
fix(cli/learning): #180 — thread dagStructure from learn evaluate + warn on missing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",

--- a/packages/cli/src/__tests__/learn-feedback.test.ts
+++ b/packages/cli/src/__tests__/learn-feedback.test.ts
@@ -151,6 +151,78 @@ describe("registerFeedbackCommand", () => {
   });
 });
 
+// ─── learn evaluate — dagStructure building ───────────────────────────────────
+
+describe("learn evaluate — dagStructure from workflow.tasks", () => {
+  it("builds dagStructure correctly from a workflow with parallel branches", () => {
+    // Simulates what the evaluate action does when --workflow is passed.
+    // Workflow: parse → [analyze, lint] → report (parallel middle tasks)
+    const workflowTasks: Record<string, { dependsOn?: readonly string[] }> = {
+      parse: {},
+      analyze: { dependsOn: ["parse"] },
+      lint: { dependsOn: ["parse"] },
+      report: { dependsOn: ["analyze", "lint"] },
+    };
+
+    const dagStructure: Record<string, readonly string[]> = {};
+    for (const [taskName, task] of Object.entries(workflowTasks)) {
+      dagStructure[taskName] = task.dependsOn ?? [];
+    }
+
+    expect(dagStructure).toEqual({
+      parse: [],
+      analyze: ["parse"],
+      lint: ["parse"],
+      report: ["analyze", "lint"],
+    });
+  });
+
+  it("assigns empty array for tasks with no dependsOn", () => {
+    const workflowTasks: Record<string, { dependsOn?: readonly string[] }> = {
+      root: {},
+      leaf: { dependsOn: ["root"] },
+    };
+
+    const dagStructure: Record<string, readonly string[]> = {};
+    for (const [taskName, task] of Object.entries(workflowTasks)) {
+      dagStructure[taskName] = task.dependsOn ?? [];
+    }
+
+    expect(dagStructure.root).toEqual([]);
+    expect(dagStructure.leaf).toEqual(["root"]);
+  });
+
+  it("learn evaluate subcommand has --workflow option", () => {
+    const program = makeProgram();
+    registerLearnCommand(program);
+    const learn = program.commands.find((c) => c.name() === "learn");
+    const evaluateCmd = learn?.commands.find((c) => c.name() === "evaluate");
+    expect(evaluateCmd).toBeDefined();
+    const workflowOption = evaluateCmd?.options.find(
+      (o) => o.long === "--workflow",
+    );
+    expect(workflowOption).toBeDefined();
+  });
+
+  it("handles workflow with three linear tasks correctly", () => {
+    const workflowTasks: Record<string, { dependsOn?: readonly string[] }> = {
+      fetch: {},
+      transform: { dependsOn: ["fetch"] },
+      store: { dependsOn: ["transform"] },
+    };
+
+    const dagStructure: Record<string, readonly string[]> = {};
+    for (const [taskName, task] of Object.entries(workflowTasks)) {
+      dagStructure[taskName] = task.dependsOn ?? [];
+    }
+
+    expect(Object.keys(dagStructure)).toHaveLength(3);
+    expect(dagStructure.fetch).toEqual([]);
+    expect(dagStructure.transform).toEqual(["fetch"]);
+    expect(dagStructure.store).toEqual(["transform"]);
+  });
+});
+
 // ─── bin.ts integration — both commands appear together ──────────────────────
 
 describe("bin.ts command registration", () => {

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -72,17 +72,50 @@ export function registerLearnCommand(program: Command): void {
   learn
     .command("evaluate")
     .description("Run hypothetical evaluation of draft skills")
-    .action(async () => {
+    .option(
+      "-w, --workflow <file>",
+      "Workflow file to derive DAG structure for downstream task detection",
+    )
+    .action(async (opts: { workflow?: string }) => {
       try {
         const [store, { runEvaluation }] = await Promise.all([
           loadStore(),
           import("@ageflow/learning"),
         ]);
 
+        // Build dagStructure from workflow file when provided so that
+        // runEvaluation can perform accurate transitive downstream detection.
+        let dagStructure: Record<string, readonly string[]> | undefined;
+        if (opts.workflow) {
+          const resolvedWorkflowPath = path.resolve(opts.workflow);
+          let mod: Record<string, unknown>;
+          try {
+            mod = (await import(resolvedWorkflowPath)) as Record<
+              string,
+              unknown
+            >;
+          } catch (importErr) {
+            process.stderr.write(
+              `Error: Cannot import workflow file "${opts.workflow}": ${importErr instanceof Error ? importErr.message : String(importErr)}\n`,
+            );
+            process.exit(1);
+          }
+          const workflow = (mod.default ?? mod.workflow) as
+            | { tasks: Record<string, { dependsOn?: readonly string[] }> }
+            | undefined;
+          if (workflow?.tasks) {
+            dagStructure = {};
+            for (const [taskName, task] of Object.entries(workflow.tasks)) {
+              dagStructure[taskName] = task.dependsOn ?? [];
+            }
+          }
+        }
+
         process.stdout.write("Running evaluation workflow...\n");
         const summary = await runEvaluation({
           skillStore: store,
           traceStore: store,
+          ...(dagStructure !== undefined ? { dagStructure } : {}),
         });
 
         process.stdout.write(

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/workflows.test.ts
+++ b/packages/learning/src/__tests__/workflows.test.ts
@@ -1,5 +1,5 @@
 import { createTestHarness } from "@ageflow/testing";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillStore, TraceStore } from "../interfaces.js";
 import type {
   ExecutionTrace,
@@ -902,5 +902,68 @@ describe("runPromotion — rollback logic", () => {
     expect(result.skillsChecked).toBe(2);
     expect(result.rollbacks).toBe(1);
     expect(result.noops).toBe(1);
+  });
+});
+
+// ─── runEvaluation — dagStructure warning (#180) ──────────────────────────────
+
+describe("runEvaluation — dagStructure warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("logs a warning when dagStructure is undefined", async () => {
+    const skillStore = makeSkillStore();
+    const traceStore = makeTraceStore();
+
+    await runEvaluation({ skillStore, traceStore });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("dagStructure not provided to runEvaluation"),
+    );
+  });
+
+  it("warning message mentions downstream task detection degraded", async () => {
+    const skillStore = makeSkillStore();
+    const traceStore = makeTraceStore();
+
+    await runEvaluation({ skillStore, traceStore });
+
+    const [message] = warnSpy.mock.calls[0] as [string];
+    expect(message).toContain("downstream task detection degraded");
+    expect(message).toContain("credit assignment will be incomplete");
+  });
+
+  it("does NOT warn when dagStructure is provided", async () => {
+    const skillStore = makeSkillStore();
+    const traceStore = makeTraceStore();
+
+    await runEvaluation({
+      skillStore,
+      traceStore,
+      dagStructure: { taskA: [], taskB: ["taskA"] },
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn when dagStructure is empty object (explicit empty DAG)", async () => {
+    const skillStore = makeSkillStore();
+    const traceStore = makeTraceStore();
+
+    await runEvaluation({
+      skillStore,
+      traceStore,
+      dagStructure: {},
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/learning/src/workflows/evaluation.ts
+++ b/packages/learning/src/workflows/evaluation.ts
@@ -201,6 +201,12 @@ export interface EvaluationSummary {
 export async function runEvaluation(
   input: EvaluationInput,
 ): Promise<EvaluationSummary> {
+  if (input.dagStructure === undefined) {
+    console.warn(
+      "[learning] dagStructure not provided to runEvaluation — downstream task detection degraded; credit assignment will be incomplete. Pass dagStructure for accurate results.",
+    );
+  }
+
   const traceSample = input.traceSample ?? DEFAULT_TRACE_SAMPLE;
   const statuses = input.statuses ?? (["active", "retired"] as const);
 


### PR DESCRIPTION
PR #177 added dagStructure-based downstream detection but the learn-evaluate CLI never threaded it through → silent credit-assignment degradation. Fix: CLI builds dagStructure from workflow.tasks; runEvaluation warns when absent. 8 new tests. Bumps cli 0.5.0→0.5.1, learning 0.4.5→0.4.6. Closes #180.