### PR TITLE
feat(learning): #171 — auto-trigger runReflection per reflectEvery interval

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,11 +108,11 @@
         "agentwf": "./dist/bin.js",
       },
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
-        "@ageflow/executor": "^0.4.3",
-        "@ageflow/learning": "^0.4.1",
+        "@ageflow/core": "^0.6.0",
+        "@ageflow/executor": "^0.6.0",
+        "@ageflow/learning": "^0.4.3",
         "@ageflow/learning-sqlite": "^0.4.1",
-        "@ageflow/mcp-server": "^0.3.3",
+        "@ageflow/mcp-server": "^0.5.0",
         "boxen": "^8.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },
@@ -185,9 +185,9 @@
       "name": "@ageflow/mcp-server",
       "version": "0.5.0",
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
-        "@ageflow/executor": "^0.4.3",
-        "@ageflow/server": "^0.4.2",
+        "@ageflow/core": "^0.6.0",
+        "@ageflow/executor": "^0.6.0",
+        "@ageflow/server": "^0.4.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "zod-to-json-schema": "^3.23.0",
       },
@@ -254,8 +254,8 @@
       "name": "@ageflow/server",
       "version": "0.4.4",
       "dependencies": {
-        "@ageflow/core": "^0.4.3",
-        "@ageflow/executor": "^0.4.3",
+        "@ageflow/core": "^0.6.0",
+        "@ageflow/executor": "^0.6.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -771,6 +771,10 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@ageflow/cli/@ageflow/learning": ["@ageflow/learning@0.4.6", "", { "dependencies": { "@ageflow/core": "^0.6.0" }, "peerDependencies": { "@ageflow/executor": "^0.6.0" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-bcBippO8KLk3rmN6I4SuOtncQu3sEwO5sKzEMcaZWSdiHTzkAttOKEZ5t2YiuPc+TDvnIOW7panNUMqTNnZ8aQ=="],
+
+    "@ageflow/learning-sqlite/@ageflow/learning": ["@ageflow/learning@0.4.6", "", { "dependencies": { "@ageflow/core": "^0.6.0" }, "peerDependencies": { "@ageflow/executor": "^0.6.0" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-bcBippO8KLk3rmN6I4SuOtncQu3sEwO5sKzEMcaZWSdiHTzkAttOKEZ5t2YiuPc+TDvnIOW7panNUMqTNnZ8aQ=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/hooks.test.ts
+++ b/packages/learning/src/__tests__/hooks.test.ts
@@ -8,6 +8,7 @@ import type {
   SkillRecord,
   TraceFilter,
 } from "../types.js";
+import * as reflectionModule from "../workflows/reflection.js";
 
 // ─── In-memory mock stores ────────────────────────────────────────────────────
 
@@ -360,5 +361,123 @@ describe("createLearningHooks", () => {
     expect(trace.taskTraces).toHaveLength(2);
     expect(trace.taskTraces[0].agentRunner).toBe("api");
     expect(trace.taskTraces[1].agentRunner).toBe("anthropic");
+  });
+
+  // ─── #171: reflectEvery scheduler ────────────────────────────────────────────
+
+  describe("#171: reflectEvery scheduler", () => {
+    const dagStructure = { taskA: [] as readonly string[] };
+
+    async function runWorkflow(
+      hooks: ReturnType<typeof createLearningHooks>,
+    ): Promise<void> {
+      hooks.onTaskStart?.("taskA", "api");
+      hooks.onTaskComplete?.("taskA", "out", makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({}, makeMetrics());
+    }
+
+    it("reflectEvery: 3 + 9 completions → runReflection fires 3 times", async () => {
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        .mockResolvedValue({
+          workflowScore: 0.8,
+          skillsGenerated: 0,
+          skillsUpdated: 0,
+          tasksReflected: [],
+          taskScores: {},
+        });
+
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        dagStructure,
+        config: { reflectEvery: 3 },
+      });
+
+      for (let i = 0; i < 9; i++) {
+        await runWorkflow(hooks);
+      }
+      // Allow fire-and-forget promises to settle
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      spy.mockRestore();
+    });
+
+    it("reflectEvery: 1 + 1 completion → runReflection fires once", async () => {
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        .mockResolvedValue({
+          workflowScore: 0.9,
+          skillsGenerated: 0,
+          skillsUpdated: 0,
+          tasksReflected: [],
+          taskScores: {},
+        });
+
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        dagStructure,
+        config: { reflectEvery: 1 },
+      });
+
+      await runWorkflow(hooks);
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it("reflectEvery: undefined (default) → never fires automatically", async () => {
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        .mockResolvedValue({
+          workflowScore: 0.9,
+          skillsGenerated: 0,
+          skillsUpdated: 0,
+          tasksReflected: [],
+          taskScores: {},
+        });
+
+      // No reflectEvery in config and no dagStructure → should never fire
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        // No dagStructure — auto-reflection disabled
+      });
+
+      await runWorkflow(hooks);
+      await runWorkflow(hooks);
+      await runWorkflow(hooks);
+      await Promise.resolve();
+
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("runReflection failure does NOT crash workflow (fire-and-forget)", async () => {
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        .mockRejectedValue(new Error("LLM API down"));
+
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        dagStructure,
+        config: { reflectEvery: 1 },
+      });
+
+      // onWorkflowComplete must resolve without throwing even if runReflection rejects
+      await expect(runWorkflow(hooks)).resolves.toBeUndefined();
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/learning/src/hooks.ts
+++ b/packages/learning/src/hooks.ts
@@ -2,19 +2,26 @@ import type { WorkflowHooks } from "@ageflow/core";
 import type { SkillStore, TraceStore } from "./interfaces.js";
 import type { ExecutionTrace, LearningConfig, TaskTrace } from "./types.js";
 import { DEFAULT_CONFIG } from "./types.js";
+import { runReflection } from "./workflows/reflection.js";
 
 export interface CreateLearningHooksOptions {
   readonly skillStore: SkillStore;
   readonly traceStore: TraceStore;
   readonly workflowName: string;
   readonly config?: Partial<LearningConfig>;
+  /**
+   * DAG structure passed to runReflection when auto-reflection fires.
+   * Required for reflectEvery scheduling; if omitted, auto-reflection is
+   * silently skipped even when reflectEvery is set.
+   */
+  readonly dagStructure?: Record<string, readonly string[]>;
 }
 
 export function createLearningHooks(
   opts: CreateLearningHooksOptions,
 ): WorkflowHooks {
-  const _config = { ...DEFAULT_CONFIG, ...opts.config }; // reserved for Phase 6
-  const { skillStore, traceStore, workflowName } = opts;
+  const config = { ...DEFAULT_CONFIG, ...opts.config };
+  const { skillStore, traceStore, workflowName, dagStructure } = opts;
 
   // Per-run state (reset on each workflow execution)
   let taskTraces: TaskTrace[] = [];
@@ -150,7 +157,31 @@ export function createLearningHooks(
       isFirstTaskOfRun = true;
       capturedWorkflowInput = null;
 
-      // TODO Phase 6: trigger reflectionWorkflow here based on config.reflectEvery
+      // Auto-reflection scheduler — Phase 6 implementation of reflectEvery config.
+      // Fires runReflection() non-blocking (fire-and-forget) when the condition is met.
+      // Errors are logged but never propagate to avoid blocking workflow completion.
+      if (dagStructure !== undefined) {
+        const { reflectEvery } = config;
+        let shouldReflect = false;
+
+        if (reflectEvery === "always") {
+          shouldReflect = true;
+        } else if (typeof reflectEvery === "number" && reflectEvery >= 1) {
+          shouldReflect = runCount % reflectEvery === 0;
+        }
+        // "on-failure" and "on-feedback" are intentionally left for future phases.
+
+        if (shouldReflect) {
+          runReflection({
+            currentTrace: trace,
+            dagStructure,
+            skillStore,
+            traceStore,
+          }).catch((err: unknown) => {
+            console.warn("[learning] auto-reflection failed", err);
+          });
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
Closes Phase 6 TODO from #113 split. `reflectEvery` was parsed but never consumed. Now: hooks track completed-run count and fire runReflection() non-blocking when count % reflectEvery === 0. Errors logged via console.warn but don't propagate. Numeric and `"always"` values supported; `"on-failure"`/`"on-feedback"` reserved for future. dagStructure must be supplied to enable. 4 new tests. Bumps learning 0.4.6→0.5.0. Closes #171.