### PR TITLE
feat(core/executor/learning/testing/cli): #169 — onTaskSpawnArgs/Result hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },
@@ -265,7 +265,7 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,5 +1,11 @@
 import path from "node:path";
-import type { TaskMetrics, WorkflowDef, WorkflowMetrics } from "@ageflow/core";
+import type {
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  TaskMetrics,
+  WorkflowDef,
+  WorkflowMetrics,
+} from "@ageflow/core";
 import { shutdownAllRunners } from "@ageflow/core";
 import { WorkflowExecutor } from "@ageflow/executor";
 import type { Command } from "commander";
@@ -69,6 +75,23 @@ export function registerRunCommand(program: Command): void {
             renderWorkflowComplete(summary);
             existingHooks?.onWorkflowComplete?.(result, summary);
           },
+          ...(existingHooks?.onTaskSpawnArgs !== undefined
+            ? {
+                onTaskSpawnArgs: (taskName: string, args: RunnerSpawnArgs) => {
+                  existingHooks.onTaskSpawnArgs?.(taskName as never, args);
+                },
+              }
+            : {}),
+          ...(existingHooks?.onTaskSpawnResult !== undefined
+            ? {
+                onTaskSpawnResult: (
+                  taskName: string,
+                  result: RunnerSpawnResult,
+                ) => {
+                  existingHooks.onTaskSpawnResult?.(taskName as never, result);
+                },
+              }
+            : {}),
         };
 
         const executor = new WorkflowExecutor({ ...workflow, hooks });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -748,6 +748,28 @@ export interface WorkflowHooks<T extends TasksMap = TasksMap> {
   readonly getSystemPromptPrefix?: (
     taskName: keyof T & string,
   ) => string | undefined | Promise<string | undefined>;
+  /**
+   * Called just before a task's runner.spawn() is invoked. Receives the
+   * resolved spawn args (prompt, tools, MCP servers, session handle, etc.).
+   *
+   * Best-effort: errors thrown from this hook are caught, logged via
+   * console.warn, and do NOT interrupt the task.
+   */
+  readonly onTaskSpawnArgs?: (
+    taskName: keyof T & string,
+    args: RunnerSpawnArgs,
+  ) => void;
+  /**
+   * Called just after a task's runner.spawn() returns. Receives the result
+   * (stdout, sessionHandle, token counts, tool-call trail).
+   *
+   * Best-effort: errors thrown from this hook are caught, logged via
+   * console.warn, and do NOT interrupt the task.
+   */
+  readonly onTaskSpawnResult?: (
+    taskName: keyof T & string,
+    result: RunnerSpawnResult,
+  ) => void;
 }
 
 // ─── MCP exposure config ─────────────────────────────────────────────────────

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/node-runner.spawn-hooks.test.ts
+++ b/packages/executor/src/__tests__/node-runner.spawn-hooks.test.ts
@@ -1,0 +1,274 @@
+import { defineAgent } from "@ageflow/core";
+import type {
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  WorkflowHooks,
+} from "@ageflow/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { runNode } from "../node-runner.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSuccessResult(data: unknown): RunnerSpawnResult {
+  return {
+    stdout: JSON.stringify(data),
+    sessionHandle: "sess-spawn-hook",
+    tokensIn: 5,
+    tokensOut: 10,
+  };
+}
+
+const simpleAgent = defineAgent({
+  runner: "mock",
+  input: z.object({ text: z.string() }),
+  output: z.object({ result: z.string() }),
+  prompt: ({ text }) => `Process: ${text}`,
+  retry: { max: 1, on: [], backoff: "fixed" },
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("runNode — onTaskSpawnArgs / onTaskSpawnResult hooks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("onTaskSpawnArgs fires with correct taskName and args before spawn", async () => {
+    const captured: { taskName: string; args: RunnerSpawnArgs }[] = [];
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: (taskName, args) => {
+        captured.push({ taskName, args });
+      },
+    };
+
+    await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "my-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].taskName).toBe("my-task");
+    expect(captured[0].args.prompt).toContain("hello");
+    expect(captured[0].args.taskName).toBe("my-task");
+  });
+
+  it("onTaskSpawnArgs fires before runner.spawn (ordering)", async () => {
+    const order: string[] = [];
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn(async () => {
+        order.push("spawn");
+        return makeSuccessResult({ result: "ok" });
+      }),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: (_taskName, _args) => {
+        order.push("onTaskSpawnArgs");
+      },
+      onTaskSpawnResult: (_taskName, _result) => {
+        order.push("onTaskSpawnResult");
+      },
+    };
+
+    await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "order-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(order).toEqual(["onTaskSpawnArgs", "spawn", "onTaskSpawnResult"]);
+  });
+
+  it("onTaskSpawnResult fires with correct taskName and result after spawn", async () => {
+    const captured: { taskName: string; result: RunnerSpawnResult }[] = [];
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "done" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnResult: (taskName, result) => {
+        captured.push({ taskName, result });
+      },
+    };
+
+    await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "result-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].taskName).toBe("result-task");
+    expect(captured[0].result.stdout).toBe(JSON.stringify({ result: "done" }));
+    expect(captured[0].result.sessionHandle).toBe("sess-spawn-hook");
+    expect(captured[0].result.tokensIn).toBe(5);
+    expect(captured[0].result.tokensOut).toBe(10);
+  });
+
+  it("onTaskSpawnArgs error does NOT crash the task (best-effort)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: (_taskName, _args) => {
+        throw new Error("hook exploded");
+      },
+    };
+
+    const [nodeResult] = await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "safe-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    // Task still succeeded despite hook error
+    expect(nodeResult.output).toEqual({ result: "ok" });
+    // Warning was logged
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("onTaskSpawnArgs");
+  });
+
+  it("onTaskSpawnResult error does NOT crash the task (best-effort)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnResult: (_taskName, _result) => {
+        throw new Error("result hook exploded");
+      },
+    };
+
+    const [nodeResult] = await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "safe-result-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(nodeResult.output).toEqual({ result: "ok" });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("onTaskSpawnResult");
+  });
+
+  it("hooks do not fire when not provided", async () => {
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    // No hooks — should complete without error
+    const [nodeResult] = await Promise.all([
+      runNode({ agent: simpleAgent }, { text: "hello" }, runner, "no-hooks"),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(nodeResult.output).toEqual({ result: "ok" });
+  });
+
+  it("hooks are called per-retry attempt", async () => {
+    const spawnArgsCalls: string[] = [];
+    const spawnResultCalls: string[] = [];
+
+    const retryableAgent = defineAgent({
+      runner: "mock",
+      input: z.object({ text: z.string() }),
+      output: z.object({ result: z.string() }),
+      prompt: ({ text }) => `Process: ${text}`,
+      retry: { max: 3, on: ["subprocess_error"], backoff: "fixed" },
+    });
+
+    let callCount = 0;
+    const subprocessErr = Object.assign(new Error("subprocess error"), {
+      code: "subprocess_error",
+    });
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn(async () => {
+        callCount++;
+        if (callCount < 2) throw subprocessErr;
+        return makeSuccessResult({ result: "ok" });
+      }),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: (taskName) => {
+        spawnArgsCalls.push(taskName);
+      },
+      onTaskSpawnResult: (taskName) => {
+        spawnResultCalls.push(taskName);
+      },
+    };
+
+    await Promise.all([
+      runNode(
+        { agent: retryableAgent },
+        { text: "hello" },
+        runner,
+        "retry-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    // onTaskSpawnArgs fires on every attempt (including the failing one)
+    expect(spawnArgsCalls).toHaveLength(2);
+    // onTaskSpawnResult fires only on the successful attempt
+    expect(spawnResultCalls).toHaveLength(1);
+  });
+});

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -340,7 +340,29 @@ export async function runNode<
         spawnArgs.permissions = permissions;
       }
 
+      // Fire onTaskSpawnArgs hook (best-effort — errors must not crash the task)
+      try {
+        hooks?.onTaskSpawnArgs?.(taskName, spawnArgs);
+      } catch (hookErr) {
+        console.warn(
+          "[agentflow] onTaskSpawnArgs hook error for task %s:",
+          taskName,
+          hookErr,
+        );
+      }
+
       const spawnResult = await runner.spawn(spawnArgs);
+
+      // Fire onTaskSpawnResult hook (best-effort — errors must not crash the task)
+      try {
+        hooks?.onTaskSpawnResult?.(taskName, spawnResult);
+      } catch (hookErr) {
+        console.warn(
+          "[agentflow] onTaskSpawnResult hook error for task %s:",
+          taskName,
+          hookErr,
+        );
+      }
 
       // Parse and validate output through Zod security boundary
       const output = parseAgentOutput(

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/hooks.test.ts
+++ b/packages/learning/src/__tests__/hooks.test.ts
@@ -363,6 +363,105 @@ describe("createLearningHooks", () => {
     expect(trace.taskTraces[1].agentRunner).toBe("anthropic");
   });
 
+  // ─── #169: onTaskSpawnArgs / onTaskSpawnResult ──────────────────────────────
+
+  describe("#169: spawn args/result captured in TaskTrace", () => {
+    it("TaskTrace.spawnArgs is populated when onTaskSpawnArgs fires", async () => {
+      const traceStore = makeTraceStore();
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore,
+        workflowName: "bug-fix",
+      });
+
+      const spawnArgs = {
+        prompt: "Analyze this repo",
+        taskName: "analyze",
+        systemPrompt: "You MUST respond with valid JSON",
+      };
+
+      hooks.onTaskStart?.("analyze", "api");
+      hooks.onTaskSpawnArgs?.("analyze", spawnArgs);
+      hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+      const trace = traceStore.traces[0];
+      expect(trace.taskTraces[0].spawnArgs).toEqual(spawnArgs);
+    });
+
+    it("TaskTrace.spawnResult is populated when onTaskSpawnResult fires", async () => {
+      const traceStore = makeTraceStore();
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore,
+        workflowName: "bug-fix",
+      });
+
+      const spawnResult = {
+        stdout: JSON.stringify({ fixed: true }),
+        sessionHandle: "sess-123",
+        tokensIn: 100,
+        tokensOut: 50,
+      };
+
+      hooks.onTaskStart?.("analyze", "api");
+      hooks.onTaskSpawnResult?.("analyze", spawnResult);
+      hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+      const trace = traceStore.traces[0];
+      expect(trace.taskTraces[0].spawnResult).toEqual(spawnResult);
+    });
+
+    it("TaskTrace.spawnArgs and spawnResult are both omitted when hooks never fire", async () => {
+      const traceStore = makeTraceStore();
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore,
+        workflowName: "bug-fix",
+      });
+
+      // Neither spawn hook is called
+      hooks.onTaskStart?.("analyze", "api");
+      hooks.onTaskComplete?.("analyze", { fixed: true }, makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({ fixed: true }, makeMetrics());
+
+      const trace = traceStore.traces[0];
+      expect(trace.taskTraces[0].spawnArgs).toBeUndefined();
+      expect(trace.taskTraces[0].spawnResult).toBeUndefined();
+    });
+
+    it("spawnArgs and spawnResult reset correctly between runs", async () => {
+      const traceStore = makeTraceStore();
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore,
+        workflowName: "bug-fix",
+      });
+
+      const spawnArgs1 = {
+        prompt: "Run 1 prompt",
+        taskName: "taskA",
+        systemPrompt: "",
+      };
+
+      // Run 1: with spawn args
+      hooks.onTaskStart?.("taskA", "api");
+      hooks.onTaskSpawnArgs?.("taskA", spawnArgs1);
+      hooks.onTaskComplete?.("taskA", "out1", makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+      // Run 2: without spawn args
+      hooks.onTaskStart?.("taskB", "api");
+      // No onTaskSpawnArgs for taskB
+      hooks.onTaskComplete?.("taskB", "out2", makeTaskMetrics());
+      await hooks.onWorkflowComplete?.({}, makeMetrics());
+
+      expect(traceStore.traces[0].taskTraces[0].spawnArgs).toEqual(spawnArgs1);
+      expect(traceStore.traces[1].taskTraces[0].spawnArgs).toBeUndefined();
+    });
+  });
+
   // ─── #171: reflectEvery scheduler ────────────────────────────────────────────
 
   describe("#171: reflectEvery scheduler", () => {

--- a/packages/learning/src/hooks.ts
+++ b/packages/learning/src/hooks.ts
@@ -1,4 +1,8 @@
-import type { WorkflowHooks } from "@ageflow/core";
+import type {
+  RunnerSpawnArgs,
+  RunnerSpawnResult,
+  WorkflowHooks,
+} from "@ageflow/core";
 import type { SkillStore, TraceStore } from "./interfaces.js";
 import type { ExecutionTrace, LearningConfig, TaskTrace } from "./types.js";
 import { DEFAULT_CONFIG } from "./types.js";
@@ -43,6 +47,10 @@ export function createLearningHooks(
   // #173: runner brand per task — populated in onTaskStart, read in onTaskComplete/onTaskError
   const taskRunnerMap = new Map<string, string>();
 
+  // #169: spawn args/result per task — populated by onTaskSpawnArgs/onTaskSpawnResult
+  const taskSpawnArgsMap = new Map<string, RunnerSpawnArgs>();
+  const taskSpawnResultMap = new Map<string, RunnerSpawnResult>();
+
   return {
     // #172: capture workflow input once at run start
     onWorkflowStart(input) {
@@ -57,6 +65,8 @@ export function createLearningHooks(
         skillCache.clear();
         resolvedSkillContent.clear();
         taskRunnerMap.clear();
+        taskSpawnArgsMap.clear();
+        taskSpawnResultMap.clear();
         isFirstTaskOfRun = false;
       }
 
@@ -81,6 +91,16 @@ export function createLearningHooks(
       }
     },
 
+    // #169: capture resolved spawn args before each runner.spawn() call
+    onTaskSpawnArgs(taskName, args) {
+      taskSpawnArgsMap.set(taskName, args);
+    },
+
+    // #169: capture raw spawn result after each runner.spawn() returns
+    onTaskSpawnResult(taskName, result) {
+      taskSpawnResultMap.set(taskName, result);
+    },
+
     async getSystemPromptPrefix(taskName) {
       // Await the pending promise so skills are never silently dropped.
       const pending = skillCache.get(taskName);
@@ -99,6 +119,10 @@ export function createLearningHooks(
       // #173: read runner brand captured in onTaskStart
       const agentRunner = taskRunnerMap.get(taskName) ?? "";
 
+      // #169: retrieve captured spawn args/result for this task
+      const spawnArgs = taskSpawnArgsMap.get(taskName);
+      const spawnResult = taskSpawnResultMap.get(taskName);
+
       taskTraces.push({
         taskName,
         agentRunner,
@@ -111,6 +135,8 @@ export function createLearningHooks(
         tokensOut: metrics.tokensOut,
         durationMs: metrics.latencyMs,
         retryCount: metrics.retries,
+        ...(spawnArgs !== undefined ? { spawnArgs } : {}),
+        ...(spawnResult !== undefined ? { spawnResult } : {}),
       });
 
       // Mark next onTaskStart as still part of this run

--- a/packages/learning/src/types.ts
+++ b/packages/learning/src/types.ts
@@ -25,6 +25,18 @@ export const TaskTraceSchema = z.object({
   tokensOut: z.number(),
   durationMs: z.number(),
   retryCount: z.number(),
+  /**
+   * The resolved spawn args passed to runner.spawn() — captured via
+   * onTaskSpawnArgs. Includes the full prompt, tool list, MCP servers, etc.
+   * Present only when the onTaskSpawnArgs hook fired for this task.
+   */
+  spawnArgs: z.unknown().optional(),
+  /**
+   * The raw runner.spawn() result — captured via onTaskSpawnResult.
+   * Includes stdout, sessionHandle, token counts and tool-call trail.
+   * Present only when the onTaskSpawnResult hook fired for this task.
+   */
+  spawnResult: z.unknown().optional(),
 });
 
 export type TaskTrace = z.infer<typeof TaskTraceSchema>;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/testing",
   "type": "module",

--- a/packages/testing/src/__tests__/test-harness.test.ts
+++ b/packages/testing/src/__tests__/test-harness.test.ts
@@ -382,4 +382,54 @@ describe("createTestHarness", () => {
     // Assert that the hook was called with the workflow input
     expect(receivedInput).toEqual(workflowInput);
   });
+
+  it("onTaskSpawnArgs hook is forwarded and receives task name + args", async () => {
+    const captured: { taskName: string; prompt: string }[] = [];
+
+    const workflow = defineWorkflow({
+      name: "test-spawn-args-hook",
+      tasks: {
+        analyze: { agent: analyzeAgent, input: { value: "src/" } },
+      },
+      hooks: {
+        onTaskSpawnArgs: (taskName, args) => {
+          captured.push({ taskName, prompt: args.prompt });
+        },
+      },
+    });
+
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("analyze", { issues: [] });
+
+    await harness.run();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].taskName).toBe("analyze");
+    expect(typeof captured[0].prompt).toBe("string");
+  });
+
+  it("onTaskSpawnResult hook is forwarded and receives task name + result", async () => {
+    const captured: { taskName: string; stdout: string }[] = [];
+
+    const workflow = defineWorkflow({
+      name: "test-spawn-result-hook",
+      tasks: {
+        analyze: { agent: analyzeAgent, input: { value: "src/" } },
+      },
+      hooks: {
+        onTaskSpawnResult: (taskName, result) => {
+          captured.push({ taskName, stdout: result.stdout });
+        },
+      },
+    });
+
+    const harness = createTestHarness(workflow);
+    harness.mockAgent("analyze", { issues: ["a", "b"] });
+
+    await harness.run();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].taskName).toBe("analyze");
+    expect(JSON.parse(captured[0].stdout)).toEqual({ issues: ["a", "b"] });
+  });
 });

--- a/packages/testing/src/test-harness.ts
+++ b/packages/testing/src/test-harness.ts
@@ -213,6 +213,26 @@ export function createTestHarness(workflow: WorkflowDef): TestHarness {
         ...(workflowHooks?.onCheckpoint !== undefined
           ? { onCheckpoint: workflowHooks.onCheckpoint }
           : {}),
+        ...(workflowHooks?.onTaskSpawnArgs !== undefined
+          ? {
+              onTaskSpawnArgs: (
+                taskName: string,
+                args: import("@ageflow/core").RunnerSpawnArgs,
+              ) => {
+                workflowHooks.onTaskSpawnArgs?.(taskName as never, args);
+              },
+            }
+          : {}),
+        ...(workflowHooks?.onTaskSpawnResult !== undefined
+          ? {
+              onTaskSpawnResult: (
+                taskName: string,
+                result: import("@ageflow/core").RunnerSpawnResult,
+              ) => {
+                workflowHooks.onTaskSpawnResult?.(taskName as never, result);
+              },
+            }
+          : {}),
       };
 
       const wrappedWorkflow: WorkflowDef = { ...workflow, hooks: harnessHooks };


### PR DESCRIPTION
Closes #169 (split from #113). New WorkflowHooks: onTaskSpawnArgs (called just before runner.spawn), onTaskSpawnResult (called just after). Both protected against hook errors (best-effort, log-and-continue). `@ageflow/learning` consumes them to capture raw prompt + tool calls into TaskTrace, eliminating prior workarounds. Bumps: core 0.6.1→0.6.2, executor 0.6.4→0.6.5, learning 0.5.0→0.5.1, testing 0.3.6→0.3.7, cli 0.5.1→0.5.2. 15 new tests across 3 packages. Closes #169.

Note: spec doc has no §7.1 numbered section; hook shapes derived from existing RunnerSpawnArgs/RunnerSpawnResult types and issue prompt.