### PR TITLE
fix: #185 — bump learning consumer dep ranges + serialize auto-reflection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,14 +103,14 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.6.0",
-        "@ageflow/learning": "^0.4.3",
+        "@ageflow/learning": "^0.5.0",
         "@ageflow/learning-sqlite": "^0.4.1",
         "@ageflow/mcp-server": "^0.5.0",
         "boxen": "^8.0.0",
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },
@@ -171,9 +171,9 @@
     },
     "packages/learning-sqlite": {
       "name": "@ageflow/learning-sqlite",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@ageflow/learning": "^0.4.1",
+        "@ageflow/learning": "^0.5.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -771,10 +771,6 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "@ageflow/cli/@ageflow/learning": ["@ageflow/learning@0.4.6", "", { "dependencies": { "@ageflow/core": "^0.6.0" }, "peerDependencies": { "@ageflow/executor": "^0.6.0" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-bcBippO8KLk3rmN6I4SuOtncQu3sEwO5sKzEMcaZWSdiHTzkAttOKEZ5t2YiuPc+TDvnIOW7panNUMqTNnZ8aQ=="],
-
-    "@ageflow/learning-sqlite/@ageflow/learning": ["@ageflow/learning@0.4.6", "", { "dependencies": { "@ageflow/core": "^0.6.0" }, "peerDependencies": { "@ageflow/executor": "^0.6.0" }, "optionalPeers": ["@ageflow/executor"] }, "sha512-bcBippO8KLk3rmN6I4SuOtncQu3sEwO5sKzEMcaZWSdiHTzkAttOKEZ5t2YiuPc+TDvnIOW7panNUMqTNnZ8aQ=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ageflow/core": "^0.6.0",
     "@ageflow/executor": "^0.6.0",
-    "@ageflow/learning": "^0.4.3",
+    "@ageflow/learning": "^0.5.0",
     "@ageflow/learning-sqlite": "^0.4.1",
     "@ageflow/mcp-server": "^0.5.0",
     "chalk": "^5.3.0",

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning-sqlite",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SQLite + sqlite-vec storage for @ageflow/learning",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
   "type": "module",
@@ -19,7 +19,7 @@
     "lint": "biome check src/"
   },
   "dependencies": {
-    "@ageflow/learning": "^0.4.1"
+    "@ageflow/learning": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",

--- a/packages/learning/src/__tests__/hooks.test.ts
+++ b/packages/learning/src/__tests__/hooks.test.ts
@@ -578,5 +578,94 @@ describe("createLearningHooks", () => {
       expect(spy).toHaveBeenCalledTimes(1);
       spy.mockRestore();
     });
+
+    // ─── #185: serialization (isReflecting guard) ─────────────────────────────
+
+    it("#185: two completions while reflection is slow → only one reflection runs concurrently", async () => {
+      // neverResolve keeps the first reflection in-flight for the duration of the test.
+      const reflectionResult = {
+        workflowScore: 0.9,
+        skillsGenerated: 0,
+        skillsUpdated: 0,
+        tasksReflected: [] as string[],
+        taskScores: {} as Record<string, number>,
+      };
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        // First call: never resolves during this test (simulates slow reflection)
+        .mockImplementationOnce(() => new Promise(() => {}))
+        // Second call (if guard fails): instant — so the test assertion catches it
+        .mockResolvedValueOnce(reflectionResult);
+
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        dagStructure,
+        config: { reflectEvery: 1 },
+      });
+
+      // Completion 1 — triggers reflection; leaves it in-flight
+      await runWorkflow(hooks);
+      // Completion 2 — reflection 1 still in-flight → must be debounced (skipped)
+      await runWorkflow(hooks);
+      await Promise.resolve();
+
+      // Only one reflection should have been launched so far
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      spy.mockRestore();
+    });
+
+    it("#185: after first reflection finishes, next eligible completion fires again", async () => {
+      let resolveFirst!: () => void;
+      const reflectionResult = {
+        workflowScore: 0.9,
+        skillsGenerated: 0,
+        skillsUpdated: 0,
+        tasksReflected: [] as string[],
+        taskScores: {} as Record<string, number>,
+      };
+
+      const spy = vi
+        .spyOn(reflectionModule, "runReflection")
+        // First call: slow (controlled via resolveFirst)
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveFirst = () => resolve(reflectionResult);
+            }),
+        )
+        // Second call: instant
+        .mockResolvedValueOnce(reflectionResult);
+
+      const hooks = createLearningHooks({
+        skillStore: makeSkillStore(),
+        traceStore: makeTraceStore(),
+        workflowName: "test-wf",
+        dagStructure,
+        config: { reflectEvery: 1 },
+      });
+
+      // Completion 1 — launches slow reflection
+      await runWorkflow(hooks);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Completion 2 — reflection still in-flight → debounced
+      await runWorkflow(hooks);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Settle the first reflection and allow microtasks to drain
+      resolveFirst();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Completion 3 — isReflecting is now false → new reflection fires
+      await runWorkflow(hooks);
+      await Promise.resolve();
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/learning/src/hooks.ts
+++ b/packages/learning/src/hooks.ts
@@ -51,6 +51,22 @@ export function createLearningHooks(
   const taskSpawnArgsMap = new Map<string, RunnerSpawnArgs>();
   const taskSpawnResultMap = new Map<string, RunnerSpawnResult>();
 
+  /**
+   * #185 — serialization guard for auto-reflection.
+   *
+   * Auto-reflection is intentionally fire-and-forget (it must not block workflow
+   * completion), but running concurrent reflections would race on the skill store
+   * — the second pass could overwrite skills written by the first with stale data.
+   *
+   * `isReflecting` is set to `true` just before a `runReflection` promise is
+   * launched and cleared in its `.then`/`.catch` handler.  Any workflow
+   * completion that would normally trigger reflection while a previous one is
+   * still in flight logs a debounce warning and skips the launch.  Once the
+   * in-flight reflection settles the flag is cleared, so the *next* eligible
+   * completion will fire normally.
+   */
+  let isReflecting = false;
+
   return {
     // #172: capture workflow input once at run start
     onWorkflowStart(input) {
@@ -198,14 +214,30 @@ export function createLearningHooks(
         // "on-failure" and "on-feedback" are intentionally left for future phases.
 
         if (shouldReflect) {
-          runReflection({
-            currentTrace: trace,
-            dagStructure,
-            skillStore,
-            traceStore,
-          }).catch((err: unknown) => {
-            console.warn("[learning] auto-reflection failed", err);
-          });
+          if (isReflecting) {
+            // A previous auto-reflection is still in flight.  Launching another
+            // one concurrently could cause the two passes to race on the skill
+            // store (each writing skills based on a snapshot that doesn't
+            // include the other's writes).  Skip and let the next eligible
+            // workflow completion retry.
+            console.warn(
+              "[learning] auto-reflection debounced — previous reflection still in flight",
+            );
+          } else {
+            isReflecting = true;
+            runReflection({
+              currentTrace: trace,
+              dagStructure,
+              skillStore,
+              traceStore,
+            })
+              .catch((err: unknown) => {
+                console.warn("[learning] auto-reflection failed", err);
+              })
+              .finally(() => {
+                isReflecting = false;
+              });
+          }
         }
       }
     },


### PR DESCRIPTION
Closes Codex P1×2 from #182. (A) cli/learning-sqlite still pinned learning ^0.4.x → bun resolved older published version; bumped to ^0.5.0. (B) Auto-reflection now guarded by isReflecting flag; concurrent triggers debounced+skipped. Bumps learning 0.5.1→0.5.2, cli 0.5.2→0.5.3, learning-sqlite 0.4.1→0.4.2. 2 new serialization tests. Closes #185.