### PR TITLE
fix(core/executor): #187 — await onTaskSpawnArgs/Result hooks (catch async rejections)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -753,23 +753,25 @@ export interface WorkflowHooks<T extends TasksMap = TasksMap> {
    * resolved spawn args (prompt, tools, MCP servers, session handle, etc.).
    *
    * Best-effort: errors thrown from this hook are caught, logged via
-   * console.warn, and do NOT interrupt the task.
+   * console.warn, and do NOT interrupt the task. Async hooks are supported —
+   * the executor awaits the returned promise before proceeding.
    */
   readonly onTaskSpawnArgs?: (
     taskName: keyof T & string,
     args: RunnerSpawnArgs,
-  ) => void;
+  ) => void | Promise<void>;
   /**
    * Called just after a task's runner.spawn() returns. Receives the result
    * (stdout, sessionHandle, token counts, tool-call trail).
    *
    * Best-effort: errors thrown from this hook are caught, logged via
-   * console.warn, and do NOT interrupt the task.
+   * console.warn, and do NOT interrupt the task. Async hooks are supported —
+   * the executor awaits the returned promise before proceeding.
    */
   readonly onTaskSpawnResult?: (
     taskName: keyof T & string,
     result: RunnerSpawnResult,
-  ) => void;
+  ) => void | Promise<void>;
 }
 
 // ─── MCP exposure config ─────────────────────────────────────────────────────

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/executor/src/__tests__/node-runner.spawn-hooks.test.ts
+++ b/packages/executor/src/__tests__/node-runner.spawn-hooks.test.ts
@@ -271,4 +271,112 @@ describe("runNode — onTaskSpawnArgs / onTaskSpawnResult hooks", () => {
     // onTaskSpawnResult fires only on the successful attempt
     expect(spawnResultCalls).toHaveLength(1);
   });
+
+  it("async onTaskSpawnArgs that rejects after a tick is caught — workflow does not crash", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: async (_taskName, _args) => {
+        // Simulate async work before throwing
+        await Promise.resolve();
+        throw new Error("async hook exploded");
+      },
+    };
+
+    const [nodeResult] = await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "async-args-throw-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    // Task still succeeded despite async hook rejection
+    expect(nodeResult.output).toEqual({ result: "ok" });
+    // Warning was logged
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("onTaskSpawnArgs");
+  });
+
+  it("async onTaskSpawnResult that rejects after a tick is caught — workflow does not crash", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi.fn().mockResolvedValue(makeSuccessResult({ result: "ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnResult: async (_taskName, _result) => {
+        await Promise.resolve();
+        throw new Error("async result hook exploded");
+      },
+    };
+
+    const [nodeResult] = await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "async-result-throw-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(nodeResult.output).toEqual({ result: "ok" });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("onTaskSpawnResult");
+  });
+
+  it("async onTaskSpawnArgs that resolves — spawn proceeds normally, result observed", async () => {
+    const resolved: string[] = [];
+
+    const runner = {
+      validate: vi.fn().mockResolvedValue({ ok: true }),
+      spawn: vi
+        .fn()
+        .mockResolvedValue(makeSuccessResult({ result: "async-ok" })),
+    };
+
+    const hooks: WorkflowHooks = {
+      onTaskSpawnArgs: async (taskName, _args) => {
+        await Promise.resolve();
+        resolved.push(`args:${taskName}`);
+      },
+      onTaskSpawnResult: async (taskName, _result) => {
+        await Promise.resolve();
+        resolved.push(`result:${taskName}`);
+      },
+    };
+
+    const [nodeResult] = await Promise.all([
+      runNode(
+        { agent: simpleAgent },
+        { text: "hello" },
+        runner,
+        "async-resolve-task",
+        undefined,
+        { hooks },
+      ),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(nodeResult.output).toEqual({ result: "async-ok" });
+    // Both async hooks resolved and were awaited before proceeding
+    expect(resolved).toEqual([
+      "args:async-resolve-task",
+      "result:async-resolve-task",
+    ]);
+  });
 });

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -342,7 +342,7 @@ export async function runNode<
 
       // Fire onTaskSpawnArgs hook (best-effort — errors must not crash the task)
       try {
-        hooks?.onTaskSpawnArgs?.(taskName, spawnArgs);
+        await hooks?.onTaskSpawnArgs?.(taskName, spawnArgs);
       } catch (hookErr) {
         console.warn(
           "[agentflow] onTaskSpawnArgs hook error for task %s:",
@@ -355,7 +355,7 @@ export async function runNode<
 
       // Fire onTaskSpawnResult hook (best-effort — errors must not crash the task)
       try {
-        hooks?.onTaskSpawnResult?.(taskName, spawnResult);
+        await hooks?.onTaskSpawnResult?.(taskName, spawnResult);
       } catch (hookErr) {
         console.warn(
           "[agentflow] onTaskSpawnResult hook error for task %s:",

--- a/packages/executor/src/node-runner.ts
+++ b/packages/executor/src/node-runner.ts
@@ -341,27 +341,35 @@ export async function runNode<
       }
 
       // Fire onTaskSpawnArgs hook (best-effort — errors must not crash the task)
-      try {
-        await hooks?.onTaskSpawnArgs?.(taskName, spawnArgs);
-      } catch (hookErr) {
-        console.warn(
-          "[agentflow] onTaskSpawnArgs hook error for task %s:",
-          taskName,
-          hookErr,
-        );
+      // Only await if a hook is actually defined to avoid extra microtasks that
+      // could shift external timing-sensitive flows (e.g. mcp-server async-mode
+      // inflight-lock test #18).
+      if (hooks?.onTaskSpawnArgs !== undefined) {
+        try {
+          await hooks.onTaskSpawnArgs(taskName, spawnArgs);
+        } catch (hookErr) {
+          console.warn(
+            "[agentflow] onTaskSpawnArgs hook error for task %s:",
+            taskName,
+            hookErr,
+          );
+        }
       }
 
       const spawnResult = await runner.spawn(spawnArgs);
 
       // Fire onTaskSpawnResult hook (best-effort — errors must not crash the task)
-      try {
-        await hooks?.onTaskSpawnResult?.(taskName, spawnResult);
-      } catch (hookErr) {
-        console.warn(
-          "[agentflow] onTaskSpawnResult hook error for task %s:",
-          taskName,
-          hookErr,
-        );
+      // Same gating as onTaskSpawnArgs above.
+      if (hooks?.onTaskSpawnResult !== undefined) {
+        try {
+          await hooks.onTaskSpawnResult(taskName, spawnResult);
+        } catch (hookErr) {
+          console.warn(
+            "[agentflow] onTaskSpawnResult hook error for task %s:",
+            taskName,
+            hookErr,
+          );
+        }
       }
 
       // Parse and validate output through Zod security boundary


### PR DESCRIPTION
PR #184 added spawn hooks but invoked them without await → async hook rejections escaped as unhandled promises. Fix: widen return type to void|Promise<void> in core, await invocations in node-runner. 3 new tests cover async throw/resolve. Bumps core 0.6.2→0.6.3, executor 0.6.5→0.6.6. Closes #187.