### PR TITLE
chore(executor): #176 — major bump 0.6.6 → 0.7.0 for runNode signature change

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "bin": {
         "agentwf": "./dist/bin.js",
       },
@@ -138,7 +138,7 @@
     },
     "packages/executor": {
       "name": "@ageflow/executor",
-      "version": "0.6.6",
+      "version": "0.7.0",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "zod-to-json-schema": "^3.23.0",
@@ -151,7 +151,7 @@
     },
     "packages/learning": {
       "name": "@ageflow/learning",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
       },
@@ -163,7 +163,7 @@
         "zod": "^3.23.0",
       },
       "peerDependencies": {
-        "@ageflow/executor": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
       },
       "optionalPeers": [
         "@ageflow/executor",
@@ -183,7 +183,7 @@
     },
     "packages/mcp-server": {
       "name": "@ageflow/mcp-server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.6.0",
@@ -252,7 +252,7 @@
     },
     "packages/server": {
       "name": "@ageflow/server",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.6.0",
@@ -265,10 +265,10 @@
     },
     "packages/testing": {
       "name": "@ageflow/testing",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
-        "@ageflow/executor": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@ageflow/core": "^0.6.0",
-    "@ageflow/executor": "^0.6.0",
+    "@ageflow/executor": "^0.7.0",
     "@ageflow/learning": "^0.5.0",
     "@ageflow/learning-sqlite": "^0.4.1",
     "@ageflow/mcp-server": "^0.5.0",

--- a/packages/executor/CHANGELOG.md
+++ b/packages/executor/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.7.0
+
+### Breaking
+
+- `runNode()` signature changed in v0.6.3 (#167) from positional optional args to a single `RunNodeOpts` object after the required parameters. This was inadvertently shipped as a patch — now correctly versioned as a major bump. Existing JS callers using positional args must migrate to the options-object form.

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/executor",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "DAG executor, loop runner, session manager, HITL, budget tracker, and preflight checks for ageflow",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/executor",
   "type": "module",

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Self-evolving skill layer for ageflow \u2014 trace collection, skill injection, LLM reflection with DAG-aware credit assignment",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning",
   "type": "module",
@@ -22,7 +22,7 @@
     "@ageflow/core": "^0.6.0"
   },
   "peerDependencies": {
-    "@ageflow/executor": "^0.6.0"
+    "@ageflow/executor": "^0.7.0"
   },
   "peerDependenciesMeta": {
     "@ageflow/executor": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/mcp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Expose ageflow workflows as MCP tools (stdio transport, progress streaming, HITL via elicitation).",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/mcp-server",
   "type": "module",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ageflow/core": "^0.6.0",
-    "@ageflow/executor": "^0.6.0",
+    "@ageflow/executor": "^0.7.0",
     "@ageflow/server": "^0.4.4",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod-to-json-schema": "^3.23.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Embeddable execution surface for ageflow workflows: stream, fire-and-forget, async HITL, cancellation.",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/server",
   "type": "module",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@ageflow/core": "^0.6.0",
-    "@ageflow/executor": "^0.6.0"
+    "@ageflow/executor": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/testing",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Test harness for ageflow workflows — mock agents, inspect call counts, no API calls needed",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/testing",
   "type": "module",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@ageflow/core": "^0.6.0",
-    "@ageflow/executor": "^0.6.0",
+    "@ageflow/executor": "^0.7.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR #167/#168 changed runNode from positional optionals to options object — breaking for JS consumers (TS catches at compile time, JS callers don't). Correctly versioned now as major. Consumer dep ranges bumped to ^0.7.0. New CHANGELOG.md. Closes #176.