### PR TITLE
chore(cli): bump 0.5.4 → 0.5.5 to publish executor ^0.7.0 dep range

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "@ageflow/cli",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "bin": {
         "agentwf": "./dist/bin.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "CLI for ageflow \u2014 agentwf run / validate / dry-run / init",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/cli",
   "type": "module",


### PR DESCRIPTION
Concurrent #189/#190 race: both bumped cli to 0.5.4. #190 published first (with executor ^0.6.0). #189 updated executor range to ^0.7.0 but couldn't republish 0.5.4. This bump publishes the correct range.