### PR TITLE
feat(core): #192 — defineWorkflowFactory<I> helper for input-closure workflows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -216,7 +216,40 @@ const executor = new WorkflowExecutor(workflow);
 await executor.run();
 ```
 
+See also [`defineWorkflowFactory`](#defineworkflowfactoryi) — a helper that codifies this closure pattern.
+
 - **Special keys like `$input`, `$parent`, or `$prev`** — these do not exist. See below for loop-specific context access.
+
+## `defineWorkflowFactory<I>`
+
+A typed helper that codifies the [closure pattern](#ctx-in-task-input-callbacks) shown above. Instead of manually writing a factory function, pass the config-builder callback to `defineWorkflowFactory` and get back a typed factory function.
+
+```ts
+// Before (manual factory):
+export function createPipeline(input: PipelineInput): WorkflowDef {
+  return defineWorkflow({
+    name: "pipeline",
+    tasks: {
+      analyze: { agent: analyzeAgent, input: { repoPath: input.repoPath } },
+    },
+  });
+}
+
+// After (using helper):
+export const createPipeline = defineWorkflowFactory<PipelineInput>(
+  (input) => ({
+    name: "pipeline",
+    tasks: {
+      analyze: { agent: analyzeAgent, input: { repoPath: input.repoPath } },
+    },
+  }),
+);
+```
+
+Both produce an identical `WorkflowDef`. The helper version:
+- enforces the return type automatically (no manual `: WorkflowDef<...>` annotation needed)
+- makes the factory-closure pattern visible at a glance
+- is compatible with any consumer that calls `createPipeline(input)`
 
 ## Accessing outer ctx and previous iteration inside loop
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/__tests__/builders.test.ts
+++ b/packages/core/src/__tests__/builders.test.ts
@@ -1,9 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import { z } from "zod";
 import {
   defineAgent,
   defineFunction,
   defineWorkflow,
+  defineWorkflowFactory,
   loop,
   registerRunner,
   resolveAgentDef,
@@ -12,6 +21,7 @@ import {
   shutdownAllRunners,
   unregisterRunner,
 } from "../builders.js";
+import type { WorkflowDef } from "../types.js";
 
 describe("defineAgent", () => {
   it("returns correct structure with runner brand", () => {
@@ -556,5 +566,120 @@ describe("defineFunction", () => {
     });
     const result = await fn.execute({ value: "hello" });
     expect(result.upper).toBe("HELLO");
+  });
+});
+
+describe("defineWorkflowFactory", () => {
+  interface PipelineInput {
+    repoPath: string;
+    maxIssues: number;
+  }
+
+  const analyzeAgent = defineAgent({
+    runner: "claude",
+    input: z.object({ repoPath: z.string(), limit: z.number() }),
+    output: z.object({ issues: z.array(z.string()) }),
+    prompt: ({ repoPath, limit }) => `Analyze ${repoPath}, max ${limit} issues`,
+  });
+
+  it("factory called with input returns a valid WorkflowDef", () => {
+    const createPipeline = defineWorkflowFactory<PipelineInput>((input) => ({
+      name: "test-pipeline",
+      tasks: {
+        analyze: {
+          agent: analyzeAgent,
+          input: { repoPath: input.repoPath, limit: input.maxIssues },
+        },
+      },
+    }));
+
+    const wf = createPipeline({ repoPath: "./src", maxIssues: 10 });
+
+    expect(wf.name).toBe("test-pipeline");
+    expect(wf.tasks.analyze).toBeDefined();
+    // Input values are closed over correctly
+    expect((wf.tasks.analyze as { input: unknown }).input).toEqual({
+      repoPath: "./src",
+      limit: 10,
+    });
+  });
+
+  it("input typing flows through — return type is WorkflowDef", () => {
+    const createPipeline = defineWorkflowFactory<PipelineInput>((input) => ({
+      name: "type-check-pipeline",
+      tasks: {
+        analyze: {
+          agent: analyzeAgent,
+          input: { repoPath: input.repoPath, limit: input.maxIssues },
+        },
+      },
+    }));
+
+    const wf = createPipeline({ repoPath: "./src", maxIssues: 5 });
+
+    // Runtime: object is plain WorkflowDef (name + tasks)
+    expect(typeof wf.name).toBe("string");
+    expect(typeof wf.tasks).toBe("object");
+
+    // Compile-time: the factory is typed as (input: PipelineInput) => WorkflowDef<T>
+    expectTypeOf(createPipeline).parameter(0).toMatchTypeOf<PipelineInput>();
+    expectTypeOf(wf).toMatchTypeOf<WorkflowDef>();
+  });
+
+  it("two different inputs produce two different WorkflowDefs", () => {
+    const analyzeAgent2 = defineAgent({
+      runner: "claude",
+      input: z.object({ path: z.string() }),
+      output: z.object({ findings: z.array(z.string()) }),
+      prompt: ({ path }) => `Scan ${path}`,
+    });
+    const summarizeAgent = defineAgent({
+      runner: "claude",
+      input: z.object({ findings: z.array(z.string()) }),
+      output: z.object({ summary: z.string() }),
+      prompt: ({ findings }) => `Summarize: ${findings.join(", ")}`,
+    });
+
+    const createRepoPipeline = defineWorkflowFactory<{
+      repo: string;
+      summarize: boolean;
+    }>((input) => ({
+      name: `repo-pipeline-${input.repo}`,
+      tasks: input.summarize
+        ? {
+            scan: { agent: analyzeAgent2, input: { path: input.repo } },
+            summarize: {
+              agent: summarizeAgent,
+              dependsOn: ["scan"],
+              input: (
+                ctx: Record<string, { output: { findings: string[] } }>,
+              ) => ({
+                findings: ctx.scan?.output.findings ?? [],
+              }),
+            },
+          }
+        : {
+            scan: { agent: analyzeAgent2, input: { path: input.repo } },
+          },
+    }));
+
+    const wfWithSummary = createRepoPipeline({
+      repo: "./packages",
+      summarize: true,
+    });
+    const wfWithoutSummary = createRepoPipeline({
+      repo: "./src",
+      summarize: false,
+    });
+
+    // Different workflow names
+    expect(wfWithSummary.name).toBe("repo-pipeline-./packages");
+    expect(wfWithoutSummary.name).toBe("repo-pipeline-./src");
+
+    // Different task counts — summarize variant has 2 tasks, scan-only has 1
+    expect(Object.keys(wfWithSummary.tasks)).toHaveLength(2);
+    expect(Object.keys(wfWithoutSummary.tasks)).toHaveLength(1);
+    expect(wfWithSummary.tasks).toHaveProperty("summarize");
+    expect(wfWithoutSummary.tasks).not.toHaveProperty("summarize");
   });
 });

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -194,6 +194,35 @@ export function defineWorkflow<const T extends TasksMap>(
 }
 
 /**
+ * Define a workflow factory that closes over a typed input value.
+ *
+ * Captures the de-facto consumer pattern: wrap `defineWorkflow` in a function
+ * that receives workflow-level data and threads it into task inputs via closure.
+ * Removes per-pipeline boilerplate and the typing footgun of manually annotating
+ * the factory return type.
+ *
+ * @example
+ * // Before (manual factory):
+ * export function createPipeline(input: PipelineInput): WorkflowDef<...> {
+ *   return defineWorkflow({ name: "pipeline", tasks: { ... } });
+ * }
+ *
+ * // After (using helper):
+ * export const createPipeline = defineWorkflowFactory<PipelineInput>(
+ *   (input) => ({ name: "pipeline", tasks: { ... } }),
+ * );
+ *
+ * @remarks
+ * v2: optional second argument for Zod input validation schema (deferred).
+ * When added, the factory will parse+validate `input` before calling `fn`.
+ */
+export function defineWorkflowFactory<I, const T extends TasksMap = TasksMap>(
+  fn: (input: I) => WorkflowDef<T>,
+): (input: I) => WorkflowDef<T> {
+  return (input: I) => defineWorkflow(fn(input));
+}
+
+/**
  * Define a loop task. Runs inner DAG iteratively until `until` returns true.
  *
  * @example

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export {
   defineAgent,
   defineFunction,
   defineWorkflow,
+  defineWorkflowFactory,
   getRunner,
   getRunners,
   loop,


### PR DESCRIPTION
Captures the de-facto consumer pattern (validated by sAIler dev-workflow, 5 pipelines): wrap defineWorkflow in a factory closing over input. Removes ~5 LOC + a typing footgun per pipeline. Cross-linked from "ctx in task-input-callbacks" docs (#134). 3 new tests. Bumps core 0.6.3→0.6.4. Closes #192.