### PR TITLE
feat(learning-sqlite): #170 — sqlite-vec extension support + FTS5 fallback warning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
       },
       "dependencies": {
         "@ageflow/core": "^0.6.0",
-        "@ageflow/executor": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
         "@ageflow/learning": "^0.5.0",
         "@ageflow/learning-sqlite": "^0.4.1",
         "@ageflow/mcp-server": "^0.5.0",
@@ -171,7 +171,7 @@
     },
     "packages/learning-sqlite": {
       "name": "@ageflow/learning-sqlite",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@ageflow/learning": "^0.5.0",
       },
@@ -186,7 +186,7 @@
       "version": "0.5.1",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
-        "@ageflow/executor": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
         "@ageflow/server": "^0.4.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "zod-to-json-schema": "^3.23.0",
@@ -255,7 +255,7 @@
       "version": "0.4.5",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
-        "@ageflow/executor": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -771,6 +771,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@ageflow/cli/@ageflow/learning-sqlite": ["@ageflow/learning-sqlite@0.4.2", "", { "dependencies": { "@ageflow/learning": "^0.5.0" } }, "sha512-/1lNQLIryqwKiWyhOtWN6GUiHpQTHFXkBeoBsfnkJ0R9nRc1qznXJnHKpGDFLgJYel7CeM9SxMK/jjxc7mNtuw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning-sqlite",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "SQLite + sqlite-vec storage for @ageflow/learning",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
   "type": "module",

--- a/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
+++ b/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for sqlite-vec integration in @ageflow/learning-sqlite.
+ *
+ * vec0 KNN search tests are gated behind SQLITE_VEC_AVAILABLE=1 because the
+ * extension is a native shared library that may not be present in CI.
+ * Run with:
+ *   SQLITE_VEC_AVAILABLE=1 bun run test
+ */
+
+import { Database } from "bun:sqlite";
+import type { SkillRecord } from "@ageflow/learning";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MIGRATIONS } from "../migrations.js";
+import { SqliteLearningStore } from "../sqlite-learning-store.js";
+import { SqliteSkillStore } from "../sqlite-skill-store.js";
+
+// ─── Feature flag ─────────────────────────────────────────────────────────────
+
+const VEC_AVAILABLE = process.env.SQLITE_VEC_AVAILABLE === "1";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkill(overrides: Partial<SkillRecord> = {}): SkillRecord {
+  return {
+    id: crypto.randomUUID(),
+    name: "test-skill",
+    description: "A test skill",
+    content: "# Skill\nDo the thing well.",
+    targetAgent: "analyze",
+    version: 0,
+    status: "active",
+    score: 0.5,
+    runCount: 0,
+    bestInLineage: true,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** Create a Float32Array of the given dimension filled with a value. */
+function makeEmbedding(dim: number, fill = 0.1): Float32Array {
+  return new Float32Array(dim).fill(fill);
+}
+
+// ─── FTS5 fallback — always runs ─────────────────────────────────────────────
+
+describe("SqliteLearningStore — FTS5 fallback (no sqlite-vec)", () => {
+  let store: SqliteLearningStore;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // In a normal test environment sqlite-vec is not available — the store
+    // constructor will call console.warn with the fallback message.
+    store = new SqliteLearningStore(new Database(":memory:"));
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("emits PERMANENT warning when sqlite-vec is unavailable", () => {
+    // This test asserts the warning only when vec is actually unavailable.
+    if (VEC_AVAILABLE) {
+      // If extension loaded, no warning should have been emitted.
+      expect(warnSpy).not.toHaveBeenCalled();
+    } else {
+      expect(warnSpy).toHaveBeenCalledOnce();
+      const [msg] = warnSpy.mock.calls[0] as [string];
+      expect(msg).toContain("[learning-sqlite]");
+      expect(msg).toContain("sqlite-vec");
+      expect(msg).toContain("FTS5");
+      // Must be actionable — include install hint
+      expect(msg).toContain("sqlite-vec");
+      expect(msg).toContain("vec0");
+    }
+  });
+
+  it("vecAvailable reflects extension load outcome", () => {
+    expect(store.vecAvailable).toBe(VEC_AVAILABLE);
+  });
+
+  it("search works via FTS5 when embedding is absent", async () => {
+    const skill = makeSkill({ description: "typescript error handling" });
+    await store.save(skill);
+    const results = await store.search("typescript error", 10);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.skill.id).toBe(skill.id);
+  });
+
+  it("search falls back to FTS5 even if queryEmbedding passed when vec unavailable", async () => {
+    if (VEC_AVAILABLE) return; // only meaningful when vec is absent
+    const skill = makeSkill({ description: "async queue processing" });
+    await store.save(skill);
+    const fakeEmbedding = makeEmbedding(1536);
+    const results = await store.search("async queue", 10, fakeEmbedding);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.skill.id).toBe(skill.id);
+  });
+
+  it("SkillRecord round-trip preserves embedding field", async () => {
+    // Embeddings are not stored in the skills SQL table — they live in
+    // skills_vec. So round-trip via get() will not return embedding.
+    // This test confirms embedding is accepted on save without errors.
+    const embedding = makeEmbedding(1536, 0.42);
+    const skill = makeSkill({ embedding });
+    // save must not throw even when vec is unavailable
+    await expect(store.save(skill)).resolves.toBeUndefined();
+    // get() returns the skill without embedding (vec table absent/skipped)
+    const loaded = await store.get(skill.id);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.id).toBe(skill.id);
+    // embedding is not persisted in skills table — expected undefined on load
+    expect(loaded?.embedding).toBeUndefined();
+  });
+});
+
+// ─── Warning fires every init (permanent) ────────────────────────────────────
+
+describe("SqliteLearningStore — warning fires every init", () => {
+  it("emits warning on each new store instance when vec unavailable", () => {
+    if (VEC_AVAILABLE) return; // skip when extension is present
+
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      new SqliteLearningStore(new Database(":memory:"));
+      new SqliteLearningStore(new Database(":memory:"));
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ─── SqliteSkillStore constructor — vecAvailable=false ───────────────────────
+
+describe("SqliteSkillStore — FTS5 path (vecAvailable=false)", () => {
+  let db: Database;
+  let store: SqliteSkillStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    for (const sql of MIGRATIONS) db.run(sql);
+    store = new SqliteSkillStore(db, false);
+  });
+
+  afterEach(() => db.close());
+
+  it("search uses FTS5 when vecAvailable=false even with embedding query", async () => {
+    const skill = makeSkill({ description: "concurrent batch processing" });
+    await store.save(skill);
+    const results = await store.search(
+      "concurrent batch",
+      10,
+      makeEmbedding(1536),
+    );
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.skill.id).toBe(skill.id);
+  });
+
+  it("delete removes skill without touching skills_vec", async () => {
+    const skill = makeSkill();
+    await store.save(skill);
+    await expect(store.delete(skill.id)).resolves.toBeUndefined();
+    expect(await store.get(skill.id)).toBeNull();
+  });
+});
+
+// ─── Vec0 KNN tests — gated on SQLITE_VEC_AVAILABLE=1 ────────────────────────
+
+describe.skipIf(!VEC_AVAILABLE)(
+  "SqliteLearningStore — vec0 KNN search (SQLITE_VEC_AVAILABLE=1 required)",
+  () => {
+    let store: SqliteLearningStore;
+
+    beforeEach(() => {
+      // Use a custom low dimension to keep tests fast
+      store = new SqliteLearningStore(new Database(":memory:"), {
+        embeddingDimensions: 4,
+      });
+    });
+
+    it("vecAvailable is true when extension loaded", () => {
+      expect(store.vecAvailable).toBe(true);
+    });
+
+    it("save skill with embedding, search returns it via KNN", async () => {
+      const embedding = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+      const skill = makeSkill({ embedding });
+      await store.save(skill);
+
+      // Query with the same vector — should be the nearest neighbor
+      const results = await store.search("", 5, embedding);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.skill.id).toBe(skill.id);
+    });
+
+    it("search returns nearest neighbor by cosine distance", async () => {
+      const near = makeSkill({
+        embedding: new Float32Array([1.0, 0.0, 0.0, 0.0]),
+      });
+      const far = makeSkill({
+        embedding: new Float32Array([0.0, 0.0, 0.0, 1.0]),
+      });
+      await store.save(near);
+      await store.save(far);
+
+      const query = new Float32Array([1.0, 0.0, 0.0, 0.0]);
+      const results = await store.search("", 5, query);
+      expect(results[0]?.skill.id).toBe(near.id);
+    });
+
+    it("relevance score is in [0,1]", async () => {
+      const skill = makeSkill({
+        embedding: new Float32Array([0.5, 0.5, 0.5, 0.5]),
+      });
+      await store.save(skill);
+      const results = await store.search(
+        "",
+        5,
+        new Float32Array([0.5, 0.5, 0.5, 0.5]),
+      );
+      expect(results[0]?.relevance).toBeGreaterThanOrEqual(0);
+      expect(results[0]?.relevance).toBeLessThanOrEqual(1);
+    });
+
+    it("delete cleans up skills_vec entry", async () => {
+      const embedding = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+      const skill = makeSkill({ embedding });
+      await store.save(skill);
+      await store.delete(skill.id);
+      // After deletion, KNN search should return nothing for that exact vector
+      const results = await store.search("", 5, embedding);
+      const ids = results.map((r) => r.skill.id);
+      expect(ids).not.toContain(skill.id);
+    });
+
+    it("search falls back to FTS5 when no queryEmbedding provided", async () => {
+      const skill = makeSkill({ description: "event sourcing pattern" });
+      await store.save(skill);
+      const results = await store.search("event sourcing", 10);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.skill.id).toBe(skill.id);
+    });
+  },
+);

--- a/packages/learning-sqlite/src/index.ts
+++ b/packages/learning-sqlite/src/index.ts
@@ -1,5 +1,6 @@
 // @ageflow/learning-sqlite — SQLite-backed stores for @ageflow/learning
-export { MIGRATIONS } from "./migrations.js";
+export { MIGRATIONS, makeVecTableSql } from "./migrations.js";
 export { SqliteSkillStore } from "./sqlite-skill-store.js";
 export { SqliteTraceStore } from "./sqlite-trace-store.js";
 export { SqliteLearningStore } from "./sqlite-learning-store.js";
+export type { SqliteLearningStoreOptions } from "./sqlite-learning-store.js";

--- a/packages/learning-sqlite/src/migrations.ts
+++ b/packages/learning-sqlite/src/migrations.ts
@@ -44,3 +44,15 @@ export const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_traces_workflow
    ON traces(workflow_name, run_at DESC)`,
 ] as const;
+
+/**
+ * SQL to create the sqlite-vec virtual table for embedding-based KNN search.
+ * Dimension must match the embedding size stored in SkillRecord.embedding.
+ * Only executed when the sqlite-vec extension is successfully loaded.
+ */
+export function makeVecTableSql(dimensions: number): string {
+  return `CREATE VIRTUAL TABLE IF NOT EXISTS skills_vec USING vec0(
+    skill_id TEXT PRIMARY KEY,
+    embedding float[${dimensions}]
+  )`;
+}

--- a/packages/learning-sqlite/src/sqlite-learning-store.ts
+++ b/packages/learning-sqlite/src/sqlite-learning-store.ts
@@ -8,22 +8,87 @@ import type {
   TraceFilter,
   TraceStore,
 } from "@ageflow/learning";
-import { MIGRATIONS } from "./migrations.js";
+import { MIGRATIONS, makeVecTableSql } from "./migrations.js";
 import { SqliteSkillStore } from "./sqlite-skill-store.js";
 import { SqliteTraceStore } from "./sqlite-trace-store.js";
+
+// ─── sqlite-vec extension loading ─────────────────────────────────────────────
+
+/**
+ * Default embedding dimension for vec0 virtual table.
+ * Must match the dimension of embeddings stored in SkillRecord.embedding.
+ * Override via SqliteLearningStoreOptions.embeddingDimensions.
+ */
+const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
+
+/**
+ * Attempt to load the sqlite-vec extension.
+ * Returns true if loaded successfully, false otherwise.
+ * Emits a PERMANENT warning on every failed load — callers should not suppress
+ * this (per spec §2.4: consumers must not be silently degraded).
+ */
+function tryLoadVec(db: Database, dimensions: number): boolean {
+  try {
+    // sqlite-vec ships the extension as "vec0" (the module entrypoint)
+    db.loadExtension("vec0");
+    db.run(makeVecTableSql(dimensions));
+    return true;
+  } catch (err) {
+    // PERMANENT warning — fires every init when extension is missing.
+    // This is intentional: silent fallback would hide a misconfiguration.
+    console.warn(
+      `[learning-sqlite] sqlite-vec extension failed to load — semantic search will fall back to FTS5 keyword matching. Install sqlite-vec (https://github.com/asg017/sqlite-vec) and ensure the vec0 shared library is on the extension search path to enable embedding-based skill retrieval. Error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+// ─── SqliteLearningStore options ──────────────────────────────────────────────
+
+export interface SqliteLearningStoreOptions {
+  /**
+   * Number of dimensions in the embedding vectors stored in SkillRecord.
+   * Must match the model used to produce embeddings.
+   * @default 1536
+   */
+  embeddingDimensions?: number;
+}
+
+// ─── SqliteLearningStore ──────────────────────────────────────────────────────
 
 /**
  * Convenience wrapper — single SQLite database backing both stores.
  * Implements SkillStore & TraceStore.
+ *
+ * At construction time, attempts to load the sqlite-vec extension for
+ * embedding-based KNN search. If the extension is unavailable, a PERMANENT
+ * warning is emitted and the store falls back to FTS5 keyword search.
+ *
+ * Embeddings are an external concern — this package stores and searches them
+ * but does not generate them. Produce embeddings upstream (e.g. via the
+ * reflection workflow) and pass them in via SkillRecord.embedding.
  */
 export class SqliteLearningStore implements SkillStore, TraceStore {
   private readonly skillStore: SqliteSkillStore;
   private readonly traceStore: SqliteTraceStore;
+  /** Whether the sqlite-vec extension loaded successfully at init. */
+  readonly vecAvailable: boolean;
 
-  constructor(pathOrDb: string | Database) {
+  constructor(
+    pathOrDb: string | Database,
+    options: SqliteLearningStoreOptions = {},
+  ) {
     const db = typeof pathOrDb === "string" ? new Database(pathOrDb) : pathOrDb;
+    const dimensions =
+      options.embeddingDimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
+
+    // Run base schema migrations first (skills, fts5, traces)
     for (const sql of MIGRATIONS) db.run(sql);
-    this.skillStore = new SqliteSkillStore(db);
+
+    // Attempt sqlite-vec extension load (permanent warning on failure)
+    this.vecAvailable = tryLoadVec(db, dimensions);
+
+    this.skillStore = new SqliteSkillStore(db, this.vecAvailable);
     this.traceStore = new SqliteTraceStore(db);
   }
 
@@ -55,8 +120,12 @@ export class SqliteLearningStore implements SkillStore, TraceStore {
     return this.skillStore.getBestInLineage(skillId);
   }
 
-  search(query: string, limit: number): Promise<ScoredSkill[]> {
-    return this.skillStore.search(query, limit);
+  search(
+    query: string,
+    limit: number,
+    queryEmbedding?: Float32Array,
+  ): Promise<ScoredSkill[]> {
+    return this.skillStore.search(query, limit, queryEmbedding);
   }
 
   list(): Promise<SkillRecord[]> {

--- a/packages/learning-sqlite/src/sqlite-skill-store.ts
+++ b/packages/learning-sqlite/src/sqlite-skill-store.ts
@@ -36,13 +36,18 @@ function rowToRecord(row: SkillRow): SkillRecord {
     runCount: row.run_count,
     bestInLineage: row.best_in_lineage === 1,
     createdAt: row.created_at,
+    // embedding is not stored as a row column — it lives in skills_vec
   };
 }
 
 // ─── SqliteSkillStore ─────────────────────────────────────────────────────────
 
 export class SqliteSkillStore implements SkillStore {
-  constructor(private readonly db: Database) {}
+  constructor(
+    private readonly db: Database,
+    /** Whether sqlite-vec was successfully loaded at init. */
+    private readonly vecAvailable: boolean = false,
+  ) {}
 
   async save(skill: SkillRecord): Promise<void> {
     // Insert or replace in skills table
@@ -85,6 +90,22 @@ export class SqliteSkillStore implements SkillStore {
         $name: skill.name,
         $description: skill.description,
       });
+
+    // Sync vec0 table if extension is available and skill has an embedding
+    if (this.vecAvailable && skill.embedding !== undefined) {
+      this.db
+        .query("DELETE FROM skills_vec WHERE skill_id = $id")
+        .run({ $id: skill.id });
+      this.db
+        .query(
+          `INSERT INTO skills_vec(skill_id, embedding)
+           VALUES ($id, $embedding)`,
+        )
+        .run({
+          $id: skill.id,
+          $embedding: skill.embedding,
+        });
+    }
   }
 
   async get(id: string): Promise<SkillRecord | null> {
@@ -182,7 +203,66 @@ export class SqliteSkillStore implements SkillStore {
     return row ? rowToRecord(row) : null;
   }
 
-  async search(query: string, limit: number): Promise<ScoredSkill[]> {
+  /**
+   * Search skills by query string or embedding.
+   *
+   * If sqlite-vec is available AND a queryEmbedding is provided, uses vec0
+   * KNN cosine-distance search. Otherwise falls back to FTS5 keyword search.
+   *
+   * @param query - Keyword query (used for FTS5 fallback)
+   * @param limit - Maximum results to return
+   * @param queryEmbedding - Optional embedding vector for semantic KNN search
+   */
+  async search(
+    query: string,
+    limit: number,
+    queryEmbedding?: Float32Array,
+  ): Promise<ScoredSkill[]> {
+    if (this.vecAvailable && queryEmbedding !== undefined) {
+      return this._searchVec(queryEmbedding, limit);
+    }
+    return this._searchFts(query, limit);
+  }
+
+  // ─── Vec0 KNN search ──────────────────────────────────────────────────────
+
+  private _searchVec(
+    queryEmbedding: Float32Array,
+    limit: number,
+  ): ScoredSkill[] {
+    interface VecRow {
+      skill_id: string;
+      distance: number;
+    }
+
+    const vecRows = this.db
+      .query<VecRow, { $embedding: Float32Array; $limit: number }>(
+        `SELECT skill_id, distance
+         FROM skills_vec
+         WHERE embedding MATCH $embedding
+         ORDER BY distance
+         LIMIT $limit`,
+      )
+      .all({ $embedding: queryEmbedding, $limit: limit });
+
+    const results: ScoredSkill[] = [];
+    for (const vecRow of vecRows) {
+      const skillRow = this.db
+        .query<SkillRow, { $id: string }>("SELECT * FROM skills WHERE id = $id")
+        .get({ $id: vecRow.skill_id });
+      if (skillRow) {
+        // sqlite-vec cosine distance is in [0,2] — convert to similarity [0,1]
+        const relevance = Math.max(0, Math.min(1, 1 - vecRow.distance / 2));
+        results.push({ skill: rowToRecord(skillRow), relevance });
+      }
+    }
+
+    return results;
+  }
+
+  // ─── FTS5 keyword search ──────────────────────────────────────────────────
+
+  private _searchFts(query: string, limit: number): ScoredSkill[] {
     interface FtsRow {
       skill_id: string;
       rank: number;
@@ -235,7 +315,13 @@ export class SqliteSkillStore implements SkillStore {
   }
 
   async delete(id: string): Promise<void> {
-    // Clean up FTS5 first
+    // Clean up vec0 first (if available)
+    if (this.vecAvailable) {
+      this.db
+        .query("DELETE FROM skills_vec WHERE skill_id = $id")
+        .run({ $id: id });
+    }
+    // Clean up FTS5
     this.db
       .query("DELETE FROM skills_fts WHERE skill_id = $id")
       .run({ $id: id });

--- a/packages/learning/src/types.ts
+++ b/packages/learning/src/types.ts
@@ -73,6 +73,13 @@ export const SkillRecordSchema = z.object({
   runCount: z.number().int().nonnegative(),
   bestInLineage: z.boolean(),
   createdAt: z.string().datetime(),
+  /**
+   * Optional embedding vector for semantic search via sqlite-vec.
+   * Produced externally (e.g. by the reflection workflow) and stored here.
+   * When present the SQLite store uses vec0 KNN search; otherwise
+   * falls back to FTS5 keyword search.
+   */
+  embedding: z.instanceof(Float32Array).optional(),
 });
 
 export type SkillRecord = z.infer<typeof SkillRecordSchema>;


### PR DESCRIPTION
Optional sqlite-vec integration for embedding-based skill retrieval per spec §2.4. Falls back to FTS5 with PERMANENT warning at every init when extension unavailable. SkillRecord gains optional embedding field (Float32Array). 14 new tests (6 gated behind SQLITE_VEC_AVAILABLE=1). No hard runtime dep. Bumps learning-sqlite 0.4.2→0.5.0. Closes #170.