### PR TITLE
fix(learning-sqlite): #199 — vec0 table uses cosine distance + relevance conversion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
     },
     "packages/learning-sqlite": {
       "name": "@ageflow/learning-sqlite",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@ageflow/learning": "^0.5.0",
       },

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning-sqlite",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "SQLite + sqlite-vec storage for @ageflow/learning",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
   "type": "module",

--- a/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
+++ b/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
@@ -210,6 +210,48 @@ describe.skipIf(!VEC_AVAILABLE)(
       expect(results[0]?.skill.id).toBe(near.id);
     });
 
+    it("cosine distance ordering: identical > similar > orthogonal", async () => {
+      // Three skills with 3-dimensional embeddings:
+      //   exact  = [1, 0, 0] — same direction as query (cosine distance 0)
+      //   similar = [0.9, 0.1, 0] — slightly off-axis (small cosine distance)
+      //   ortho  = [0, 1, 0] — orthogonal to query (cosine distance 1)
+      const exact = makeSkill({
+        embedding: new Float32Array([1, 0, 0]),
+        targetAgent: "cosine-test",
+      });
+      const similar = makeSkill({
+        embedding: new Float32Array([0.9, 0.1, 0]),
+        targetAgent: "cosine-test",
+      });
+      const ortho = makeSkill({
+        embedding: new Float32Array([0, 1, 0]),
+        targetAgent: "cosine-test",
+      });
+
+      // Use a fresh store with 3-dimensional embeddings
+      const store3d = new SqliteLearningStore(new Database(":memory:"), {
+        embeddingDimensions: 3,
+      });
+      await store3d.save(exact);
+      await store3d.save(similar);
+      await store3d.save(ortho);
+
+      const query = new Float32Array([1, 0, 0]);
+      const results = await store3d.search("", 3, query);
+
+      expect(results.length).toBe(3);
+
+      // Order must be: exact first, similar second, ortho last
+      expect(results[0]?.skill.id).toBe(exact.id);
+      expect(results[1]?.skill.id).toBe(similar.id);
+      expect(results[2]?.skill.id).toBe(ortho.id);
+
+      // Relevance must be strictly decreasing
+      const [r0, r1, r2] = results.map((r) => r.relevance);
+      expect(r0).toBeGreaterThan(r1 ?? -1);
+      expect(r1).toBeGreaterThan(r2 ?? -1);
+    });
+
     it("relevance score is in [0,1]", async () => {
       const skill = makeSkill({
         embedding: new Float32Array([0.5, 0.5, 0.5, 0.5]),

--- a/packages/learning-sqlite/src/migrations.ts
+++ b/packages/learning-sqlite/src/migrations.ts
@@ -53,6 +53,6 @@ export const MIGRATIONS = [
 export function makeVecTableSql(dimensions: number): string {
   return `CREATE VIRTUAL TABLE IF NOT EXISTS skills_vec USING vec0(
     skill_id TEXT PRIMARY KEY,
-    embedding float[${dimensions}]
+    embedding float[${dimensions}] distance_metric=cosine
   )`;
 }

--- a/packages/learning-sqlite/src/sqlite-skill-store.ts
+++ b/packages/learning-sqlite/src/sqlite-skill-store.ts
@@ -226,6 +226,21 @@ export class SqliteSkillStore implements SkillStore {
 
   // ─── Vec0 KNN search ──────────────────────────────────────────────────────
 
+  /**
+   * KNN search using vec0 cosine distance.
+   *
+   * The skills_vec table is created with `distance_metric=cosine`, so sqlite-vec
+   * returns cosine distance values in [0, 2]:
+   *   - 0 = identical direction (maximum similarity)
+   *   - 1 = orthogonal vectors
+   *   - 2 = opposite directions (minimum similarity)
+   *
+   * Relevance is derived as: `relevance = 1 - distance / 2`
+   * which maps the distance range [0, 2] to a relevance range [0, 1]:
+   *   - relevance 1.0 = perfect match
+   *   - relevance 0.5 = orthogonal (unrelated)
+   *   - relevance 0.0 = maximally dissimilar
+   */
   private _searchVec(
     queryEmbedding: Float32Array,
     limit: number,
@@ -251,7 +266,7 @@ export class SqliteSkillStore implements SkillStore {
         .query<SkillRow, { $id: string }>("SELECT * FROM skills WHERE id = $id")
         .get({ $id: vecRow.skill_id });
       if (skillRow) {
-        // sqlite-vec cosine distance is in [0,2] — convert to similarity [0,1]
+        // Cosine distance ∈ [0, 2] → relevance ∈ [0, 1]: relevance = 1 - distance/2
         const relevance = Math.max(0, Math.min(1, 1 - vecRow.distance / 2));
         results.push({ skill: rowToRecord(skillRow), relevance });
       }


### PR DESCRIPTION
Codex P1 follow-up to #197. vec0 table now uses distance_metric=cosine (matches typical embedding API conventions). Distance → relevance via 1 - distance/2 (cosine ∈ [0, 2] → relevance ∈ [0, 1]). 1 new gated test asserts ordering. Bumps learning-sqlite 0.5.0→0.5.1. Closes #199.