### PR TITLE
fix(core): #198 — preserve task-key inference in defineWorkflowFactory

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/__tests__/builders.test.ts
+++ b/packages/core/src/__tests__/builders.test.ts
@@ -583,7 +583,7 @@ describe("defineWorkflowFactory", () => {
   });
 
   it("factory called with input returns a valid WorkflowDef", () => {
-    const createPipeline = defineWorkflowFactory<PipelineInput>((input) => ({
+    const createPipeline = defineWorkflowFactory((input: PipelineInput) => ({
       name: "test-pipeline",
       tasks: {
         analyze: {
@@ -605,7 +605,7 @@ describe("defineWorkflowFactory", () => {
   });
 
   it("input typing flows through — return type is WorkflowDef", () => {
-    const createPipeline = defineWorkflowFactory<PipelineInput>((input) => ({
+    const createPipeline = defineWorkflowFactory((input: PipelineInput) => ({
       name: "type-check-pipeline",
       tasks: {
         analyze: {
@@ -640,28 +640,27 @@ describe("defineWorkflowFactory", () => {
       prompt: ({ findings }) => `Summarize: ${findings.join(", ")}`,
     });
 
-    const createRepoPipeline = defineWorkflowFactory<{
-      repo: string;
-      summarize: boolean;
-    }>((input) => ({
-      name: `repo-pipeline-${input.repo}`,
-      tasks: input.summarize
-        ? {
-            scan: { agent: analyzeAgent2, input: { path: input.repo } },
-            summarize: {
-              agent: summarizeAgent,
-              dependsOn: ["scan"],
-              input: (
-                ctx: Record<string, { output: { findings: string[] } }>,
-              ) => ({
-                findings: ctx.scan?.output.findings ?? [],
-              }),
+    const createRepoPipeline = defineWorkflowFactory(
+      (input: { repo: string; summarize: boolean }) => ({
+        name: `repo-pipeline-${input.repo}`,
+        tasks: input.summarize
+          ? {
+              scan: { agent: analyzeAgent2, input: { path: input.repo } },
+              summarize: {
+                agent: summarizeAgent,
+                dependsOn: ["scan"],
+                input: (
+                  ctx: Record<string, { output: { findings: string[] } }>,
+                ) => ({
+                  findings: ctx.scan?.output.findings ?? [],
+                }),
+              },
+            }
+          : {
+              scan: { agent: analyzeAgent2, input: { path: input.repo } },
             },
-          }
-        : {
-            scan: { agent: analyzeAgent2, input: { path: input.repo } },
-          },
-    }));
+      }),
+    );
 
     const wfWithSummary = createRepoPipeline({
       repo: "./packages",

--- a/packages/core/src/__tests__/types.test-d.ts
+++ b/packages/core/src/__tests__/types.test-d.ts
@@ -1,6 +1,11 @@
 import { assertType, describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
-import { defineAgent, defineFunction, resolveAgentDef } from "../builders.js";
+import {
+  defineAgent,
+  defineFunction,
+  defineWorkflowFactory,
+  resolveAgentDef,
+} from "../builders.js";
 import type {
   AgentDef,
   BoundCtx,
@@ -206,6 +211,67 @@ describe("CtxFor with fn task dep", () => {
         readonly output: { orders: string[]; total: number };
         readonly _source: "function";
       };
+    }>({} as Ctx);
+  });
+});
+
+// ─── defineWorkflowFactory task-key inference (#198) ─────────────────────────
+
+const factoryAgentA = defineAgent({
+  runner: "claude",
+  input: z.object({}),
+  output: z.object({ x: z.string() }),
+  prompt: () => "a",
+});
+
+const factoryAgentB = defineAgent({
+  runner: "claude",
+  input: z.object({}),
+  output: z.object({ y: z.number() }),
+  prompt: () => "b",
+});
+
+describe("defineWorkflowFactory preserves task-key inference", () => {
+  it("task keys are 'a' | 'b', not string (TasksMap-wide)", () => {
+    const f = defineWorkflowFactory((_input: { name: string }) => ({
+      name: "x",
+      tasks: {
+        a: { agent: factoryAgentA, input: () => ({}) },
+        b: {
+          agent: factoryAgentB,
+          dependsOn: ["a"] as const,
+          input: () => ({}),
+        },
+      },
+    }));
+
+    const wf = f({ name: "test" });
+
+    // keyof Tasks must be the literal union "a" | "b", not the wide string type
+    expectTypeOf<keyof typeof wf.tasks>().toEqualTypeOf<"a" | "b">();
+  });
+
+  it("CtxFor narrows correctly on a factory-produced WorkflowDef", () => {
+    const f = defineWorkflowFactory((_input: { name: string }) => ({
+      name: "x",
+      tasks: {
+        a: { agent: factoryAgentA, input: () => ({}) },
+        b: {
+          agent: factoryAgentB,
+          dependsOn: ["a"] as const,
+          input: () => ({}),
+        },
+      },
+    }));
+
+    const wf = f({ name: "test" });
+    type Tasks = typeof wf.tasks;
+
+    // CtxFor<Tasks, "b"> should have key "a" with output { x: string }, not the
+    // wide TasksMap shape where output is unknown for all string keys
+    type Ctx = CtxFor<Tasks, "b">;
+    assertType<{
+      readonly a: { readonly output: { x: string }; readonly _source: "agent" };
     }>({} as Ctx);
   });
 });

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -201,6 +201,10 @@ export function defineWorkflow<const T extends TasksMap>(
  * Removes per-pipeline boilerplate and the typing footgun of manually annotating
  * the factory return type.
  *
+ * Task-key inference is fully preserved: the return type of the produced factory
+ * carries the exact `T` inferred from `fn`'s return shape, so `CtxFor<>` and
+ * other per-key utilities narrow correctly without a second generic argument.
+ *
  * @example
  * // Before (manual factory):
  * export function createPipeline(input: PipelineInput): WorkflowDef<...> {
@@ -216,7 +220,7 @@ export function defineWorkflow<const T extends TasksMap>(
  * v2: optional second argument for Zod input validation schema (deferred).
  * When added, the factory will parse+validate `input` before calling `fn`.
  */
-export function defineWorkflowFactory<I, const T extends TasksMap = TasksMap>(
+export function defineWorkflowFactory<I, const T extends TasksMap>(
   fn: (input: I) => WorkflowDef<T>,
 ): (input: I) => WorkflowDef<T> {
   return (input: I) => defineWorkflow(fn(input));


### PR DESCRIPTION
Codex P1 follow-up to #196. Removed the `= TasksMap` default on T; TS now infers T from lambda return shape. Callers annotate the lambda param instead of passing explicit type arg: `defineWorkflowFactory((input: I) => ...)`. CtxFor<> narrows correctly. 2 new type tests. Bumps core 0.6.4→0.6.5. Closes #198.