### PR TITLE
fix(core): #203 — restore one-arg generic call shape for defineWorkflowFactory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/core": {
       "name": "@ageflow/core",
-      "version": "0.6.4",
+      "version": "0.6.6",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "vitest": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/core",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Type-safe DSL for multi-agent AI workflows — defineAgent, defineWorkflow, loop, sessionToken",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/core",
   "type": "module",

--- a/packages/core/src/__tests__/types.test-d.ts
+++ b/packages/core/src/__tests__/types.test-d.ts
@@ -275,3 +275,76 @@ describe("defineWorkflowFactory preserves task-key inference", () => {
     }>({} as Ctx);
   });
 });
+
+// ─── defineWorkflowFactory back-compat call shapes (#203) ────────────────────
+
+interface PipelineInput203 {
+  repoPath: string;
+}
+
+describe("defineWorkflowFactory call-shape back-compat (#203)", () => {
+  it("old shape: explicit <I> type arg compiles (T = TasksMap, wide)", () => {
+    // This was the pre-v0.6.5 canonical pattern. T resolves to TasksMap (wide).
+    const f = defineWorkflowFactory<PipelineInput203>((input) => ({
+      name: "back-compat",
+      tasks: {
+        a: { agent: factoryAgentA, input: () => ({}) },
+        b: {
+          agent: factoryAgentB,
+          dependsOn: ["a"] as const,
+          input: () => ({}),
+        },
+      },
+    }));
+
+    const wf = f({ repoPath: "./src" });
+
+    // Input type is preserved correctly
+    expectTypeOf(f).parameter(0).toEqualTypeOf<PipelineInput203>();
+
+    // T = TasksMap, so task keys are string (wide) — acceptable back-compat behaviour
+    expectTypeOf<keyof typeof wf.tasks>().toEqualTypeOf<string>();
+  });
+
+  it("new shape: lambda annotation compiles and narrows task keys", () => {
+    // Canonical v0.6.6+ pattern: annotate the lambda parameter instead.
+    const f = defineWorkflowFactory((input: PipelineInput203) => ({
+      name: "new-shape",
+      tasks: {
+        a: { agent: factoryAgentA, input: () => ({}) },
+        b: {
+          agent: factoryAgentB,
+          dependsOn: ["a"] as const,
+          input: () => ({}),
+        },
+      },
+    }));
+
+    const wf = f({ repoPath: "./src" });
+
+    // Input type is preserved correctly
+    expectTypeOf(f).parameter(0).toEqualTypeOf<PipelineInput203>();
+
+    // T is inferred — task keys are narrow "a" | "b"
+    expectTypeOf<keyof typeof wf.tasks>().toEqualTypeOf<"a" | "b">();
+  });
+
+  it("both shapes produce a WorkflowDef at runtime", () => {
+    const f1 = defineWorkflowFactory<PipelineInput203>((input) => ({
+      name: "wf1",
+      tasks: { a: { agent: factoryAgentA, input: () => ({}) } },
+    }));
+
+    const f2 = defineWorkflowFactory((input: PipelineInput203) => ({
+      name: "wf2",
+      tasks: { a: { agent: factoryAgentA, input: () => ({}) } },
+    }));
+
+    const wf1 = f1({ repoPath: "./src" });
+    const wf2 = f2({ repoPath: "./src" });
+
+    // Both return WorkflowDef shapes (have a tasks property)
+    assertType<{ tasks: TasksMap }>(wf1);
+    assertType<{ tasks: TasksMap }>(wf2);
+  });
+});

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -205,25 +205,47 @@ export function defineWorkflow<const T extends TasksMap>(
  * carries the exact `T` inferred from `fn`'s return shape, so `CtxFor<>` and
  * other per-key utilities narrow correctly without a second generic argument.
  *
- * @example
- * // Before (manual factory):
- * export function createPipeline(input: PipelineInput): WorkflowDef<...> {
- *   return defineWorkflow({ name: "pipeline", tasks: { ... } });
- * }
+ * ## Call shapes
  *
- * // After (using helper):
+ * **Preferred — lambda annotation (narrow inference):**
+ * ```ts
+ * export const createPipeline = defineWorkflowFactory(
+ *   (input: PipelineInput) => ({ name: "pipeline", tasks: { ... } }),
+ * );
+ * ```
+ * TypeScript infers both `I` and `T` from the lambda, giving you the exact
+ * task-key union on the returned `WorkflowDef`.
+ *
+ * **Back-compat — explicit `<I>` (wide type, T = TasksMap):**
+ * ```ts
  * export const createPipeline = defineWorkflowFactory<PipelineInput>(
  *   (input) => ({ name: "pipeline", tasks: { ... } }),
  * );
+ * ```
+ * Equivalent to pre-v0.6.5 behaviour. Task keys are typed as `string` (wide),
+ * but the factory compiles and runs correctly. Migrate to the lambda-annotation
+ * form when you need narrow `CtxFor<>` / task-key inference.
  *
  * @remarks
  * v2: optional second argument for Zod input validation schema (deferred).
  * When added, the factory will parse+validate `input` before calling `fn`.
  */
+// Overload 1: lambda annotation — T inferred from fn return shape (preferred, narrow)
 export function defineWorkflowFactory<I, const T extends TasksMap>(
   fn: (input: I) => WorkflowDef<T>,
-): (input: I) => WorkflowDef<T> {
-  return (input: I) => defineWorkflow(fn(input));
+): (input: I) => WorkflowDef<T>;
+// Overload 2: explicit <I> only — T defaults to TasksMap (back-compat, wide)
+export function defineWorkflowFactory<I>(
+  fn: (input: I) => WorkflowDef<TasksMap>,
+): (input: I) => WorkflowDef<TasksMap>;
+// Implementation
+export function defineWorkflowFactory(
+  // biome-ignore lint/suspicious/noExplicitAny: overload implementation signature
+  fn: (input: any) => WorkflowDef<any>,
+  // biome-ignore lint/suspicious/noExplicitAny: overload implementation signature
+): (input: any) => WorkflowDef<any> {
+  // biome-ignore lint/suspicious/noExplicitAny: overload implementation signature
+  return (input: any) => defineWorkflow(fn(input));
 }
 
 /**


### PR DESCRIPTION
Codex P1 follow-up to #201. PR #201 broke `defineWorkflowFactory<MyInput>(fn)` shape. Now provides 2 overloads: lambda-annotation (narrow, canonical) + explicit `<I>` (back-compat, T defaults to TasksMap). Both work. 3 new type tests. Bumps core 0.6.5→0.6.6. Closes #203.