### PR TITLE
fix(learning-sqlite): #206 — wrap vec migration in transaction (atomic)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
     },
     "packages/learning-sqlite": {
       "name": "@ageflow/learning-sqlite",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@ageflow/learning": "^0.5.0",
       },

--- a/packages/learning-sqlite/package.json
+++ b/packages/learning-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/learning-sqlite",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "SQLite + sqlite-vec storage for @ageflow/learning",
   "homepage": "https://github.com/Neftedollar/ageflow/tree/master/packages/learning-sqlite",
   "type": "module",

--- a/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
+++ b/packages/learning-sqlite/src/__tests__/sqlite-vec.test.ts
@@ -287,6 +287,72 @@ describe.skipIf(!VEC_AVAILABLE)(
   },
 );
 
+// ─── Atomic migration rollback — always runs (no sqlite-vec required) ─────────
+
+describe("skills_vec migration — atomic rollback on error", () => {
+  it("transaction semantics: rollback preserves state on mid-flight throw", () => {
+    // This test does NOT require sqlite-vec. It validates that bun:sqlite
+    // db.transaction() rolls back on throw — which is the contract the
+    // migration fix (#206) relies on.
+    //
+    // We simulate the migration pattern (snapshot → DROP → CREATE → INSERT)
+    // using regular SQLite tables, inject a failure during the CREATE step,
+    // and assert: (a) the error propagates, (b) the original table is intact.
+
+    const db = new Database(":memory:");
+
+    // Create an "old" table with a couple of rows.
+    db.run("CREATE TABLE skills_vec (skill_id TEXT PRIMARY KEY, val INTEGER)");
+    db.run("INSERT INTO skills_vec VALUES ('skill-1', 10)");
+    db.run("INSERT INTO skills_vec VALUES ('skill-2', 20)");
+
+    // Attempt the migration inside a transaction, but throw mid-way.
+    let threw = false;
+    try {
+      db.transaction(() => {
+        // Snapshot
+        const rows = db
+          .query<{ skill_id: string; val: number }, []>(
+            "SELECT skill_id, val FROM skills_vec",
+          )
+          .all();
+        // Drop old
+        db.exec("DROP TABLE skills_vec");
+        // Simulate a failure during recreation (e.g. bad SQL / extension error)
+        if (rows.length >= 0) {
+          throw new Error("simulated mid-migration failure");
+        }
+        // The INSERT block below is never reached.
+        for (const row of rows) {
+          db.run("INSERT INTO skills_vec VALUES (?, ?)", [
+            row.skill_id,
+            row.val,
+          ]);
+        }
+      })();
+    } catch {
+      threw = true;
+    }
+
+    // Error must have propagated.
+    expect(threw).toBe(true);
+
+    // The original table must be intact — transaction rolled back the DROP.
+    const rows = db
+      .query<{ skill_id: string; val: number }, []>(
+        "SELECT skill_id, val FROM skills_vec ORDER BY skill_id",
+      )
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.skill_id).toBe("skill-1");
+    expect(rows[0]?.val).toBe(10);
+    expect(rows[1]?.skill_id).toBe("skill-2");
+    expect(rows[1]?.val).toBe(20);
+
+    db.close();
+  });
+});
+
 // ─── detectVecDistanceMetric unit tests — always runs ────────────────────────
 
 describe("detectVecDistanceMetric", () => {

--- a/packages/learning-sqlite/src/sqlite-learning-store.ts
+++ b/packages/learning-sqlite/src/sqlite-learning-store.ts
@@ -44,19 +44,22 @@ function tryLoadVec(db: Database, dimensions: number): boolean {
       console.warn(
         `[learning-sqlite] migrating skills_vec from ${existing} → cosine distance. Existing embeddings will be repopulated.`,
       );
-      // Read existing rows from the old table before dropping it.
-      // Embeddings are stored only in skills_vec (not in the skills table).
-      const oldRows = db
-        .query<{ skill_id: string; embedding: Buffer }, []>(
-          "SELECT skill_id, embedding FROM skills_vec",
-        )
-        .all();
-      db.exec("DROP TABLE skills_vec");
-      db.exec(makeVecTableSql(dimensions));
-      const insert = db.prepare(
-        "INSERT INTO skills_vec (skill_id, embedding) VALUES (?, ?)",
-      );
-      for (const r of oldRows) insert.run(r.skill_id, r.embedding);
+      // Wrap the destructive migration in a transaction so that a failure
+      // during DROP/CREATE/INSERT rolls back atomically — the original table
+      // is preserved rather than left in a corrupt/absent state.
+      db.transaction(() => {
+        const oldRows = db
+          .query<{ skill_id: string; embedding: Buffer }, []>(
+            "SELECT skill_id, embedding FROM skills_vec",
+          )
+          .all();
+        db.exec("DROP TABLE skills_vec");
+        db.exec(makeVecTableSql(dimensions));
+        const insert = db.prepare(
+          "INSERT INTO skills_vec (skill_id, embedding) VALUES (?, ?)",
+        );
+        for (const row of oldRows) insert.run(row.skill_id, row.embedding);
+      })();
     } else {
       // No existing table or already cosine — create if absent (IF NOT EXISTS).
       db.run(makeVecTableSql(dimensions));


### PR DESCRIPTION
Codex P1 follow-up to #205. Migration was: snapshot → DROP → CREATE → INSERT. Mid-flight failure left db without skills_vec. Now wrapped in bun:sqlite transaction with automatic rollback. New non-gated test confirms rollback semantics. Bumps learning-sqlite 0.5.2→0.5.3. Closes #206.