### PR TITLE
feat(dev-workflow): #194 sub-PR 1 — scaffold packages/dev-workflow/ skeleton

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,26 @@
         "zod": ">=3.23.0 <4.0.0",
       },
     },
+    "packages/dev-workflow": {
+      "name": "@ageflow/dev-workflow",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ageflow/core": "^0.6.0",
+        "@ageflow/executor": "^0.7.0",
+        "@ageflow/learning": "^0.5.0",
+        "@ageflow/learning-sqlite": "^0.5.0",
+        "@ageflow/runner-claude": "^0.3.5",
+        "@ageflow/runner-codex": "^0.3.5",
+        "@ageflow/testing": "^0.3.8",
+        "execa": "^9.5.0",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "packages/executor": {
       "name": "@ageflow/executor",
       "version": "0.7.0",
@@ -230,7 +250,7 @@
       "name": "@ageflow/runner-claude",
       "version": "0.3.5",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.6.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -242,7 +262,7 @@
       "name": "@ageflow/runner-codex",
       "version": "0.3.5",
       "dependencies": {
-        "@ageflow/core": "workspace:*",
+        "@ageflow/core": "^0.6.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
@@ -291,6 +311,8 @@
     "@ageflow/cli": ["@ageflow/cli@workspace:packages/cli"],
 
     "@ageflow/core": ["@ageflow/core@workspace:packages/core"],
+
+    "@ageflow/dev-workflow": ["@ageflow/dev-workflow@workspace:packages/dev-workflow"],
 
     "@ageflow/dogfooding": ["@ageflow/dogfooding@workspace:dogfooding"],
 
@@ -438,6 +460,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
@@ -560,6 +586,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
@@ -569,6 +597,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -586,6 +616,8 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -595,6 +627,8 @@
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -608,7 +642,11 @@
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -644,6 +682,8 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -655,6 +695,8 @@
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -671,6 +713,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -726,6 +770,8 @@
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
@@ -748,6 +794,8 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -768,6 +816,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
@@ -777,6 +827,8 @@
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/packages/dev-workflow/CLAUDE.md
+++ b/packages/dev-workflow/CLAUDE.md
@@ -1,0 +1,45 @@
+# dev-workflow — AgentFlow Engineering Operations
+
+This package is the dogfood engineering loop for the ageflow monorepo itself.
+It implements a multi-stage pipeline (PLAN → BUILD → TEST → VERIFY → SHIP)
+as an ageflow workflow. Every product-code change to ageflow goes through it.
+
+**Design spec:** `../../docs/superpowers/specs/2026-04-15-agentflow-design.md`
+
+**Status:** Sub-PR 1 of 5 from issue #194 — scaffold only, no real LLM tasks yet.
+
+**How to invoke:**
+```
+bun run --filter @ageflow/dev-workflow dev-workflow <issue-number>
+bun run --filter @ageflow/dev-workflow dev-workflow --dry-run <issue-number>
+```
+
+## Focus keywords (activate standing roles)
+
+ageflow touches these domains:
+
+- **TypeScript, Bun, monorepo, Turborepo, Vitest** — baseline toolchain
+- **ageflow, DSL, defineAgent, defineWorkflow, loop, executor** — core framework
+- **runner-claude, runner-codex, runner-api, MCP, subprocess** — runner surface
+- **learning, learning-sqlite, reflection, skill injection** — learning layer
+- **security, prompt injection, Zod, safePath, sanitizeInput** — security surface
+- **DX, CLI, typechecking, lint, biome** — developer experience
+
+Parsed by focus-parser (sub-PR 2) → standing roles per `docs/role-capabilities.md`:
+
+- `security` / `prompt injection` / `Zod` → `engineering-security-engineer` at PLAN + VERIFY
+- `ageflow` / `LLM` / `MCP` → `engineering-ai-engineer` at PLAN + BUILD + VERIFY
+- `DX` / `CLI` / `typescript` → `engineering-software-architect` at PLAN + VERIFY
+- `executor` / `runner` → `engineering-backend-architect` at PLAN + VERIFY
+
+## Project-specific rules
+
+- **Spec adherence.** Every code change is reviewed against the agentflow design
+  doc (`docs/superpowers/specs/2026-04-15-agentflow-design.md`) by a
+  `spec-adherence-reviewer` role at VERIFY step (sub-PR 2+).
+- **Version bumps.** Follow semver: patch for fixes, minor for features.
+  Bump in package.json only — changeset automation TBD.
+- **No publish.** This package is `private: true` — never published to npm.
+- **dev-workflow writes only to `packages/` and `docs/`**, never to its own
+  source tree during a pipeline execution run.
+- **No real LLM calls in this file or shared/** until sub-PR 4.

--- a/packages/dev-workflow/README.md
+++ b/packages/dev-workflow/README.md
@@ -1,0 +1,60 @@
+# @ageflow/dev-workflow
+
+Dogfood package: ageflow running its own engineering pipeline.
+
+## Purpose
+
+Every code change to the ageflow monorepo goes through this pipeline:
+PLAN → BUILD → TEST → VERIFY → SHIP — implemented as an ageflow workflow.
+This is the strategic commitment from issue #194 to use our own tool in anger.
+
+## Status: scaffold — sub-PR 1 of 5 (issue #194)
+
+| Sub-PR | Status | Contents |
+|--------|--------|----------|
+| 1 (this) | merged | Package scaffold, pipeline stubs, run.ts wiring |
+| 2 | pending | Role library + ageflow-orchestrator role |
+| 3 | pending | Learning hooks + SQLite store |
+| 4 | pending | First real issue run through dogfood |
+| 5 | pending | 10-run retrospective + tuning |
+
+## Invoke (once sub-PR 4 is merged)
+
+```sh
+# Run pipeline for a GitHub issue:
+bun run --filter @ageflow/dev-workflow dev-workflow <issue-number>
+
+# Dry-run (no LLM calls, logs would-be plan):
+bun run --filter @ageflow/dev-workflow dev-workflow --dry-run <issue-number>
+```
+
+## What is NOT implemented yet
+
+- **Real LLM tasks** — pipeline stubs use `defineFunction` no-ops. Real
+  role-based agents land in sub-PR 2.
+- **Executor dispatch** — `run.ts` loads the issue and logs the plan but does
+  not call `WorkflowExecutor.stream()`. That wiring lands in sub-PR 4.
+- **Git worktree creation** — `createWorktree()` logs the would-be command
+  but does not run `git worktree add`. Real call lands in sub-PR 4.
+- **Learning hooks** — `@ageflow/learning` is declared as a dependency but
+  not wired. Integration lands in sub-PR 3.
+- **Role library** — standing roles parsed from CLAUDE.md focus keywords
+  land in sub-PR 2 alongside the ageflow-orchestrator role definition.
+
+## Package structure
+
+```
+packages/dev-workflow/
+├── run.ts               ← entry point (issue loader + pipeline router)
+├── CLAUDE.md            ← focus keywords + project rules for AI agents
+├── pipelines/
+│   ├── feature.ts       ← PLAN → BUILD → TEST → VERIFY → SHIP
+│   ├── bugfix.ts        ← TRIAGE → REPRODUCE → FIX → TEST → VERIFY → SHIP
+│   ├── docs.ts          ← DRAFT → REVIEW → PUBLISH
+│   └── release.ts       ← CHANGELOG → BUMP → PUBLISH → ANNOUNCE
+└── shared/
+    ├── types.ts          ← Issue, PipelineType, WorkflowInput schemas
+    ├── issue-loader.ts   ← loadIssue() + determinePipeline() via gh CLI
+    ├── runners.ts        ← initRunners() (codex primary, claude optional)
+    └── worktree.ts       ← createWorktree() + removeWorktree() stubs
+```

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ageflow/dev-workflow",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check .",
+    "dev-workflow": "bun run run.ts"
+  },
+  "dependencies": {
+    "@ageflow/core": "^0.6.0",
+    "@ageflow/executor": "^0.7.0",
+    "@ageflow/runner-claude": "^0.3.5",
+    "@ageflow/runner-codex": "^0.3.5",
+    "@ageflow/learning": "^0.5.0",
+    "@ageflow/learning-sqlite": "^0.5.0",
+    "@ageflow/testing": "^0.3.8",
+    "execa": "^9.5.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/dev-workflow/pipelines/bugfix.ts
+++ b/packages/dev-workflow/pipelines/bugfix.ts
@@ -1,0 +1,70 @@
+// Bugfix pipeline — TRIAGE → REPRODUCE → FIX → TEST → VERIFY → SHIP.
+//
+// Sub-PR 1: skeleton stub. All tasks are defineFunction no-ops returning {}.
+// Real role-based agents (triage analyst, engineer, code reviewer) land in
+// sub-PR 2. LLM dispatch lands in sub-PR 4.
+
+import { defineFunction, defineWorkflowFactory } from "@ageflow/core";
+import { z } from "zod";
+import type { WorkflowInput } from "../shared/types.js";
+
+const noopFn = defineFunction({
+  name: "noop",
+  input: z.object({}).passthrough(),
+  output: z.object({}),
+  execute: async () => ({}),
+});
+
+export const createBugfixPipeline = defineWorkflowFactory(
+  (input: WorkflowInput) => ({
+    name: "bugfix-pipeline",
+    tasks: {
+      // TRIAGE — classify severity, identify affected files.
+      // Sub-PR 2: replace with triage-analyst agent.
+      triage: {
+        fn: noopFn,
+        input: () => ({ issueNumber: input.issue.number }),
+      },
+
+      // REPRODUCE — write a failing test that captures the bug.
+      // Sub-PR 2: replace with engineer agent.
+      reproduce: {
+        fn: noopFn,
+        dependsOn: ["triage"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // FIX — implement the minimal code change.
+      // Sub-PR 2: replace with build role agent.
+      fix: {
+        fn: noopFn,
+        dependsOn: ["reproduce"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // TEST — confirm the failing test now passes.
+      // Sub-PR 2: replace with test-runner agent.
+      test: {
+        fn: noopFn,
+        dependsOn: ["fix"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // VERIFY — regression check + security review.
+      // Sub-PR 2: replace with verify agents + loop for rework.
+      verify: {
+        fn: noopFn,
+        dependsOn: ["test"] as const,
+        input: () => ({}),
+      },
+
+      // SHIP — push branch + open PR.
+      // Sub-PR 2: replace with ship agent.
+      ship: {
+        fn: noopFn,
+        dependsOn: ["verify"] as const,
+        input: () => ({ issueNumber: input.issue.number }),
+      },
+    },
+  }),
+);

--- a/packages/dev-workflow/pipelines/docs.ts
+++ b/packages/dev-workflow/pipelines/docs.ts
@@ -1,0 +1,54 @@
+// Docs pipeline — DRAFT → REVIEW → PUBLISH.
+//
+// Used for issues labelled `docs` or `content`: API docs, README updates,
+// design specs, and CLAUDE.md maintenance.
+//
+// Sub-PR 1: skeleton stub. All tasks are defineFunction no-ops returning {}.
+// Real role-based agents (tech-writer, code-reviewer) land in sub-PR 2.
+
+import { defineFunction, defineWorkflowFactory } from "@ageflow/core";
+import { z } from "zod";
+import type { WorkflowInput } from "../shared/types.js";
+
+const noopFn = defineFunction({
+  name: "noop",
+  input: z.object({}).passthrough(),
+  output: z.object({}),
+  execute: async () => ({}),
+});
+
+export const createDocsPipeline = defineWorkflowFactory(
+  (input: WorkflowInput) => ({
+    name: "docs-pipeline",
+    tasks: {
+      // DRAFT — write or update the documentation content.
+      // Sub-PR 2: replace with technical-writer agent.
+      draft: {
+        fn: noopFn,
+        input: () => ({
+          issueNumber: input.issue.number,
+          specPath: input.specPath,
+        }),
+      },
+
+      // REVIEW — accuracy check against design spec and existing code.
+      // Sub-PR 2: replace with code-reviewer + spec-adherence-reviewer agents.
+      review: {
+        fn: noopFn,
+        dependsOn: ["draft"] as const,
+        input: () => ({ specPath: input.specPath }),
+      },
+
+      // PUBLISH — commit changes + open PR.
+      // Sub-PR 2: replace with ship agent.
+      publish: {
+        fn: noopFn,
+        dependsOn: ["review"] as const,
+        input: () => ({
+          worktreePath: input.worktreePath,
+          issueNumber: input.issue.number,
+        }),
+      },
+    },
+  }),
+);

--- a/packages/dev-workflow/pipelines/feature.ts
+++ b/packages/dev-workflow/pipelines/feature.ts
@@ -1,0 +1,64 @@
+// Feature pipeline — PLAN → BUILD → TEST → VERIFY → SHIP DAG.
+//
+// Sub-PR 1: skeleton stub. All tasks are defineFunction no-ops that return {}.
+// Real role-based agents land in sub-PR 2. LLM dispatch lands in sub-PR 4.
+//
+// Uses defineWorkflowFactory to validate the helper works in production code
+// (part of the dogfood proof — closes the loop on #192/#196).
+
+import { defineFunction, defineWorkflowFactory } from "@ageflow/core";
+import { z } from "zod";
+import type { WorkflowInput } from "../shared/types.js";
+
+const noopFn = defineFunction({
+  name: "noop",
+  input: z.object({}).passthrough(),
+  output: z.object({}),
+  execute: async () => ({}),
+});
+
+export const createFeaturePipeline = defineWorkflowFactory(
+  (input: WorkflowInput) => ({
+    name: "feature-pipeline",
+    tasks: {
+      // PLAN phase — parallel design/security/ai review.
+      // Sub-PR 2: replace with real role agents (pm, architect, security, ai).
+      plan: {
+        fn: noopFn,
+        input: () => ({ issueNumber: input.issue.number }),
+      },
+
+      // BUILD phase — implement plan in worktree.
+      // Sub-PR 2: replace with build role agent + session sharing.
+      build: {
+        fn: noopFn,
+        dependsOn: ["plan"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // TEST phase — run `bun test` in worktree.
+      // Sub-PR 2: replace with test-runner agent.
+      test: {
+        fn: noopFn,
+        dependsOn: ["build"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // VERIFY phase — reality-check + code-review + security-review.
+      // Sub-PR 2: replace with verify role agents + loop for re-work.
+      verify: {
+        fn: noopFn,
+        dependsOn: ["test"] as const,
+        input: () => ({}),
+      },
+
+      // SHIP phase — push branch + open PR via gh.
+      // Sub-PR 2: replace with ship agent.
+      ship: {
+        fn: noopFn,
+        dependsOn: ["verify"] as const,
+        input: () => ({ issueNumber: input.issue.number }),
+      },
+    },
+  }),
+);

--- a/packages/dev-workflow/pipelines/release.ts
+++ b/packages/dev-workflow/pipelines/release.ts
@@ -1,0 +1,59 @@
+// Release pipeline — CHANGELOG → BUMP → PUBLISH → ANNOUNCE.
+//
+// Used for issues labelled `release`. Covers semver bumps, npm publish,
+// and GitHub release creation for the @ageflow/* packages.
+//
+// Sub-PR 1: skeleton stub. All tasks are defineFunction no-ops returning {}.
+// Real role-based agents (tech-writer, devops, ship) land in sub-PR 2.
+
+import { defineFunction, defineWorkflowFactory } from "@ageflow/core";
+import { z } from "zod";
+import type { WorkflowInput } from "../shared/types.js";
+
+const noopFn = defineFunction({
+  name: "noop",
+  input: z.object({}).passthrough(),
+  output: z.object({}),
+  execute: async () => ({}),
+});
+
+export const createReleasePipeline = defineWorkflowFactory(
+  (input: WorkflowInput) => ({
+    name: "release-pipeline",
+    tasks: {
+      // CHANGELOG — summarise commits since last tag into CHANGELOG.md.
+      // Sub-PR 2: replace with tech-writer agent reading git log.
+      changelog: {
+        fn: noopFn,
+        input: () => ({ issueNumber: input.issue.number }),
+      },
+
+      // BUMP — update package.json versions across affected packages.
+      // Sub-PR 2: replace with engineer agent following semver rules.
+      bump: {
+        fn: noopFn,
+        dependsOn: ["changelog"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // PUBLISH — bun publish for each changed package.
+      // Sub-PR 2: replace with devops agent + dry-run guard.
+      publish: {
+        fn: noopFn,
+        dependsOn: ["bump"] as const,
+        input: () => ({ worktreePath: input.worktreePath }),
+      },
+
+      // ANNOUNCE — create GitHub release + tag.
+      // Sub-PR 2: replace with ship agent calling gh release create.
+      announce: {
+        fn: noopFn,
+        dependsOn: ["publish"] as const,
+        input: () => ({
+          issueNumber: input.issue.number,
+          worktreePath: input.worktreePath,
+        }),
+      },
+    },
+  }),
+);

--- a/packages/dev-workflow/run.ts
+++ b/packages/dev-workflow/run.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * dev-workflow entry point — dogfood ageflow on its own development.
+ *
+ * Usage:
+ *   bun run run.ts <issue-number>
+ *   bun run run.ts --dry-run <issue-number>
+ *
+ * What this does (sub-PR 1 — scaffold only):
+ *   1. Parses <issue-number> from argv.
+ *   2. Loads the GitHub issue via `gh` CLI (real call, no LLM).
+ *   3. Determines pipeline type from issue labels.
+ *   4. Logs the determination and would-be plan.
+ *   5. Does NOT invoke the executor (deferred to sub-PR 4).
+ *
+ * Planned API surface (sub-PR 4):
+ *   - initRunners()           — register codex + claude runners
+ *   - createWorktree()        — isolate pipeline in sibling directory
+ *   - pipelineFactory(input)  — build WorkflowDef from chosen pipeline
+ *   - new WorkflowExecutor(pipeline, { budgetTracker })
+ *   - executor.stream(input)  — AsyncGenerator<WorkflowEvent, WorkflowResult>
+ *   - commentIssue()          — gate-progress markers on the GitHub issue
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { determinePipeline, loadIssue } from "./shared/issue-loader.js";
+import type { PipelineType, WorkflowInput } from "./shared/types.js";
+import { worktreePath } from "./shared/worktree.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+
+async function main(): Promise<void> {
+  // Parse argv: --dry-run flag + issue number.
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const issueNumber = Number(args.find((a) => /^\d+$/.test(a)));
+
+  if (!issueNumber) {
+    console.error("Usage: bun run run.ts [--dry-run] <issue-number>");
+    process.exit(1);
+  }
+
+  console.log(`[dev-workflow] loading issue #${issueNumber}…`);
+
+  const issue = await loadIssue(issueNumber);
+  const pipelineType: PipelineType = determinePipeline(issue);
+
+  console.log(`[dev-workflow] issue: "${issue.title}"`);
+  console.log(`[dev-workflow] labels: [${issue.labels.join(", ")}]`);
+  console.log(`[dev-workflow] pipeline: ${pipelineType}`);
+
+  // Build the would-be input (worktree not created yet — stub path).
+  const input: WorkflowInput = {
+    issue,
+    worktreePath: worktreePath(REPO_ROOT, issue.number),
+    specPath: resolve(
+      REPO_ROOT,
+      "docs/superpowers/specs/2026-04-15-agentflow-design.md",
+    ),
+    dryRun,
+  };
+
+  // Log the plan without invoking the executor.
+  // Sub-PR 4 replaces this block with real executor.stream() invocation.
+  console.log("[dev-workflow] would-be plan:");
+  console.log(
+    JSON.stringify(
+      {
+        pipeline: pipelineType,
+        issueNumber: input.issue.number,
+        worktreePath: input.worktreePath,
+        specPath: input.specPath,
+        dryRun: input.dryRun,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (dryRun) {
+    console.log("[dev-workflow] DRY-RUN complete — no LLM calls made.");
+    return;
+  }
+
+  // Sub-PR 4: uncomment and implement the executor block below.
+  //
+  // initRunners();
+  // const worktree = await createWorktree(REPO_ROOT, issue);
+  // const pipelineFactory = { feature: createFeaturePipeline, ... }[pipelineType];
+  // const pipeline = pipelineFactory({ ...input, worktreePath: worktree });
+  // const budgetTracker = new BudgetTracker();
+  // const executor = new WorkflowExecutor(pipeline, { budgetTracker });
+  // const gen = executor.stream(input);
+  // let result = await gen.next();
+  // while (!result.done) { ... result = await gen.next(); }
+  // console.log("[dev-workflow] workflow complete:", result.value.metrics);
+
+  console.log(
+    "[dev-workflow] scaffold ready — executor dispatch deferred to sub-PR 4 (see #194).",
+  );
+}
+
+main().catch((err) => {
+  console.error("[dev-workflow] fatal:", err);
+  process.exit(1);
+});

--- a/packages/dev-workflow/shared/issue-loader.ts
+++ b/packages/dev-workflow/shared/issue-loader.ts
@@ -1,0 +1,58 @@
+// GitHub issue loader — wraps the `gh` CLI via execa.
+// Using gh (not octokit) keeps auth in the CLI credential store and avoids a
+// separate token. execa is a thin async wrapper around child_process.
+//
+// Real calls are made here (no LLM). Safe to run in sub-PR 1+.
+
+import { execa } from "execa";
+import { type Issue, IssueSchema, type PipelineType } from "./types.js";
+
+/** Load a GitHub issue by number. Throws on network error or not-found. */
+export async function loadIssue(number: number): Promise<Issue> {
+  const { stdout } = await execa("gh", [
+    "issue",
+    "view",
+    String(number),
+    "--json",
+    "number,title,body,labels,state,url",
+  ]);
+
+  const raw = JSON.parse(stdout) as Record<string, unknown>;
+
+  // gh returns labels as objects {name, color, ...} — keep only name strings.
+  if (Array.isArray(raw.labels)) {
+    raw.labels = (raw.labels as Array<{ name: string }>).map((l) => l.name);
+  }
+
+  // gh returns state as uppercase ("OPEN"/"CLOSED") — normalise to lowercase.
+  if (typeof raw.state === "string") {
+    raw.state = raw.state.toLowerCase();
+  }
+
+  return IssueSchema.parse(raw);
+}
+
+/**
+ * Determine pipeline type from issue labels.
+ *
+ * Label precedence:
+ *   bug / bugfix  → bugfix
+ *   release       → release
+ *   docs / content → docs
+ *   (everything else) → feature
+ */
+export function determinePipeline(issue: Issue): PipelineType {
+  const labels = new Set(issue.labels.map((l) => l.toLowerCase()));
+  if (labels.has("bug") || labels.has("bugfix")) return "bugfix";
+  if (labels.has("release")) return "release";
+  if (labels.has("docs") || labels.has("content")) return "docs";
+  return "feature";
+}
+
+/** Post a comment on an issue (used for gate-progress markers in sub-PR 4+). */
+export async function commentIssue(
+  number: number,
+  body: string,
+): Promise<void> {
+  await execa("gh", ["issue", "comment", String(number), "--body", body]);
+}

--- a/packages/dev-workflow/shared/runners.ts
+++ b/packages/dev-workflow/shared/runners.ts
@@ -1,0 +1,30 @@
+// Runner registration for dev-workflow.
+//
+// Primary runner: "codex" (CLI subprocess, auth via ChatGPT OAuth).
+// Optional: "claude" (requires ANTHROPIC_API_KEY — separate billing).
+//
+// Codex is preferred as primary because the Claude Code OAuth session is not
+// forwarded to child processes (claude --print subprocess has no Claude Code
+// session), whereas codex authenticates via ChatGPT OAuth in-subprocess.
+//
+// ClaudeRunner and CodexRunner constructors accept no required args —
+// model, timeout, maxToolRounds come from RunnerSpawnArgs at task execution
+// time. Auth is sourced from each CLI's own credential store.
+
+import { registerRunner } from "@ageflow/core";
+import { ClaudeRunner } from "@ageflow/runner-claude";
+import { CodexRunner } from "@ageflow/runner-codex";
+
+let initialized = false;
+
+/** Register ageflow runners. Idempotent — safe to call multiple times. */
+export function initRunners(): void {
+  if (initialized) return;
+  initialized = true;
+
+  // Primary runner for all agent tasks.
+  registerRunner("codex", new CodexRunner());
+
+  // Optional secondary runner. Sub-PR 4 wires role-level runner selection.
+  registerRunner("claude", new ClaudeRunner());
+}

--- a/packages/dev-workflow/shared/types.ts
+++ b/packages/dev-workflow/shared/types.ts
@@ -1,0 +1,38 @@
+// Shared types for dev-workflow orchestrator, pipeline stubs, and utilities.
+// Any external contract (GitHub issue, focus keywords, pipeline routing) is
+// defined here so all modules share a single source of truth.
+
+import { z } from "zod";
+
+// ── GitHub issue as seen by the orchestrator ──────────────────────────────────
+export const IssueSchema = z.object({
+  number: z.number().int().positive(),
+  title: z.string(),
+  body: z.string(),
+  labels: z.array(z.string()),
+  state: z.enum(["open", "closed"]),
+  url: z.string().url(),
+});
+export type Issue = z.infer<typeof IssueSchema>;
+
+// ── Pipeline type (determined by labels) ─────────────────────────────────────
+export const PipelineTypeSchema = z.enum([
+  "feature",
+  "bugfix",
+  "docs",
+  "release",
+]);
+export type PipelineType = z.infer<typeof PipelineTypeSchema>;
+
+// ── Workflow-level input passed into every pipeline factory ───────────────────
+// Sub-PR 2 will extend this with roleSelection and focus fields.
+export const WorkflowInputSchema = z.object({
+  issue: IssueSchema,
+  worktreePath: z.string(),
+  // Absolute path to the ageflow design spec — for spec-adherence-reviewer
+  // (standing role added in sub-PR 2).
+  specPath: z.string(),
+  // Dry-run flag: when true, no LLM agents are invoked (sub-PR 4 guard).
+  dryRun: z.boolean().default(false),
+});
+export type WorkflowInput = z.infer<typeof WorkflowInputSchema>;

--- a/packages/dev-workflow/shared/worktree.ts
+++ b/packages/dev-workflow/shared/worktree.ts
@@ -1,0 +1,79 @@
+// Git worktree management for dev-workflow pipeline isolation.
+// Each issue run gets its own worktree → its own branch. After SHIP (merge)
+// the worktree is removed. Removal is deferred to sub-PR 4+.
+
+import { basename, dirname, join } from "node:path";
+import { execa } from "execa";
+import type { Issue } from "./types.js";
+
+/** Derive a branch name for the issue. Max 80 chars (git + GitHub limit). */
+export function branchName(
+  issue: Pick<Issue, "number" | "title" | "labels">,
+): string {
+  const prefix = pickPrefix(issue.labels);
+  const slug = slugify(issue.title);
+  const branch = `${prefix}/${issue.number}-${slug}`;
+  return branch.length > 80 ? branch.slice(0, 80) : branch;
+}
+
+/** Sibling-directory path for the worktree (e.g. ../agents-workflow-wt-194). */
+export function worktreePath(repoRoot: string, issueNumber: number): string {
+  const parent = dirname(repoRoot);
+  const name = basename(repoRoot);
+  return join(parent, `${name}-wt-${issueNumber}`);
+}
+
+/**
+ * Create a git worktree for the given issue.
+ *
+ * Stub: logs the would-be path and branch without calling git.
+ * Real implementation (execa git worktree add) lands in sub-PR 4.
+ *
+ * @returns Absolute path where the worktree would be created.
+ */
+export async function createWorktree(
+  repoRoot: string,
+  issue: Issue,
+): Promise<string> {
+  const path = worktreePath(repoRoot, issue.number);
+  const branch = branchName(issue);
+
+  // Sub-PR 1: dry stub — log only, no actual git call.
+  console.log(
+    `[worktree] would create: git worktree add ${path} -b ${branch} master`,
+  );
+
+  // Sub-PR 4: replace the log above with the real call below.
+  // await execa("git", ["worktree", "add", path, "-b", branch, "master"], {
+  //   cwd: repoRoot,
+  // });
+
+  return path;
+}
+
+/** Remove a worktree after merge/abort. Stub — real call lands in sub-PR 4. */
+export async function removeWorktree(
+  repoRoot: string,
+  issueNumber: number,
+): Promise<void> {
+  const path = worktreePath(repoRoot, issueNumber);
+  console.log(`[worktree] would remove: git worktree remove ${path} --force`);
+  // Sub-PR 4: await execa("git", ["worktree", "remove", path, "--force"], { cwd: repoRoot });
+}
+
+function pickPrefix(labels: string[]): string {
+  const lower = labels.map((l) => l.toLowerCase());
+  if (lower.includes("bug") || lower.includes("bugfix")) return "bug";
+  if (lower.includes("release")) return "release";
+  if (lower.includes("docs") || lower.includes("content")) return "docs";
+  return "feat";
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}

--- a/packages/dev-workflow/tsconfig.json
+++ b/packages/dev-workflow/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "types": ["bun"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/* [0-9]*.*",
+    "**/* [0-9]*/**",
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/dev-workflow/vitest.config.ts
+++ b/packages/dev-workflow/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+    exclude: [
+      "**/* [0-9]*.*",
+      "**/* [0-9]*/**",
+      "**/node_modules/**",
+      "**/dist/**",
+    ],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
First of 5 sub-PRs from strategic dogfood umbrella (#194). Creates `@ageflow/dev-workflow` (private, 0.0.1) consuming published @ageflow/* APIs.

## What's in (14 files)
- package.json + tsconfig + vitest.config (with Finder-dupe excludes)
- run.ts entry: parses issue#, loads via gh CLI, determines pipeline by labels — executor block stubbed
- 4 pipelines (feature/bugfix/docs/release) using defineWorkflowFactory (validates #192/#196/#201/#204 helpers in production code)
- shared/{types,issue-loader,runners,worktree}.ts
- CLAUDE.md (focus keywords + standing roles)
- README documenting 5-sub-PR plan

## Deliberately NOT in (deferred to later sub-PRs)
- Real role-based agents (sub-PR 2)
- Learning hooks + sqlite store (sub-PR 3)
- First real issue end-to-end (sub-PR 4)
- 10-run retro (sub-PR 5)

## Verification
- typecheck 29/29 / build / test / lint — all PASS
- Finder dupes: 0
- defineWorkflowFactory exercised in all 4 pipeline stubs

Closes part of #194 (sub-PR 1 of 5).