### PR TITLE
feat(dev-workflow): #194 sub-PR 3 — initLearning helper + sqlite store wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bun.lockb
 # macOS Finder / iCloud duplicates (e.g. "README 2.md", "workflow-executor 5.ts")
 * [0-9]*.*
 * [0-9]*/
+
+# ageflow runtime data — local SQLite stores, traces, embeddings
+.ageflow/

--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/dev-workflow": {
       "name": "@ageflow/dev-workflow",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.7.0",

--- a/packages/dev-workflow/__tests__/learning.test.ts
+++ b/packages/dev-workflow/__tests__/learning.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for the initLearning helper — verifies directory creation,
+// hooks shape, and dbPath resolution without invoking the executor.
+//
+// SqliteLearningStore is mocked to avoid the bun:sqlite runtime dependency
+// in the Vite/Vitest environment. The real store is tested in
+// packages/learning-sqlite where bun --bun mode is available.
+
+import { randomUUID } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock @ageflow/learning-sqlite before importing the module under test ────
+
+vi.mock("@ageflow/learning-sqlite", () => {
+  class SqliteLearningStore {}
+  return { SqliteLearningStore };
+});
+
+// ─── Mock @ageflow/learning so we control hooks shape ────────────────────────
+
+vi.mock("@ageflow/learning", () => {
+  const createLearningHooks = vi.fn().mockReturnValue({
+    onWorkflowStart: vi.fn(),
+    onTaskStart: vi.fn(),
+    onTaskComplete: vi.fn(),
+    onWorkflowComplete: vi.fn(),
+  });
+  return { createLearningHooks };
+});
+
+// Import after mocks are registered
+const { initLearning } = await import("../shared/learning.js");
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = join(tmpdir(), `dev-workflow-learning-test-${randomUUID()}`);
+});
+
+afterEach(() => {
+  if (existsSync(scratchDir)) {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+});
+
+describe("initLearning", () => {
+  it("creates the .ageflow directory if it does not exist", () => {
+    const ageflowDir = join(scratchDir, ".ageflow");
+    expect(existsSync(ageflowDir)).toBe(false);
+
+    initLearning({ repoRoot: scratchDir, workflowName: "dev-workflow:test" });
+
+    expect(existsSync(ageflowDir)).toBe(true);
+  });
+
+  it("returns a hooks object with the expected callbacks", () => {
+    const { hooks } = initLearning({
+      repoRoot: scratchDir,
+      workflowName: "dev-workflow:test",
+    });
+
+    expect(typeof hooks.onWorkflowStart).toBe("function");
+    expect(typeof hooks.onTaskStart).toBe("function");
+    expect(typeof hooks.onWorkflowComplete).toBe("function");
+    expect(typeof hooks.onTaskComplete).toBe("function");
+  });
+
+  it("returns dbPath under <repoRoot>/.ageflow/learning.sqlite", () => {
+    const { dbPath } = initLearning({
+      repoRoot: scratchDir,
+      workflowName: "dev-workflow:feature",
+    });
+
+    const expected = join(scratchDir, ".ageflow", "learning.sqlite");
+    expect(dbPath).toBe(expected);
+  });
+});

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/run.ts
+++ b/packages/dev-workflow/run.ts
@@ -26,6 +26,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { determinePipeline, loadIssue } from "./shared/issue-loader.js";
+// wired in sub-PR 4 — import kept live so TypeScript validates the signature
+import { initLearning } from "./shared/learning.js";
 import type { PipelineType, WorkflowInput } from "./shared/types.js";
 import { worktreePath } from "./shared/worktree.js";
 
@@ -92,7 +94,16 @@ async function main(): Promise<void> {
   // const pipelineFactory = { feature: createFeaturePipeline, ... }[pipelineType];
   // const pipeline = pipelineFactory({ ...input, worktreePath: worktree });
   // const budgetTracker = new BudgetTracker();
-  // const executor = new WorkflowExecutor(pipeline, { budgetTracker });
+  //   const { hooks, store, dbPath } = initLearning({
+  //     repoRoot: REPO_ROOT,
+  //     workflowName: `dev-workflow:${pipelineType}`,
+  //     reflectEvery: 3,
+  //     // dagStructure: <populated by pipelineFactory>,
+  //   });
+  //   console.log(`[dev-workflow] learning store: ${dbPath}`);
+  //   const executor = new WorkflowExecutor(pipeline, { budgetTracker, hooks });
+  //   ...
+  //   await store.close();
   // const gen = executor.stream(input);
   // let result = await gen.next();
   // while (!result.done) { ... result = await gen.next(); }

--- a/packages/dev-workflow/shared/learning.ts
+++ b/packages/dev-workflow/shared/learning.ts
@@ -1,0 +1,40 @@
+// Bootstraps the @ageflow/learning observation layer for dev-workflow runs.
+// Persists traces + skills to .ageflow/learning.sqlite at the repo root so
+// every run accumulates evidence reflection can mine.
+
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { WorkflowHooks } from "@ageflow/core";
+import { createLearningHooks } from "@ageflow/learning";
+import { SqliteLearningStore } from "@ageflow/learning-sqlite";
+
+export interface InitLearningOptions {
+  /** Repo root — `.ageflow/learning.sqlite` is resolved relative to it. */
+  readonly repoRoot: string;
+  /** Workflow name surfaced in trace records (e.g. "dev-workflow:feature"). */
+  readonly workflowName: string;
+  /** Reflection cadence — every N completed runs runReflection fires. Default 3. */
+  readonly reflectEvery?: number;
+  /** Optional DAG structure forwarded to runReflection. Sub-PR 4 will populate. */
+  readonly dagStructure?: Record<string, readonly string[]>;
+}
+
+export interface InitLearningResult {
+  readonly hooks: WorkflowHooks;
+  readonly store: SqliteLearningStore;
+  readonly dbPath: string;
+}
+
+export function initLearning(opts: InitLearningOptions): InitLearningResult {
+  const dbPath = join(opts.repoRoot, ".ageflow", "learning.sqlite");
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const store = new SqliteLearningStore(dbPath);
+  const hooks = createLearningHooks({
+    skillStore: store,
+    traceStore: store,
+    workflowName: opts.workflowName,
+    config: { reflectEvery: opts.reflectEvery ?? 3 },
+    ...(opts.dagStructure ? { dagStructure: opts.dagStructure } : {}),
+  });
+  return { hooks, store, dbPath };
+}


### PR DESCRIPTION
## Summary

Sub-PR 3 of 5 for the dogfood umbrella (#194). Adds the `initLearning` helper that bootstraps `SqliteLearningStore` at `.ageflow/learning.sqlite` and returns a `WorkflowHooks` from `@ageflow/learning` with `reflectEvery: 3`.

The helper is unit-tested. The call site is staged in `run.ts` as commented code that sub-PR 4 will activate alongside the real executor invocation.

### Changes

| File | Change |
|---|---|
| `packages/dev-workflow/shared/learning.ts` | NEW — `initLearning({ repoRoot, workflowName, reflectEvery?, dagStructure? })` |
| `packages/dev-workflow/__tests__/learning.test.ts` | NEW — 3 tests, vi.mock around bun:sqlite |
| `packages/dev-workflow/run.ts` | staged sub-PR 4 wire-up block |
| `packages/dev-workflow/package.json` | 0.0.3 → 0.0.4 |
| `.gitignore` | `.ageflow/` |
| `bun.lock` | resolution update |

### Notes

- `SqliteLearningStore` takes `string` path positionally (not `{ path }` — adjusted from the spec)
- `LearningConfig.reflectEvery` accepts `number | "always" | "on-failure" | "on-feedback"`
- Tests `vi.mock` `@ageflow/learning-sqlite` so vitest doesn't try to resolve `bun:sqlite`

## Test plan

- [x] `bun run --filter @ageflow/dev-workflow typecheck` — green
- [x] `bun run --filter @ageflow/dev-workflow test` — 29/29 passing (3 new)
- [x] `bun run --filter @ageflow/dev-workflow lint` — clean
- [ ] Sub-PR 4 will activate the staged call site

Refs #194