### PR TITLE
docs(orchestrator): block direct-push to master (#217 post-mortem)

### DIFF
--- a/.claude/commands/ageflow-orchestrator.md
+++ b/.claude/commands/ageflow-orchestrator.md
@@ -192,8 +192,13 @@ The ship role:
 - Stages explicitly (`git add <path>` per file — never `-A`).
 - Commits via heredoc, Conventional Commits shape, **no
   Co-Authored-By trailers**.
-- Pushes to `origin <branch>`.
+- Pushes to `origin <branch>` — **never to `origin master`**.
 - Opens PR via `gh pr create --base master`.
+- **Never runs `gh pr merge` or `git push origin master`.** Merge is
+  CEO-gated (see step 6). Direct pushes to master skip Codex review + CI
+  pre-merge and have caused incidents (#217 post-mortem). If the agent
+  returns without a PR number, that's a NEEDS_WORK gate — re-dispatch
+  with an explicit "open PR, do NOT merge" reminder in the prompt.
 
 **Gate:** ship returns commit SHA + PR number + URL, or NEEDS_WORK with a
 failing-command reason.


### PR DESCRIPTION
## Summary

#217 post-mortem: the fix agent pushed the commit to `origin/master` directly, skipping PR + Codex review + CI pre-merge gates. Code landed green (master CI caught up), but the pattern isn't safe — next time it might not be additive.

## Change

`.claude/commands/ageflow-orchestrator.md` SHIP step now explicitly:

- `git push origin <branch>` — **never `origin master`**
- **Never runs `gh pr merge` or `git push origin master`**
- Missing PR number in ship-agent return = NEEDS_WORK gate → re-dispatch with reminder

## Test plan

- [x] Diff reviewed — 1 file, +6/-1 lines
- [ ] Next ship-agent dispatch follows the new rule (observable behavior change)

Not a code change, no version bumps.