### PR TITLE
feat(dev-workflow): PR A — real worktree ops + budget cap + rename plan

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/dev-workflow": {
       "name": "@ageflow/dev-workflow",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.7.0",

--- a/dev-run.md
+++ b/dev-run.md
@@ -1,0 +1,204 @@
+# dev-workflow — план до первого реального прогона
+
+Статус на 2026-04-18: infrastructure ~95%, real-agent coverage ~20%, end-to-end validated = 0.
+
+**Цель:** за минимальное число шагов дойти до одного успешного live-прогона через ageflow против реального GH issue.
+
+---
+
+## Текущее состояние узлов
+
+| Pipeline | Узел | Статус |
+|---|---|---|
+| **feature** | plan | ✅ real `defineAgent` (engineering-software-architect, codex) |
+| | build | ⚠️ noop |
+| | test | ⚠️ noop |
+| | verify | ✅ real `defineAgent` (engineering-code-reviewer, codex) |
+| | ship | ⚠️ noop |
+| **bugfix** | triage | ⚠️ noop |
+| | reproduce | ⚠️ noop |
+| | fix | ⚠️ noop |
+| | test | ⚠️ noop |
+| | verify | ✅ real `defineAgent` (testing-reality-checker, codex) |
+| | ship | ⚠️ noop |
+| **docs** | draft / review / publish | ⚠️ всё noop |
+| **release** | bump / publish / changelog / cleanup | ⚠️ всё noop (по спеке — должны стать `defineFunction`) |
+
+**3 из 15 узлов реальные.** Инфраструктура готова: executor, budget tracker, learning hooks, sqlite store, codex runner, 7 ролей в `packages/dev-workflow/roles/`.
+
+---
+
+## PR A — Plumbing (без LLM-стоимости)
+
+### Цель
+Убрать dry-stub'ы из worktree helper и вызывать create/remove в `run.ts`. Добавить budget cap.
+
+### Изменения
+
+**`packages/dev-workflow/shared/worktree.ts`**
+
+Заменить console.log-и в `createWorktree` и `removeWorktree` на реальные execa-вызовы:
+```ts
+await execa("git", ["worktree", "add", path, "-b", branch, base], { cwd: repoRoot });
+await execa("git", ["worktree", "remove", path, "--force"], { cwd: repoRoot });
+```
+
+**`packages/dev-workflow/run.ts`**
+
+Обернуть executor в try/finally с create/remove worktree:
+```ts
+const worktree = await createWorktree(REPO_ROOT, issue);
+const input: WorkflowInput = { ...otherFields, worktreePath: worktree };
+try {
+  const result = await executor.run(input);
+  // ...
+} finally {
+  await removeWorktree(REPO_ROOT, issue.number);
+  store.close();
+}
+```
+
+Добавить budget cap:
+```ts
+const budgetTracker = new BudgetTracker({ maxUsd: 5, onExceeded: "halt" });
+```
+
+### Тесты
+- Обновить `worktree.test.ts` — mock execa, убедиться что `createWorktree` вызывает git с правильными args
+- Smoke: `bun run dev-workflow --dry-run 194` должен по-прежнему работать
+
+### Bump
+`@ageflow/dev-workflow` 0.0.7 → 0.0.8 (private)
+
+---
+
+## PR B — Docs pipeline real (первый end-to-end)
+
+### Цель
+Сделать docs pipeline работающей от начала до конца. Минимальный контур для проверки `createLearningHooks` + real trace rows + reflection.
+
+### Новая роль
+
+**`packages/dev-workflow/roles/engineering-technical-writer.md`** — ~50 строк, пишет markdown на основе issue body + spec path.
+
+### `packages/dev-workflow/pipelines/docs.ts`
+
+- `draft` → `defineAgent(technical-writer, codex)` — пишет docs на основе issue.body
+- `review` → `defineAgent(engineering-code-reviewer, codex)` — gate APPROVED/NEEDS_WORK
+- `publish` → `defineFunction` → `git add docs/...` + commit + push + `gh pr create`
+
+### Live-смоук
+- Создать тестовый issue "docs: add short usage example to @ageflow/learning README"
+- `bun run --filter @ageflow/dev-workflow dev-workflow <N>` (без `--dry-run`)
+- Budget cap $3
+- Ожидаемый результат: PR открыт, trace в `.ageflow/learning.sqlite` (minimum 3 task_traces)
+
+### Bump
+`@ageflow/dev-workflow` 0.0.8 → 0.0.9 (private)
+
+---
+
+## PR C — Feature pipeline real
+
+### Цель
+build + test + ship реальные. feature end-to-end валиден.
+
+### `packages/dev-workflow/pipelines/feature.ts`
+
+- `build` → `defineAgent(engineering-senior-developer, codex)` + session (для возможных retry после test FAIL)
+- `test` → `defineFunction` — спавнит `bun test` в worktree, возвращает `{passed: boolean, output: string}`
+- `ship` → `defineFunction` — `git add .` + commit с conventional-commits title + push + `gh pr create`
+
+### Design-вопрос (надо решить до дispatch)
+**Session на `build`**: нужна только если тест FAIL → build агент получает retry с test output в context. Альтернатива: loop-узел с cap=3. Выбор: **session** (проще для MVP, loop — потом если потребуется).
+
+### Live-смоук
+- Найти маленький feature issue ($5 cap)
+- Цель — чтоб plan → build → test → verify → ship отработали и PR открылся
+
+### Bump
+`@ageflow/dev-workflow` 0.0.9 → 0.0.10
+
+---
+
+## PR D — Bugfix pipeline real
+
+### Цель
+Самая сложная часть. Session design для fix→test→fix итерации.
+
+### `packages/dev-workflow/pipelines/bugfix.ts`
+
+- `triage` → `defineFunction` (label-classifier — не агент). Возвращает `{severity, affectedPackages}`
+- `reproduce` → `defineAgent(senior-developer, codex)` — пишет failing test в worktree
+- `fix` → `defineAgent(senior-developer, codex)` + **session continuation от reproduce** — исправляет код, может итерировать при test FAIL
+- `test` → `defineFunction` (тот же что в feature)
+- `ship` → `defineFunction` (тот же что в feature)
+
+### Design-решение — session chain
+`reproduce.session = "bugfix"` и `fix.session = "bugfix"` — continuation. Это проверяет `SessionManager` в executor.
+
+### Live-смоук
+- Взять существующий баг ($5-8 cap)
+- Успех: PR открыт, failing test → fix → passing test
+
+### Bump
+`@ageflow/dev-workflow` 0.0.10 → 0.0.11
+
+---
+
+## PR E — Release pipeline
+
+### Цель
+Детерминированные defineFunction узлы. Не агенты.
+
+### `packages/dev-workflow/pipelines/release.ts`
+
+- `bump` → `defineFunction` — обновляет package.json versions по списку changed packages
+- `changelog` → `defineFunction` — append секции в `CHANGELOG.md` (или создание)
+- `publish` → `defineFunction` — `npm publish` в dependency order (см. таблицу в `ageflow-orchestrator.md`)
+- `cleanup` → `defineFunction` — `git tag`, optional worktree remove
+
+### Bump
+`@ageflow/dev-workflow` 0.0.11 → 0.0.12
+
+---
+
+## PR F — 10-run retrospective (sub-PR 5 #194)
+
+После 10 реальных прогонов (ожидаем ~3 docs + 5 feature/bugfix + 2 release):
+
+1. Audit `.ageflow/learning.sqlite` — топ failure modes
+2. Cross-reference с issues label `from-dogfood`
+3. Топ-5 паттернов → roadmap items
+4. Reflection-generated skill records → в role prompts
+
+Отдельный docs PR, без кода.
+
+---
+
+## Приоритет / минимальный MVP
+
+Если надо **сегодня** одного live-прогона:
+
+**PR A + PR B = MVP.** ~2-3 часа агентного времени + $3-5 LLM. docs pipeline полностью рабочая, feature/bugfix — следующими подходами.
+
+PR C, D — потом. PR E — когда появится release-процесс, которым хочется пользоваться. PR F — после 10 прогонов.
+
+---
+
+## Design-решения — требуется sign-off
+
+1. **`test` узел = `defineFunction`**, не агент. Детерминированный `bun test` надёжнее чем LLM-парсинг stdout.
+2. **`ship` узел = `defineFunction`**, не агент. Механика git/gh не нуждается в LLM.
+3. **`fix` использует session** (continuation от reproduce), не loop. Loop добавим позже если session не хватит.
+4. **`triage` = defineFunction** (label-classifier), не агент с отдельной ролью. Агенты дороже и для классификации избыточны.
+5. **Budget cap по умолчанию = $5**. Переопределяется через `--budget <N>` flag (добавить в `run.ts`).
+6. **Runner = только codex** (уже установлено). Claude добавляем позже если потребуется мультиагентные пайплайны.
+
+---
+
+## Открытые вопросы
+
+- Нужен ли `engineering-technical-writer` роль для docs, или переиспользовать `engineering-senior-developer`? (предложение: отдельная, короткая)
+- Где хранить шаблоны PR titles/bodies? (предложение: в `shared/pr-templates.ts`, отдельный файл)
+- Worktree naming: текущий шаблон `<repo>-wt-<issue>` подходит? Или переместить в `.claude/worktrees/` для консистентности с существующими?

--- a/packages/dev-workflow/__tests__/worktree.test.ts
+++ b/packages/dev-workflow/__tests__/worktree.test.ts
@@ -1,0 +1,99 @@
+// Tests for worktree helpers — verifies that createWorktree and removeWorktree
+// call execa with the expected git arguments.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn().mockResolvedValue({ stdout: "", exitCode: 0 }),
+}));
+
+import { execa } from "execa";
+import type { Issue } from "../shared/types.js";
+import {
+  branchName,
+  createWorktree,
+  removeWorktree,
+  worktreePath,
+} from "../shared/worktree.js";
+
+const FAKE_ISSUE: Issue = {
+  number: 194,
+  title: "dogfood dev-workflow",
+  body: "Run dev-workflow against ageflow itself.",
+  labels: ["feat"],
+  state: "open",
+  url: "https://github.com/Neftedollar/ageflow/issues/194",
+};
+
+const REPO_ROOT = "/repo/ageflow";
+
+beforeEach(() => {
+  // biome-ignore lint/suspicious/noExplicitAny: mock return value — only stdout matters for these tests
+  vi.mocked(execa).mockResolvedValue({ stdout: "master", exitCode: 0 } as any);
+});
+
+describe("worktreePath", () => {
+  it("returns a sibling-directory path with issue number suffix", () => {
+    const path = worktreePath(REPO_ROOT, 194);
+    expect(path).toBe("/repo/ageflow-wt-194");
+  });
+});
+
+describe("branchName", () => {
+  it("slugifies the title with feat/ prefix for unlabelled issues", () => {
+    const branch = branchName({ number: 1, title: "Hello World!", labels: [] });
+    expect(branch).toBe("feat/1-hello-world");
+  });
+
+  it("uses feat/ prefix for feat label", () => {
+    const branch = branchName(FAKE_ISSUE);
+    expect(branch).toMatch(/^feat\/194-/);
+  });
+
+  it("uses bug/ prefix for bug label", () => {
+    const branch = branchName({ number: 2, title: "Fix it", labels: ["bug"] });
+    expect(branch).toMatch(/^bug\/2-/);
+  });
+
+  it("truncates branch names longer than 80 chars", () => {
+    const longTitle = "a".repeat(100);
+    const branch = branchName({ number: 3, title: longTitle, labels: [] });
+    expect(branch.length).toBeLessThanOrEqual(80);
+  });
+});
+
+describe("createWorktree", () => {
+  it("calls git worktree add with path, -b, branch, base", async () => {
+    const result = await createWorktree(REPO_ROOT, FAKE_ISSUE);
+
+    expect(execa).toHaveBeenCalledWith(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD"],
+      { cwd: REPO_ROOT },
+    );
+
+    const expectedPath = worktreePath(REPO_ROOT, FAKE_ISSUE.number);
+    const expectedBranch = branchName(FAKE_ISSUE);
+
+    expect(execa).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "add", expectedPath, "-b", expectedBranch, "master"],
+      { cwd: REPO_ROOT },
+    );
+
+    expect(result).toBe(expectedPath);
+  });
+});
+
+describe("removeWorktree", () => {
+  it("calls git worktree remove with --force", async () => {
+    await removeWorktree(REPO_ROOT, 194);
+
+    const expectedPath = worktreePath(REPO_ROOT, 194);
+    expect(execa).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "remove", expectedPath, "--force"],
+      { cwd: REPO_ROOT },
+    );
+  });
+});

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/run.ts
+++ b/packages/dev-workflow/run.ts
@@ -53,7 +53,18 @@ async function main(): Promise<void> {
   const dryRun = args.includes("--dry-run");
   const issueNumber = Number(args.find((a) => /^\d+$/.test(a)));
   const budgetArg = args.find((a) => a.startsWith("--budget="));
-  const maxUsd = budgetArg ? Number(budgetArg.split("=")[1]) : 5;
+  let maxUsd = 5;
+  if (budgetArg) {
+    const raw = budgetArg.split("=")[1];
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      console.error(
+        `[dev-workflow] invalid --budget value: "${raw}" — must be a positive number`,
+      );
+      process.exit(1);
+    }
+    maxUsd = parsed;
+  }
 
   if (!issueNumber) {
     console.error("Usage: bun run run.ts [--dry-run] <issue-number>");
@@ -102,62 +113,72 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Live mode: create a real git worktree, then walk the DAG.
-  // If the worktree already exists (re-run same issue), git errors — caller
-  // should remove the existing worktree first and retry.
-  const worktree = await createWorktree(REPO_ROOT, issue);
-  console.log(`[dev-workflow] worktree created: ${worktree}`);
-
-  const updatedInput: WorkflowInput = { ...input, worktreePath: worktree };
-
-  // Live mode (sub-PR 4b): walks the DAG, fires learning hooks, persists
-  // traces. Agent nodes use CodexRunner — real LLM cost incurred.
-  const { hooks, store, dbPath } = initLearning({
-    repoRoot: REPO_ROOT,
-    workflowName: `dev-workflow:${pipelineType}`,
-    reflectEvery: 3,
-  });
-  console.log(`[dev-workflow] learning store: ${dbPath}`);
-
-  // Register real CodexRunner for the "codex" brand used by all pipelines.
-  // No "claude" registration — no pipeline uses it; a missing registration
-  // yields a clear RunnerNotRegisteredError rather than a silent stub.
-  registerRunner("codex", new CodexRunner());
-
-  const factory = pipelineFactories[pipelineType];
-  const pipeline = factory(updatedInput);
-  // Attach hooks and budget cap via WorkflowDef fields (executor reads from there).
-  // BudgetConfig: maxCost = USD cap, onExceed = "halt" aborts on overrun.
-  // Cast hooks to match the specific task-map type of this pipeline.
-  const pipelineWithHooks = {
-    ...pipeline,
-    // biome-ignore lint/suspicious/noExplicitAny: cross-pipeline hooks cast — each pipeline has its own TasksMap
-    hooks: hooks as WorkflowHooks<any>,
-    budget: { maxCost: maxUsd, onExceed: "halt" as const },
-  };
-
-  const budgetTracker = new BudgetTracker();
-  const executor = new WorkflowExecutor(pipelineWithHooks, { budgetTracker });
-
+  // Outer try/finally: createWorktree is inside so any failure in
+  // initLearning / registerRunner / pipeline construction / executor still
+  // triggers removeWorktree, preventing stale worktrees on error.
+  let worktree: string | undefined;
   try {
-    const result = await executor.run(updatedInput);
-    console.log("[dev-workflow] workflow complete:");
-    console.log(
-      JSON.stringify(
-        {
-          workflow: pipelineType,
-          outputKeys: Object.keys(result.outputs ?? {}),
-          metrics: result.metrics,
-        },
-        null,
-        2,
-      ),
-    );
-  } finally {
-    await removeWorktree(REPO_ROOT, issue.number).catch((err: Error) => {
-      console.warn(`[dev-workflow] worktree cleanup failed: ${err.message}`);
+    worktree = await createWorktree(REPO_ROOT, issue);
+    console.log(`[dev-workflow] worktree created: ${worktree}`);
+
+    const updatedInput: WorkflowInput = { ...input, worktreePath: worktree };
+
+    // Inner try/finally: ensures store.close() runs whenever initLearning
+    // succeeds, regardless of executor success or failure.
+    // Live mode (sub-PR 4b): walks the DAG, fires learning hooks, persists
+    // traces. Agent nodes use CodexRunner — real LLM cost incurred.
+    const { hooks, store, dbPath } = initLearning({
+      repoRoot: REPO_ROOT,
+      workflowName: `dev-workflow:${pipelineType}`,
+      reflectEvery: 3,
     });
-    store.close();
+    console.log(`[dev-workflow] learning store: ${dbPath}`);
+
+    try {
+      // Register real CodexRunner for the "codex" brand used by all pipelines.
+      // No "claude" registration — no pipeline uses it; a missing registration
+      // yields a clear RunnerNotRegisteredError rather than a silent stub.
+      registerRunner("codex", new CodexRunner());
+
+      const factory = pipelineFactories[pipelineType];
+      const pipeline = factory(updatedInput);
+      // Attach hooks and budget cap via WorkflowDef fields (executor reads from there).
+      // BudgetConfig: maxCost = USD cap, onExceed = "halt" aborts on overrun.
+      // Cast hooks to match the specific task-map type of this pipeline.
+      const pipelineWithHooks = {
+        ...pipeline,
+        // biome-ignore lint/suspicious/noExplicitAny: cross-pipeline hooks cast — each pipeline has its own TasksMap
+        hooks: hooks as WorkflowHooks<any>,
+        budget: { maxCost: maxUsd, onExceed: "halt" as const },
+      };
+
+      const budgetTracker = new BudgetTracker();
+      const executor = new WorkflowExecutor(pipelineWithHooks, {
+        budgetTracker,
+      });
+
+      const result = await executor.run(updatedInput);
+      console.log("[dev-workflow] workflow complete:");
+      console.log(
+        JSON.stringify(
+          {
+            workflow: pipelineType,
+            outputKeys: Object.keys(result.outputs ?? {}),
+            metrics: result.metrics,
+          },
+          null,
+          2,
+        ),
+      );
+    } finally {
+      store.close();
+    }
+  } finally {
+    if (worktree !== undefined) {
+      await removeWorktree(REPO_ROOT, issue.number).catch((err: Error) => {
+        console.warn(`[dev-workflow] worktree cleanup failed: ${err.message}`);
+      });
+    }
   }
 }
 

--- a/packages/dev-workflow/run.ts
+++ b/packages/dev-workflow/run.ts
@@ -26,7 +26,11 @@ import { CodexRunner } from "@ageflow/runner-codex";
 import { determinePipeline, loadIssue } from "./shared/issue-loader.js";
 import { initLearning } from "./shared/learning.js";
 import type { PipelineType, WorkflowInput } from "./shared/types.js";
-import { worktreePath } from "./shared/worktree.js";
+import {
+  createWorktree,
+  removeWorktree,
+  worktreePath,
+} from "./shared/worktree.js";
 
 import { createBugfixPipeline } from "./pipelines/bugfix.js";
 import { createDocsPipeline } from "./pipelines/docs.js";
@@ -44,10 +48,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "../..");
 
 async function main(): Promise<void> {
-  // Parse argv: --dry-run flag + issue number.
+  // Parse argv: --dry-run flag + issue number + optional --budget=<N>.
   const args = process.argv.slice(2);
   const dryRun = args.includes("--dry-run");
   const issueNumber = Number(args.find((a) => /^\d+$/.test(a)));
+  const budgetArg = args.find((a) => a.startsWith("--budget="));
+  const maxUsd = budgetArg ? Number(budgetArg.split("=")[1]) : 5;
 
   if (!issueNumber) {
     console.error("Usage: bun run run.ts [--dry-run] <issue-number>");
@@ -63,7 +69,7 @@ async function main(): Promise<void> {
   console.log(`[dev-workflow] labels: [${issue.labels.join(", ")}]`);
   console.log(`[dev-workflow] pipeline: ${pipelineType}`);
 
-  // Build the workflow input (worktree not created yet — stub path).
+  // Build the workflow input with stub path for dry-run plan logging.
   const input: WorkflowInput = {
     issue,
     worktreePath: worktreePath(REPO_ROOT, issue.number),
@@ -84,6 +90,7 @@ async function main(): Promise<void> {
         worktreePath: input.worktreePath,
         specPath: input.specPath,
         dryRun: input.dryRun,
+        budgetUsd: maxUsd,
       },
       null,
       2,
@@ -94,6 +101,14 @@ async function main(): Promise<void> {
     console.log("[dev-workflow] DRY-RUN — plan above; executor not invoked.");
     return;
   }
+
+  // Live mode: create a real git worktree, then walk the DAG.
+  // If the worktree already exists (re-run same issue), git errors — caller
+  // should remove the existing worktree first and retry.
+  const worktree = await createWorktree(REPO_ROOT, issue);
+  console.log(`[dev-workflow] worktree created: ${worktree}`);
+
+  const updatedInput: WorkflowInput = { ...input, worktreePath: worktree };
 
   // Live mode (sub-PR 4b): walks the DAG, fires learning hooks, persists
   // traces. Agent nodes use CodexRunner — real LLM cost incurred.
@@ -110,17 +125,22 @@ async function main(): Promise<void> {
   registerRunner("codex", new CodexRunner());
 
   const factory = pipelineFactories[pipelineType];
-  const pipeline = factory(input);
-  // Attach hooks via WorkflowDef.hooks field (executor reads from there).
+  const pipeline = factory(updatedInput);
+  // Attach hooks and budget cap via WorkflowDef fields (executor reads from there).
+  // BudgetConfig: maxCost = USD cap, onExceed = "halt" aborts on overrun.
   // Cast hooks to match the specific task-map type of this pipeline.
-  // biome-ignore lint/suspicious/noExplicitAny: cross-pipeline hooks cast
-  const pipelineWithHooks = { ...pipeline, hooks: hooks as WorkflowHooks<any> };
+  const pipelineWithHooks = {
+    ...pipeline,
+    // biome-ignore lint/suspicious/noExplicitAny: cross-pipeline hooks cast — each pipeline has its own TasksMap
+    hooks: hooks as WorkflowHooks<any>,
+    budget: { maxCost: maxUsd, onExceed: "halt" as const },
+  };
 
   const budgetTracker = new BudgetTracker();
   const executor = new WorkflowExecutor(pipelineWithHooks, { budgetTracker });
 
   try {
-    const result = await executor.run(input);
+    const result = await executor.run(updatedInput);
     console.log("[dev-workflow] workflow complete:");
     console.log(
       JSON.stringify(
@@ -134,6 +154,9 @@ async function main(): Promise<void> {
       ),
     );
   } finally {
+    await removeWorktree(REPO_ROOT, issue.number).catch((err: Error) => {
+      console.warn(`[dev-workflow] worktree cleanup failed: ${err.message}`);
+    });
     store.close();
   }
 }

--- a/packages/dev-workflow/shared/worktree.ts
+++ b/packages/dev-workflow/shared/worktree.ts
@@ -59,10 +59,12 @@ export function worktreePath(repoRoot: string, issueNumber: number): string {
 /**
  * Create a git worktree for the given issue.
  *
- * Stub: logs the would-be path and branch without calling git.
- * Real implementation (execa git worktree add) lands in sub-PR 4.
+ * Calls `git worktree add` to create an isolated working directory on a new
+ * branch. If the worktree or branch already exists (e.g. re-running against
+ * the same issue), the error surfaces to the caller — callers can remove the
+ * existing worktree and retry.
  *
- * @returns Absolute path where the worktree would be created.
+ * @returns Absolute path where the worktree was created.
  */
 export async function createWorktree(
   repoRoot: string,
@@ -72,27 +74,22 @@ export async function createWorktree(
   const branch = branchName(issue);
   const base = await getDefaultBranch(repoRoot);
 
-  // Sub-PR 1: dry stub — log only, no actual git call.
-  console.log(
-    `[worktree] would create: git worktree add ${path} -b ${branch} ${base}`,
-  );
-
-  // Sub-PR 4: replace the log above with the real call below.
-  // await execa("git", ["worktree", "add", path, "-b", branch, base], {
-  //   cwd: repoRoot,
-  // });
+  await execa("git", ["worktree", "add", path, "-b", branch, base], {
+    cwd: repoRoot,
+  });
 
   return path;
 }
 
-/** Remove a worktree after merge/abort. Stub — real call lands in sub-PR 4. */
+/** Remove a worktree after merge/abort. */
 export async function removeWorktree(
   repoRoot: string,
   issueNumber: number,
 ): Promise<void> {
   const path = worktreePath(repoRoot, issueNumber);
-  console.log(`[worktree] would remove: git worktree remove ${path} --force`);
-  // Sub-PR 4: await execa("git", ["worktree", "remove", path, "--force"], { cwd: repoRoot });
+  await execa("git", ["worktree", "remove", path, "--force"], {
+    cwd: repoRoot,
+  });
 }
 
 function pickPrefix(labels: string[]): string {


### PR DESCRIPTION
## Summary

First of 5 PRs implementing `dev-run.md` (renamed from dry-run.md) — the dogfood pipeline live-prep plan.

This PR is **plumbing only — no LLM cost**. It makes the worktree helper actually call git (was dry-log stub) and wires create/remove lifecycle into run.ts with a $5 USD budget cap.

### Changes

- `packages/dev-workflow/shared/worktree.ts` — real execa calls
- `packages/dev-workflow/run.ts` — try/finally worktree lifecycle + BudgetTracker cap
- `dry-run.md` → `dev-run.md` (file rename only)
- `@ageflow/dev-workflow` 0.0.7 → 0.0.8

### API note

The plan assumed `new BudgetTracker({ maxUsd: 5, onExceeded: "halt" })` but the real `BudgetTracker` constructor takes no args. Budget config (`BudgetConfig`) lives on the workflow definition with fields `maxCost` / `onExceed: "halt"`. Adjusted accordingly: `budget: { maxCost: maxUsd, onExceed: "halt" }` is spread onto `pipelineWithHooks`.

### Test plan

- [x] typecheck / test / lint green
- [x] `--dry-run` still works (exits before createWorktree)
- [ ] First real live smoke comes in PR B (docs pipeline)

Refs #194