### PR TITLE
feat(dev-workflow): PR B — real docs pipeline + technical-writer role

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/dev-workflow": {
       "name": "@ageflow/dev-workflow",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.7.0",

--- a/packages/dev-workflow/__tests__/pipelines.test.ts
+++ b/packages/dev-workflow/__tests__/pipelines.test.ts
@@ -1,9 +1,10 @@
-// Smoke tests for the pipeline factories — confirms both `feature` and
-// `bugfix` build a valid DAG at definition time with the role prompts
+// Smoke tests for the pipeline factories — confirms that `feature`, `bugfix`,
+// and `docs` build valid DAGs at definition time with the role prompts
 // loaded from disk.
 
 import { describe, expect, it } from "vitest";
 import { createBugfixPipeline } from "../pipelines/bugfix.js";
+import { createDocsPipeline } from "../pipelines/docs.js";
 import { createFeaturePipeline } from "../pipelines/feature.js";
 import type { WorkflowInput } from "../shared/types.js";
 
@@ -67,5 +68,48 @@ describe("bugfix pipeline", () => {
       expect(task.fn).toBeDefined();
       expect(task.agent).toBeUndefined();
     }
+  });
+});
+
+describe("docs pipeline", () => {
+  it("builds a workflow named docs-pipeline with 3 tasks", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    expect(wf.name).toBe("docs-pipeline");
+    const keys = Object.keys(wf.tasks).sort();
+    expect(keys).toEqual(["draft", "publish", "review"]);
+  });
+
+  it("draft task is an agent (technical-writer role-backed)", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    const draft = wf.tasks.draft as { agent?: unknown; fn?: unknown };
+    expect(draft.agent).toBeDefined();
+    expect(draft.fn).toBeUndefined();
+  });
+
+  it("review task is an agent (code-reviewer role-backed)", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    const review = wf.tasks.review as { agent?: unknown; fn?: unknown };
+    expect(review.agent).toBeDefined();
+    expect(review.fn).toBeUndefined();
+  });
+
+  it("publish task is a defineFunction (deterministic git+gh)", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    const publish = wf.tasks.publish as { agent?: unknown; fn?: unknown };
+    expect(publish.fn).toBeDefined();
+    expect(publish.agent).toBeUndefined();
+  });
+
+  it("review dependsOn draft", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    const review = wf.tasks.review as { dependsOn?: readonly string[] };
+    expect(review.dependsOn).toContain("draft");
+  });
+
+  it("publish dependsOn both draft and review", () => {
+    const wf = createDocsPipeline(FAKE_INPUT);
+    const publish = wf.tasks.publish as { dependsOn?: readonly string[] };
+    expect(publish.dependsOn).toContain("draft");
+    expect(publish.dependsOn).toContain("review");
   });
 });

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/pipelines/docs.ts
+++ b/packages/dev-workflow/pipelines/docs.ts
@@ -3,50 +3,222 @@
 // Used for issues labelled `docs` or `content`: API docs, README updates,
 // design specs, and CLAUDE.md maintenance.
 //
-// Sub-PR 1: skeleton stub. All tasks are defineFunction no-ops returning {}.
-// Real role-based agents (tech-writer, code-reviewer) land in sub-PR 2.
+// Sub-PR 2: all three tasks are now real implementations:
+//   draft   — defineAgent using engineering-technical-writer role (codex)
+//   review  — defineAgent using engineering-code-reviewer role (codex)
+//   publish — defineFunction — git add/commit/push + gh pr create
 
-import { defineFunction, defineWorkflowFactory } from "@ageflow/core";
+import {
+  defineAgent,
+  defineFunction,
+  defineWorkflowFactory,
+} from "@ageflow/core";
+import { execa } from "execa";
 import { z } from "zod";
+import { loadRoleSync } from "../shared/role-loader.js";
 import type { WorkflowInput } from "../shared/types.js";
 
-const noopFn = defineFunction({
-  name: "noop",
-  input: z.object({}).passthrough(),
-  output: z.object({}),
-  execute: async () => ({}),
+// DRAFT — engineering-technical-writer writes / updates docs from issue body.
+// Output schema mirrors the role's declared Output schema section.
+const technicalWriterAgent = defineAgent({
+  runner: "codex",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    issueBody: z.string(),
+    specPath: z.string(),
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    wordCount: z.number().int().nonnegative(),
+  }),
+  prompt: (input) => {
+    const role = loadRoleSync("engineering-technical-writer");
+    return [
+      role.body,
+      "---",
+      `Docs issue #${input.issueNumber}: ${input.issueTitle}`,
+      input.issueBody,
+      "",
+      `Spec: ${input.specPath}`,
+      `Worktree: ${input.worktreePath}`,
+      "",
+      "Write or update the relevant .md file(s). Respect the 'Rules' above.",
+    ].join("\n");
+  },
+});
+
+// REVIEW — engineering-code-reviewer checks accuracy, grammar, and scope.
+// Gate: APPROVED | NEEDS_WORK.
+const reviewerAgent = defineAgent({
+  runner: "codex",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    gate: z.enum(["APPROVED", "NEEDS_WORK"]),
+    issues: z.array(z.string()),
+  }),
+  prompt: (input) => {
+    const role = loadRoleSync("engineering-code-reviewer");
+    return [
+      role.body,
+      "---",
+      `Review docs issue #${input.issueNumber}`,
+      `Files changed: ${input.filesChanged.join(", ")}`,
+      `Draft summary: ${input.summary}`,
+      `Worktree: ${input.worktreePath}`,
+      "",
+      "Check: accuracy against spec, grammar, markdown validity, minimal scope.",
+      "Return APPROVED only if the change is publish-ready.",
+      "",
+      "## Required output (JSON)",
+      "",
+      "```json",
+      "{",
+      '  "gate": "APPROVED" | "NEEDS_WORK",',
+      '  "issues": ["<finding>"]',
+      "}",
+      "```",
+      "",
+      "Wrap your response in this JSON object exactly. Do not add prose around it.",
+    ].join("\n");
+  },
+});
+
+// PUBLISH — deterministic git + gh. Runs only when gate = APPROVED.
+// Reads the current branch from the worktree so it works regardless of
+// how the worktree was created (branch name already set by createWorktree).
+const publishFn = defineFunction({
+  name: "publish",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    worktreePath: z.string(),
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    gate: z.enum(["APPROVED", "NEEDS_WORK"]),
+  }),
+  output: z.object({
+    prNumber: z.number().int().positive().nullable(),
+    branch: z.string(),
+    commit: z.string(),
+  }),
+  execute: async (input) => {
+    if (input.gate !== "APPROVED") {
+      throw new Error(`publish blocked: review gate = ${input.gate}`);
+    }
+
+    // Read the branch the worktree is already on (set by createWorktree).
+    const { stdout: branchRaw } = await execa(
+      "git",
+      ["branch", "--show-current"],
+      { cwd: input.worktreePath },
+    );
+    const currentBranch = branchRaw.trim();
+
+    // Stage files. Guard against hallucinated paths: skip files that fail.
+    for (const file of input.filesChanged) {
+      try {
+        await execa("git", ["add", "--", file], { cwd: input.worktreePath });
+      } catch (err) {
+        console.warn(
+          `[docs/publish] git add failed for "${file}" — skipping: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    const commitMsg = `docs: #${input.issueNumber} — ${input.summary}\n\nCloses #${input.issueNumber}`;
+    await execa("git", ["commit", "-m", commitMsg], {
+      cwd: input.worktreePath,
+    });
+
+    const { stdout: commitHash } = await execa("git", ["rev-parse", "HEAD"], {
+      cwd: input.worktreePath,
+    });
+
+    await execa("git", ["push", "-u", "origin", currentBranch], {
+      cwd: input.worktreePath,
+    });
+
+    const body = `## Summary\n\n${input.summary}\n\nCloses #${input.issueNumber}`;
+    const { stdout: prUrl } = await execa(
+      "gh",
+      [
+        "pr",
+        "create",
+        "--base",
+        "master",
+        "--head",
+        currentBranch,
+        "--title",
+        `docs: #${input.issueNumber} — ${input.issueTitle}`,
+        "--body",
+        body,
+      ],
+      { cwd: input.worktreePath },
+    );
+
+    const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+    const prNumber = prNumberMatch ? Number(prNumberMatch[1]) : null;
+
+    return { prNumber, branch: currentBranch, commit: commitHash.trim() };
+  },
 });
 
 export const createDocsPipeline = defineWorkflowFactory(
   (input: WorkflowInput) => ({
     name: "docs-pipeline",
     tasks: {
-      // DRAFT — write or update the documentation content.
-      // Sub-PR 2: replace with technical-writer agent.
+      // DRAFT — technical-writer writes docs from issue body + spec.
       draft: {
-        fn: noopFn,
+        agent: technicalWriterAgent,
         input: () => ({
           issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          issueBody: input.issue.body,
           specPath: input.specPath,
+          worktreePath: input.worktreePath,
         }),
       },
 
-      // REVIEW — accuracy check against design spec and existing code.
-      // Sub-PR 2: replace with code-reviewer + spec-adherence-reviewer agents.
+      // REVIEW — code-reviewer checks accuracy, grammar, minimal scope.
       review: {
-        fn: noopFn,
+        agent: reviewerAgent,
         dependsOn: ["draft"] as const,
-        input: () => ({ specPath: input.specPath }),
+        input: (ctx: {
+          draft: {
+            output: { filesChanged: string[]; summary: string };
+          };
+        }) => ({
+          issueNumber: input.issue.number,
+          filesChanged: ctx.draft.output.filesChanged,
+          summary: ctx.draft.output.summary,
+          worktreePath: input.worktreePath,
+        }),
       },
 
-      // PUBLISH — commit changes + open PR.
-      // Sub-PR 2: replace with ship agent.
+      // PUBLISH — git add/commit/push + gh pr create.
       publish: {
-        fn: noopFn,
-        dependsOn: ["review"] as const,
-        input: () => ({
-          worktreePath: input.worktreePath,
+        fn: publishFn,
+        dependsOn: ["draft", "review"] as const,
+        input: (ctx: {
+          draft: {
+            output: { filesChanged: string[]; summary: string };
+          };
+          review: { output: { gate: "APPROVED" | "NEEDS_WORK" } };
+        }) => ({
           issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          worktreePath: input.worktreePath,
+          filesChanged: ctx.draft.output.filesChanged,
+          summary: ctx.draft.output.summary,
+          gate: ctx.review.output.gate,
         }),
       },
     },

--- a/packages/dev-workflow/pipelines/docs.ts
+++ b/packages/dev-workflow/pipelines/docs.ts
@@ -152,8 +152,6 @@ const publishFn = defineFunction({
       [
         "pr",
         "create",
-        "--base",
-        "master",
         "--head",
         currentBranch,
         "--title",

--- a/packages/dev-workflow/roles/engineering-technical-writer.md
+++ b/packages/dev-workflow/roles/engineering-technical-writer.md
@@ -1,0 +1,35 @@
+---
+role: engineering-technical-writer
+description: Writes clear, accurate markdown docs from a spec + issue body
+---
+
+# Engineering Technical Writer
+
+model-tier: execution
+mission: Write or update documentation files in the ageflow monorepo from an issue body and design spec.
+
+You write documentation for the agents-workflow (ageflow) monorepo.
+
+## Inputs
+- Issue body — describes what needs documenting
+- Spec path — reference design doc (usually `docs/superpowers/specs/2026-04-15-agentflow-design.md`)
+- Worktree path — where to write / edit files
+
+## Rules
+- Output valid markdown. Prefer short paragraphs + code blocks over prose walls.
+- Reference the design spec by file path when citing architectural decisions — don't invent quotes.
+- Write to `.md` files in `docs/`, `README.md` at package root, or `CLAUDE.md` files — match the issue's requested location.
+- Keep changes minimal. If the issue asks to "add a section on X", don't rewrite unrelated sections.
+- Do not change code files. This role touches `.md` files only.
+- When editing an existing file, preserve its structure. Add or revise only the sections the issue requests.
+
+## Output schema
+```json
+{
+  "filesChanged": ["relative/path.md"],
+  "summary": "one-sentence description of what you wrote",
+  "wordCount": 0
+}
+```
+
+Return exactly this JSON object. No prose around it.


### PR DESCRIPTION
## Summary

Second of 5 PRs implementing `dev-run.md`. Makes the **docs pipeline end-to-end real** so a dogfood operator can run `bun run dev-workflow <docs-issue>` and get a PR opened.

### What landed
- New role `engineering-technical-writer.md` — short, tight, writes markdown from issue + spec
- `pipelines/docs.ts` — 3 real nodes (draft agent / review agent / publish defineFunction)
- Tests validating DAG shape

### What didn't land
- No live run. Live smoke is a separate step (plan: $3 budget against a real docs issue).
- Feature / bugfix / release pipelines still noop — those are PRs C, D, E.

### Test plan
- [x] typecheck / test / lint green
- [x] `--dry-run 194` works
- [ ] Live smoke: `bun run dev-workflow <N> --budget=3` against a real docs issue

Refs #194