### PR TITLE
feat(dev-workflow): PR C — real feature pipeline (build/test/ship)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/dev-workflow": {
       "name": "@ageflow/dev-workflow",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "dependencies": {
         "@ageflow/core": "^0.6.0",
         "@ageflow/executor": "^0.7.0",

--- a/packages/dev-workflow/__tests__/pipelines.test.ts
+++ b/packages/dev-workflow/__tests__/pipelines.test.ts
@@ -43,13 +43,51 @@ describe("feature pipeline", () => {
     expect(verify.agent).toBeDefined();
   });
 
-  it("build/test/ship remain defineFunction stubs (mixed-node pattern)", () => {
+  it("build task is an agent (senior-developer role-backed)", () => {
     const wf = createFeaturePipeline(FAKE_INPUT);
-    for (const key of ["build", "test", "ship"] as const) {
-      const task = wf.tasks[key] as { agent?: unknown; fn?: unknown };
-      expect(task.fn).toBeDefined();
-      expect(task.agent).toBeUndefined();
-    }
+    const build = wf.tasks.build as { agent?: unknown; fn?: unknown };
+    expect(build.agent).toBeDefined();
+    expect(build.fn).toBeUndefined();
+  });
+
+  it("test task is a defineFunction (deterministic bun test runner)", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const test = wf.tasks.test as { agent?: unknown; fn?: unknown };
+    expect(test.fn).toBeDefined();
+    expect(test.agent).toBeUndefined();
+  });
+
+  it("ship task is a defineFunction (deterministic git+gh)", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const ship = wf.tasks.ship as { agent?: unknown; fn?: unknown };
+    expect(ship.fn).toBeDefined();
+    expect(ship.agent).toBeUndefined();
+  });
+
+  it("build dependsOn plan", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const build = wf.tasks.build as { dependsOn?: readonly string[] };
+    expect(build.dependsOn).toContain("plan");
+  });
+
+  it("test dependsOn build", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const test = wf.tasks.test as { dependsOn?: readonly string[] };
+    expect(test.dependsOn).toContain("build");
+  });
+
+  it("verify dependsOn test and plan", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const verify = wf.tasks.verify as { dependsOn?: readonly string[] };
+    expect(verify.dependsOn).toContain("test");
+    expect(verify.dependsOn).toContain("plan");
+  });
+
+  it("ship dependsOn verify and build", () => {
+    const wf = createFeaturePipeline(FAKE_INPUT);
+    const ship = wf.tasks.ship as { dependsOn?: readonly string[] };
+    expect(ship.dependsOn).toContain("verify");
+    expect(ship.dependsOn).toContain("build");
   });
 });
 

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/pipelines/feature.ts
+++ b/packages/dev-workflow/pipelines/feature.ts
@@ -215,11 +215,12 @@ const shipFn = defineFunction({
 
     // Stage changed files. Guard against hallucinated paths: skip files that fail.
     for (const file of input.filesChanged) {
-      await execa("git", ["add", "--", file], { cwd: input.worktreePath }).catch(
-        (err) =>
-          console.warn(
-            `[ship] git add ${file} failed: ${(err as Error).message}`,
-          ),
+      await execa("git", ["add", "--", file], {
+        cwd: input.worktreePath,
+      }).catch((err) =>
+        console.warn(
+          `[ship] git add ${file} failed: ${(err as Error).message}`,
+        ),
       );
     }
 

--- a/packages/dev-workflow/pipelines/feature.ts
+++ b/packages/dev-workflow/pipelines/feature.ts
@@ -1,29 +1,23 @@
 // Feature pipeline — PLAN → BUILD → TEST → VERIFY → SHIP DAG.
 //
-// Sub-PR 2: two tasks (plan, verify) are now real `defineAgent` calls that
-// load their prompt from the role library via `loadRole()`. The remaining
-// three (build, test, ship) stay as `defineFunction` no-ops — they land as
-// real agents in sub-PR 4 alongside executor dispatch.
+// PR C: build, test, and ship are now real implementations:
+//   plan   — defineAgent using engineering-software-architect role (codex) ✅
+//   build  — defineAgent using engineering-senior-developer role (codex)
+//   test   — defineFunction spawning `bun test` with 10-min timeout
+//   verify — defineAgent using engineering-code-reviewer role (codex) ✅
+//   ship   — defineFunction — git add/commit/push + gh pr create
 //
-// This mixed-node shape is intentional: it exercises both the agent-with-
-// role-prompt path and the deterministic `defineFunction` path inside the
-// same DAG, proving the end-to-end wiring without yet calling the executor.
+// Session on build is deferred to PR D where fix→test iteration needs it.
 
 import {
   defineAgent,
   defineFunction,
   defineWorkflowFactory,
 } from "@ageflow/core";
+import { execa } from "execa";
 import { z } from "zod";
 import { loadRoleSync } from "../shared/role-loader.js";
 import type { WorkflowInput } from "../shared/types.js";
-
-const noopFn = defineFunction({
-  name: "noop",
-  input: z.object({}).passthrough(),
-  output: z.object({}),
-  execute: async () => ({}),
-});
 
 // PLAN — engineering-software-architect produces a technical plan.
 // Uses codex (primary runner). Output schema is a tight Zod object so raw
@@ -67,6 +61,41 @@ const architectAgent = defineAgent({
       "```",
       "",
       "Wrap your response in this JSON object exactly. Do not add prose around it.",
+    ].join("\n");
+  },
+});
+
+// BUILD — engineering-senior-developer implements the plan in the worktree.
+// Session on build deferred to PR D where fix→test iteration needs it.
+const seniorDeveloperAgent = defineAgent({
+  runner: "codex",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    plan: z.string(),
+    affectedPackages: z.array(z.string()),
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    typecheckPassed: z.boolean(),
+  }),
+  prompt: (input) => {
+    const role = loadRoleSync("engineering-senior-developer");
+    return [
+      role.body,
+      "---",
+      `Feature issue #${input.issueNumber}: ${input.issueTitle}`,
+      "",
+      "Plan from architect:",
+      input.plan,
+      "",
+      `Affected packages: ${input.affectedPackages.join(", ")}`,
+      `Worktree: ${input.worktreePath}`,
+      "",
+      "Implement per the plan. Run typecheck + tests locally before returning.",
+      "Only commit reality: typecheckPassed must reflect actual exit code.",
     ].join("\n");
   },
 });
@@ -117,12 +146,124 @@ const codeReviewerAgent = defineAgent({
   },
 });
 
+// TEST — deterministic `bun test` runner. Captures output + exit code.
+// Timeout 10 minutes — long enough for slow CI-like runs.
+// reject: false — lets us capture the result on non-zero exit instead of throwing.
+const testFn = defineFunction({
+  name: "test",
+  input: z.object({
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    passed: z.boolean(),
+    output: z.string(),
+    exitCode: z.number().int(),
+  }),
+  execute: async (input) => {
+    try {
+      const { stdout, stderr, exitCode } = await execa("bun", ["test"], {
+        cwd: input.worktreePath,
+        reject: false,
+        timeout: 600_000,
+      });
+      const combinedOutput = `${stdout}\n${stderr}`.slice(-4000); // last 4KB
+      return {
+        passed: exitCode === 0,
+        output: combinedOutput,
+        exitCode: exitCode ?? -1,
+      };
+    } catch (err) {
+      return {
+        passed: false,
+        output: err instanceof Error ? err.message : String(err),
+        exitCode: -1,
+      };
+    }
+  },
+});
+
+// SHIP — deterministic git + gh. Runs only when verify gate = APPROVED.
+// Reads the current branch from the worktree so it works regardless of
+// how the worktree was created (branch name already set by createWorktree).
+const shipFn = defineFunction({
+  name: "ship",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    worktreePath: z.string(),
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    gate: z.enum(["APPROVED", "NEEDS_WORK"]),
+  }),
+  output: z.object({
+    prNumber: z.number().int().positive().nullable(),
+    branch: z.string(),
+    commit: z.string(),
+  }),
+  execute: async (input) => {
+    if (input.gate !== "APPROVED") {
+      throw new Error(`ship blocked: verify gate = ${input.gate}`);
+    }
+
+    // Read the branch the worktree is already on (set by createWorktree).
+    const { stdout: branch } = await execa(
+      "git",
+      ["branch", "--show-current"],
+      { cwd: input.worktreePath },
+    );
+    const currentBranch = branch.trim();
+
+    // Stage changed files. Guard against hallucinated paths: skip files that fail.
+    for (const file of input.filesChanged) {
+      await execa("git", ["add", "--", file], { cwd: input.worktreePath }).catch(
+        (err) =>
+          console.warn(
+            `[ship] git add ${file} failed: ${(err as Error).message}`,
+          ),
+      );
+    }
+
+    const commitMsg = `feat: #${input.issueNumber} — ${input.summary}\n\nCloses #${input.issueNumber}`;
+    await execa("git", ["commit", "-m", commitMsg], {
+      cwd: input.worktreePath,
+    });
+
+    const { stdout: commit } = await execa("git", ["rev-parse", "HEAD"], {
+      cwd: input.worktreePath,
+    });
+
+    await execa("git", ["push", "-u", "origin", currentBranch], {
+      cwd: input.worktreePath,
+    });
+
+    const body = `## Summary\n\n${input.summary}\n\nCloses #${input.issueNumber}`;
+    const { stdout: prUrl } = await execa(
+      "gh",
+      [
+        "pr",
+        "create",
+        "--head",
+        currentBranch,
+        "--title",
+        `feat: #${input.issueNumber} — ${input.issueTitle}`,
+        "--body",
+        body,
+      ],
+      { cwd: input.worktreePath },
+    );
+
+    const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+    const prNumber = prNumberMatch ? Number(prNumberMatch[1]) : null;
+
+    return { prNumber, branch: currentBranch, commit: commit.trim() };
+  },
+});
+
 export const createFeaturePipeline = defineWorkflowFactory(
   (input: WorkflowInput) => ({
     name: "feature-pipeline",
     tasks: {
       // PLAN phase — architect produces the technical plan.
-      // Sub-PR 2: wired as real defineAgent. Sub-PR 4 runs the executor.
       plan: {
         agent: architectAgent,
         input: () => ({
@@ -132,30 +273,36 @@ export const createFeaturePipeline = defineWorkflowFactory(
         }),
       },
 
-      // BUILD phase — implement plan in worktree.
-      // Sub-PR 4: replace with engineering-senior-developer agent + session.
+      // BUILD phase — senior-developer implements plan in worktree.
       build: {
-        fn: noopFn,
+        agent: seniorDeveloperAgent,
         dependsOn: ["plan"] as const,
-        input: () => ({ worktreePath: input.worktreePath }),
+        input: (ctx: {
+          plan: {
+            output: { plan: string; affectedPackages: readonly string[] };
+          };
+        }) => ({
+          issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          plan: ctx.plan.output.plan,
+          affectedPackages: [...ctx.plan.output.affectedPackages],
+          worktreePath: input.worktreePath,
+        }),
       },
 
-      // TEST phase — run `bun test` in worktree.
-      // Sub-PR 4: replace with a deterministic test-runner function.
+      // TEST phase — run `bun test` in worktree deterministically.
       test: {
-        fn: noopFn,
+        fn: testFn,
         dependsOn: ["build"] as const,
         input: () => ({ worktreePath: input.worktreePath }),
       },
 
       // VERIFY phase — code-reviewer returns APPROVED / NEEDS_WORK.
-      // Sub-PR 2: wired as real defineAgent. Reality-checker + security
-      // engineer land as parallel peers in sub-PR 3/4 (learning hooks).
+      // Depend on both `test` (for ordering) and `plan` (for the plan text
+      // passed to the reviewer's prompt). `CtxFor` only exposes direct
+      // dependencies, so `plan` must be listed here.
       verify: {
         agent: codeReviewerAgent,
-        // Depend on both `test` (for ordering) and `plan` (for the plan text
-        // passed to the reviewer's prompt). `CtxFor` only exposes direct
-        // dependencies, so `plan` must be listed here.
         dependsOn: ["test", "plan"] as const,
         input: (ctx: {
           plan: { output: { plan: string } };
@@ -167,11 +314,22 @@ export const createFeaturePipeline = defineWorkflowFactory(
       },
 
       // SHIP phase — push branch + open PR via gh.
-      // Sub-PR 4: replace with ship role (or defineFunction, TBD).
       ship: {
-        fn: noopFn,
-        dependsOn: ["verify"] as const,
-        input: () => ({ issueNumber: input.issue.number }),
+        fn: shipFn,
+        dependsOn: ["verify", "build"] as const,
+        input: (ctx: {
+          build: {
+            output: { filesChanged: readonly string[]; summary: string };
+          };
+          verify: { output: { gate: "APPROVED" | "NEEDS_WORK" } };
+        }) => ({
+          issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          worktreePath: input.worktreePath,
+          filesChanged: [...ctx.build.output.filesChanged],
+          summary: ctx.build.output.summary,
+          gate: ctx.verify.output.gate,
+        }),
       },
     },
   }),


### PR DESCRIPTION
## Summary

Third of 5 PRs implementing `dev-run.md`. Makes the **feature pipeline end-to-end real**.

### Changes
- `pipelines/feature.ts`: build → senior-developer agent, test → `bun test` defineFunction, ship → git/gh defineFunction
- Tests updated

### Test plan
- [x] typecheck / test / lint green
- [x] `--dry-run 194` works
- [ ] Live smoke on a small feature issue (CEO-gated, $5 cap per plan)

Refs #194