### PR TITLE
feat(dev-workflow): PR D — real bugfix pipeline (5 nodes swapped)

### DIFF
--- a/packages/dev-workflow/__tests__/pipelines.test.ts
+++ b/packages/dev-workflow/__tests__/pipelines.test.ts
@@ -12,8 +12,8 @@ const FAKE_INPUT: WorkflowInput = {
   issue: {
     number: 1,
     title: "example",
-    body: "example body",
-    labels: [],
+    body: "example body @ageflow/core mentions",
+    labels: ["bug", "high"],
     state: "open",
     url: "https://github.com/example/repo/issues/1",
   },
@@ -54,20 +54,110 @@ describe("feature pipeline", () => {
 });
 
 describe("bugfix pipeline", () => {
-  it("builds a workflow with the reality-checker at VERIFY", () => {
+  it("builds a workflow named bugfix-pipeline with 6 tasks", () => {
     const wf = createBugfixPipeline(FAKE_INPUT);
     expect(wf.name).toBe("bugfix-pipeline");
-    const verify = wf.tasks.verify as { agent?: unknown; fn?: unknown };
-    expect(verify.agent).toBeDefined();
+    const keys = Object.keys(wf.tasks).sort();
+    expect(keys).toEqual([
+      "fix",
+      "reproduce",
+      "ship",
+      "test",
+      "triage",
+      "verify",
+    ]);
   });
 
-  it("triage/reproduce/fix/test/ship remain stubs", () => {
+  it("triage task is a defineFunction (label classifier)", () => {
     const wf = createBugfixPipeline(FAKE_INPUT);
-    for (const key of ["triage", "reproduce", "fix", "test", "ship"] as const) {
-      const task = wf.tasks[key] as { agent?: unknown; fn?: unknown };
-      expect(task.fn).toBeDefined();
-      expect(task.agent).toBeUndefined();
-    }
+    const triage = wf.tasks.triage as { agent?: unknown; fn?: unknown };
+    expect(triage.fn).toBeDefined();
+    expect(triage.agent).toBeUndefined();
+  });
+
+  it("reproduce task is an agent (senior-developer role-backed)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const reproduce = wf.tasks.reproduce as { agent?: unknown; fn?: unknown };
+    expect(reproduce.agent).toBeDefined();
+    expect(reproduce.fn).toBeUndefined();
+  });
+
+  it("fix task is an agent (senior-developer role-backed)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const fix = wf.tasks.fix as { agent?: unknown; fn?: unknown };
+    expect(fix.agent).toBeDefined();
+    expect(fix.fn).toBeUndefined();
+  });
+
+  it("test task is a defineFunction (bun test runner)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const test = wf.tasks.test as { agent?: unknown; fn?: unknown };
+    expect(test.fn).toBeDefined();
+    expect(test.agent).toBeUndefined();
+  });
+
+  it("verify task is an agent (reality-checker role-backed)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const verify = wf.tasks.verify as { agent?: unknown; fn?: unknown };
+    expect(verify.agent).toBeDefined();
+    expect(verify.fn).toBeUndefined();
+  });
+
+  it("ship task is a defineFunction (git + gh pr create)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const ship = wf.tasks.ship as { agent?: unknown; fn?: unknown };
+    expect(ship.fn).toBeDefined();
+    expect(ship.agent).toBeUndefined();
+  });
+
+  it("reproduce dependsOn triage", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const reproduce = wf.tasks.reproduce as { dependsOn?: readonly string[] };
+    expect(reproduce.dependsOn).toContain("triage");
+  });
+
+  it("fix dependsOn reproduce", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const fix = wf.tasks.fix as { dependsOn?: readonly string[] };
+    expect(fix.dependsOn).toContain("reproduce");
+  });
+
+  it("test dependsOn fix", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const test = wf.tasks.test as { dependsOn?: readonly string[] };
+    expect(test.dependsOn).toContain("fix");
+  });
+
+  it("verify dependsOn test", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const verify = wf.tasks.verify as { dependsOn?: readonly string[] };
+    expect(verify.dependsOn).toContain("test");
+  });
+
+  it("ship dependsOn verify and fix", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const ship = wf.tasks.ship as { dependsOn?: readonly string[] };
+    expect(ship.dependsOn).toContain("verify");
+    expect(ship.dependsOn).toContain("fix");
+  });
+
+  it("reproduce and fix share a session token", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const reproduce = wf.tasks.reproduce as {
+      session?: { kind: string; name: string };
+    };
+    const fix = wf.tasks.fix as { session?: { kind: string; name: string } };
+    expect(reproduce.session).toBeDefined();
+    expect(fix.session).toBeDefined();
+    expect(reproduce.session?.kind).toBe("token");
+    expect(fix.session?.kind).toBe("token");
+    expect(reproduce.session?.name).toBe(fix.session?.name);
+  });
+
+  it("triage has no session (deterministic fn)", () => {
+    const wf = createBugfixPipeline(FAKE_INPUT);
+    const triage = wf.tasks.triage as { session?: unknown };
+    expect(triage.session).toBeUndefined();
   });
 });
 

--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/pipelines/bugfix.ts
+++ b/packages/dev-workflow/pipelines/bugfix.ts
@@ -1,31 +1,190 @@
 // Bugfix pipeline — TRIAGE → REPRODUCE → FIX → TEST → VERIFY → SHIP.
 //
-// Sub-PR 2: `verify` is now a real `defineAgent` using the
-// `testing-reality-checker` role. Reality-checking (run the code, not just
-// read it) is the load-bearing gate for bugfix pipelines — a unit test
-// that passes on master means the test didn't capture the bug, so the
-// reality checker's job is to prove regression before approving.
+// Sub-PR 4: all 5 remaining noop nodes are now real implementations:
+//   triage    — defineFunction: label-based severity + @ageflow/* detection
+//   reproduce — defineAgent(engineering-senior-developer, codex): writes failing test
+//   fix       — defineAgent(engineering-senior-developer, codex) + session continuation
+//   test      — defineFunction: bun test spawn (same pattern as PR C)
+//   ship      — defineFunction: git + gh pr create with `fix:` prefix
 //
-// Other tasks stay as `defineFunction` stubs for sub-PR 4.
+//   verify    — real defineAgent(testing-reality-checker, codex) ✅ (from sub-PR 2)
+//
+// Session design: `reproduce` and `fix` share a sessionToken("bugfix", "codex")
+// so the fix agent has full conversation context from the reproduce conversation.
 
 import {
   defineAgent,
   defineFunction,
   defineWorkflowFactory,
+  sessionToken,
 } from "@ageflow/core";
+import { execa } from "execa";
 import { z } from "zod";
 import { loadRoleSync } from "../shared/role-loader.js";
 import type { WorkflowInput } from "../shared/types.js";
 
-const noopFn = defineFunction({
-  name: "noop",
-  input: z.object({}).passthrough(),
-  output: z.object({}),
-  execute: async () => ({}),
+// Shared session token — reproduce + fix share the same codex conversation.
+const bugfixSession = sessionToken("bugfix", "codex");
+
+// TRIAGE — deterministic label classifier. No LLM call.
+// Derives severity from issue labels; extracts @ageflow/* package mentions
+// from the issue body. Fallback: affectedPackages = [] (architect fills in).
+const triageFn = defineFunction({
+  name: "triage",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    labels: z.array(z.string()),
+    issueBody: z.string(),
+  }),
+  output: z.object({
+    severity: z.enum(["critical", "high", "medium", "low"]),
+    affectedPackages: z.array(z.string()),
+  }),
+  execute: async (input) => {
+    const labelLower = input.labels.map((l) => l.toLowerCase());
+
+    let severity: "critical" | "high" | "medium" | "low" = "medium";
+    if (labelLower.includes("critical") || labelLower.includes("security")) {
+      severity = "critical";
+    } else if (
+      labelLower.includes("high") ||
+      labelLower.includes("regression")
+    ) {
+      severity = "high";
+    } else if (labelLower.includes("low") || labelLower.includes("minor")) {
+      severity = "low";
+    }
+
+    // Grep issue body for @ageflow/* mentions; deduplicate.
+    const pkgMatches = input.issueBody.match(/@ageflow\/[a-z-]+/g) ?? [];
+    const affectedPackages = [...new Set(pkgMatches)];
+
+    return { severity, affectedPackages };
+  },
 });
 
-// VERIFY — reality-checker runs the test suite on master + branch and
-// decides the gate based on evidence, not self-report.
+// REPRODUCE — senior-developer writes a failing test that captures the bug.
+// Output: test file path + describe block name + the failing output.
+const reproduceAgent = defineAgent({
+  runner: "codex",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    issueBody: z.string(),
+    affectedPackages: z.array(z.string()),
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    testFilePath: z.string(),
+    describeBlock: z.string(),
+    failingOutput: z.string(),
+  }),
+  prompt: (input) => {
+    const role = loadRoleSync("engineering-senior-developer");
+    return [
+      role.body,
+      "---",
+      `Bugfix issue #${input.issueNumber}: ${input.issueTitle}`,
+      input.issueBody,
+      "",
+      `Affected packages: ${input.affectedPackages.join(", ")}`,
+      `Worktree: ${input.worktreePath}`,
+      "",
+      "Write a failing test that reproduces the bug. Run it to confirm it fails.",
+      "Return the test file path, the describe block name, and the failing output.",
+      "",
+      "## Required output (JSON)",
+      "",
+      "```json",
+      "{",
+      '  "testFilePath": "<path/to/test/file>",',
+      '  "describeBlock": "<describe block name>",',
+      '  "failingOutput": "<relevant lines from bun test failure output>"',
+      "}",
+      "```",
+      "",
+      "Wrap your response in this JSON object exactly. Do not add prose around it.",
+    ].join("\n");
+  },
+});
+
+// FIX — senior-developer implements the minimal code change to fix the bug.
+// Shares the bugfixSession with reproduce for full conversation context.
+const fixAgent = defineAgent({
+  runner: "codex",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    testFilePath: z.string(),
+    describeBlock: z.string(),
+    failingOutput: z.string(),
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+  }),
+  prompt: (input) => {
+    const role = loadRoleSync("engineering-senior-developer");
+    return [
+      role.body,
+      "---",
+      `Bugfix issue #${input.issueNumber}`,
+      `Failing test: ${input.testFilePath} :: ${input.describeBlock}`,
+      `Previous failing output: ${input.failingOutput}`,
+      `Worktree: ${input.worktreePath}`,
+      "",
+      "Fix the bug. Run the previously failing test — it must pass now.",
+      "Return files changed + summary.",
+      "",
+      "## Required output (JSON)",
+      "",
+      "```json",
+      "{",
+      '  "filesChanged": ["<path/to/changed/file>"],',
+      '  "summary": "<one-line summary of the fix>"',
+      "}",
+      "```",
+      "",
+      "Wrap your response in this JSON object exactly. Do not add prose around it.",
+    ].join("\n");
+  },
+});
+
+// TEST — deterministic bun test runner. Same pattern as PR C feature pipeline.
+// Spawns `bun test` in the worktree; returns pass/fail + output.
+const testFn = defineFunction({
+  name: "test",
+  input: z.object({
+    worktreePath: z.string(),
+  }),
+  output: z.object({
+    passed: z.boolean(),
+    output: z.string(),
+  }),
+  execute: async (input) => {
+    try {
+      const result = await execa("bun", ["test"], {
+        cwd: input.worktreePath,
+        timeout: 10 * 60 * 1000, // 10 minutes
+        reject: false,
+      });
+      const output = [result.stdout, result.stderr]
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+      const passed = result.exitCode === 0;
+      return { passed, output };
+    } catch (err) {
+      return {
+        passed: false,
+        output: (err as Error).message,
+      };
+    }
+  },
+});
+
+// VERIFY — reality-checker proves the bug is actually gone.
+// Carries over from sub-PR 2 — not modified.
 const realityCheckerAgent = defineAgent({
   runner: "codex",
   input: z.object({
@@ -56,44 +215,154 @@ const realityCheckerAgent = defineAgent({
   },
 });
 
+// SHIP — deterministic git + gh. Runs only when gate = APPROVED.
+// Mirrors docs/publishFn with `fix:` commit/PR title prefix instead of `docs:`.
+const shipFn = defineFunction({
+  name: "ship",
+  input: z.object({
+    issueNumber: z.number().int().positive(),
+    issueTitle: z.string(),
+    worktreePath: z.string(),
+    filesChanged: z.array(z.string()),
+    summary: z.string(),
+    gate: z.enum(["APPROVED", "NEEDS_WORK"]),
+  }),
+  output: z.object({
+    prNumber: z.number().int().positive().nullable(),
+    branch: z.string(),
+    commit: z.string(),
+  }),
+  execute: async (input) => {
+    if (input.gate !== "APPROVED") {
+      throw new Error(`ship blocked: verify gate = ${input.gate}`);
+    }
+
+    // Read the branch the worktree is already on (set by createWorktree).
+    const { stdout: branchRaw } = await execa(
+      "git",
+      ["branch", "--show-current"],
+      { cwd: input.worktreePath },
+    );
+    const currentBranch = branchRaw.trim();
+
+    // Stage files. Guard against hallucinated paths: skip files that fail.
+    for (const file of input.filesChanged) {
+      try {
+        await execa("git", ["add", "--", file], { cwd: input.worktreePath });
+      } catch (err) {
+        console.warn(
+          `[bugfix/ship] git add failed for "${file}" — skipping: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    const commitMsg = `fix: #${input.issueNumber} — ${input.summary}\n\nCloses #${input.issueNumber}`;
+    await execa("git", ["commit", "-m", commitMsg], {
+      cwd: input.worktreePath,
+    });
+
+    const { stdout: commitHash } = await execa("git", ["rev-parse", "HEAD"], {
+      cwd: input.worktreePath,
+    });
+
+    await execa("git", ["push", "-u", "origin", currentBranch], {
+      cwd: input.worktreePath,
+    });
+
+    const body = `## Summary\n\n${input.summary}\n\nCloses #${input.issueNumber}`;
+    const { stdout: prUrl } = await execa(
+      "gh",
+      [
+        "pr",
+        "create",
+        "--head",
+        currentBranch,
+        "--title",
+        `fix: #${input.issueNumber} — ${input.issueTitle}`,
+        "--body",
+        body,
+      ],
+      { cwd: input.worktreePath },
+    );
+
+    const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+    const prNumber = prNumberMatch ? Number(prNumberMatch[1]) : null;
+
+    return { prNumber, branch: currentBranch, commit: commitHash.trim() };
+  },
+});
+
 export const createBugfixPipeline = defineWorkflowFactory(
   (input: WorkflowInput) => ({
     name: "bugfix-pipeline",
     tasks: {
-      // TRIAGE — classify severity, identify affected files.
-      // Sub-PR 4: replace with triage-analyst agent.
+      // TRIAGE — classify severity + identify affected packages from labels/body.
       triage: {
-        fn: noopFn,
-        input: () => ({ issueNumber: input.issue.number }),
+        fn: triageFn,
+        input: () => ({
+          issueNumber: input.issue.number,
+          labels: input.issue.labels,
+          issueBody: input.issue.body,
+        }),
       },
 
       // REPRODUCE — write a failing test that captures the bug.
-      // Sub-PR 4: replace with engineering-senior-developer agent.
+      // Session: bugfixSession — fix agent will have full reproduce conversation context.
       reproduce: {
-        fn: noopFn,
+        agent: reproduceAgent,
+        session: bugfixSession,
         dependsOn: ["triage"] as const,
-        input: () => ({ worktreePath: input.worktreePath }),
+        input: (ctx: {
+          triage: {
+            output: {
+              severity: string;
+              affectedPackages: string[];
+            };
+          };
+        }) => ({
+          issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          issueBody: input.issue.body,
+          affectedPackages: ctx.triage.output.affectedPackages,
+          worktreePath: input.worktreePath,
+        }),
       },
 
       // FIX — implement the minimal code change.
-      // Sub-PR 4: replace with engineering-senior-developer agent + session.
+      // Session: bugfixSession (same token as reproduce) — continuation.
       fix: {
-        fn: noopFn,
+        agent: fixAgent,
+        session: bugfixSession,
         dependsOn: ["reproduce"] as const,
-        input: () => ({ worktreePath: input.worktreePath }),
+        input: (ctx: {
+          reproduce: {
+            output: {
+              testFilePath: string;
+              describeBlock: string;
+              failingOutput: string;
+            };
+          };
+        }) => ({
+          issueNumber: input.issue.number,
+          testFilePath: ctx.reproduce.output.testFilePath,
+          describeBlock: ctx.reproduce.output.describeBlock,
+          failingOutput: ctx.reproduce.output.failingOutput,
+          worktreePath: input.worktreePath,
+        }),
       },
 
-      // TEST — confirm the failing test now passes.
-      // Sub-PR 4: replace with deterministic test-runner function.
+      // TEST — deterministic bun test runner; confirms the failing test passes.
       test: {
-        fn: noopFn,
+        fn: testFn,
         dependsOn: ["fix"] as const,
-        input: () => ({ worktreePath: input.worktreePath }),
+        input: () => ({
+          worktreePath: input.worktreePath,
+        }),
       },
 
       // VERIFY — reality-checker proves the bug is actually gone.
-      // Sub-PR 2: wired as real defineAgent. Code-reviewer peer lands in
-      // sub-PR 4 as a parallel VERIFY step.
+      // Depends on both test (ordering) and fix (needs filesChanged for context,
+      // but passes only issueNumber+worktreePath — reality-checker runs git diff itself).
       verify: {
         agent: realityCheckerAgent,
         dependsOn: ["test"] as const,
@@ -103,12 +372,21 @@ export const createBugfixPipeline = defineWorkflowFactory(
         }),
       },
 
-      // SHIP — push branch + open PR.
-      // Sub-PR 4: replace with ship role.
+      // SHIP — push branch + open PR (gate-gated by verify output).
       ship: {
-        fn: noopFn,
-        dependsOn: ["verify"] as const,
-        input: () => ({ issueNumber: input.issue.number }),
+        fn: shipFn,
+        dependsOn: ["verify", "fix"] as const,
+        input: (ctx: {
+          verify: { output: { gate: "APPROVED" | "NEEDS_WORK" } };
+          fix: { output: { filesChanged: string[]; summary: string } };
+        }) => ({
+          issueNumber: input.issue.number,
+          issueTitle: input.issue.title,
+          worktreePath: input.worktreePath,
+          filesChanged: ctx.fix.output.filesChanged,
+          summary: ctx.fix.output.summary,
+          gate: ctx.verify.output.gate,
+        }),
       },
     },
   }),


### PR DESCRIPTION
## Summary

Fourth of 5 PRs implementing `dev-run.md`. Makes the **bugfix pipeline end-to-end real**.

### Changes
- 5 real nodes: triage (fn), reproduce (agent), fix (agent + session), test (fn), ship (fn)

### Design notes
- `triage` is a `defineFunction` — label classification is deterministic, no LLM needed
- `fix` uses session continuation from `reproduce` if `defineAgent` supports `session`; fallback is explicit prior-output-as-input

### Test plan
- [x] typecheck / test / lint green
- [x] `--dry-run 194` works
- [ ] Live smoke on real bug issue (CEO-gated, $5-8 cap per plan)

Refs #194