### PR TITLE
fix(dev-workflow): #230 — JSON output overrides

### DIFF
--- a/packages/dev-workflow/package.json
+++ b/packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ageflow/dev-workflow",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dev-workflow/pipelines/bugfix.ts
+++ b/packages/dev-workflow/pipelines/bugfix.ts
@@ -211,6 +211,18 @@ const realityCheckerAgent = defineAgent({
       "",
       "Reproduce the bug on master, then verify the fix on the worktree",
       "branch. Cite the test file + describe block that captures the bug.",
+      "",
+      "## Required output (JSON)",
+      "",
+      "```json",
+      "{",
+      '  "commandsRun": [{ "cmd": "<shell command>", "result": "PASS" | "FAIL" | "SKIPPED" }],',
+      '  "regressionProof": "<1-2 sentence evidence the bug is gone>",',
+      '  "gate": "APPROVED" | "NEEDS_WORK"',
+      "}",
+      "```",
+      "",
+      "Wrap your response in this JSON object exactly. Do not add prose around it.",
     ].join("\n");
   },
 });

--- a/packages/dev-workflow/pipelines/feature.ts
+++ b/packages/dev-workflow/pipelines/feature.ts
@@ -96,6 +96,18 @@ const seniorDeveloperAgent = defineAgent({
       "",
       "Implement per the plan. Run typecheck + tests locally before returning.",
       "Only commit reality: typecheckPassed must reflect actual exit code.",
+      "",
+      "## Required output (JSON)",
+      "",
+      "```json",
+      "{",
+      '  "filesChanged": ["<path>", ...],',
+      '  "summary": "<one-sentence description>",',
+      '  "typecheckPassed": true | false',
+      "}",
+      "```",
+      "",
+      "Wrap your response in this JSON object exactly. Do not add prose around it.",
     ].join("\n");
   },
 });


### PR DESCRIPTION
## Summary

Fixes #230. First-live-run blocker — two agents (`seniorDeveloperAgent` in feature.ts, `realityCheckerAgent` in bugfix.ts) had no JSON output override in their prompts, so they would follow the role's markdown instruction and return text that fails Zod validation.

### Changes
- feature.ts#seniorDeveloperAgent prompt — append Required output block
- bugfix.ts#realityCheckerAgent prompt — append Required output block
- `@ageflow/dev-workflow` 0.0.15 → 0.0.16

### Test plan
- [x] typecheck/test/lint green
- [x] dry-run 194 works

Closes #230